### PR TITLE
Bug fixes in get_observations

### DIFF
--- a/openghg/processing/_observations.py
+++ b/openghg/processing/_observations.py
@@ -106,14 +106,15 @@ def get_single_site(
 
     # Get the observation data
     obs_results = search(
-        locations=site, inlet=inlet, start_date=start_date, end_date=end_date, species=species, instrument=instrument
+        site=site, inlet=inlet, start_date=start_date, end_date=end_date, species=species, instrument=instrument,
+        find_all = False
     )
 
     # TODO - what if we want to return observations from multiple heights?
     try:
         site_key = list(obs_results.keys())[0]
     except IndexError:
-        raise ValueError(f"Unable to find any measurement data for {site} at a height of {height} in the {network} network.")
+        raise ValueError(f"Unable to find any measurement data for {site} at a height of {inlet} in the {network} network.")
     
     # TODO - update Search to return a SearchResult object that makes it easier to retrieve data
     # GJ 2021-03-09

--- a/openghg/processing/_search.py
+++ b/openghg/processing/_search.py
@@ -9,7 +9,7 @@ __all__ = ["search", "search_footprints", "search_emissions"]
 
 
 def search(**kwargs) -> Dict:
-    # locations: Union[str, List],
+    # site: Union[str, List],
     # species: Optional[Union[str, List]] = None,
     # inlet: Optional[Union[str, List]] = None,
     # instrument: Optional[str] = None,


### PR DESCRIPTION
I think get_observations was calling ```search``` with the "locations" keyword, whereas the metadata expects "site". I changed these.

Also, I changed the call to ```search``` to have ```find_all=False```, as it wasn't returning anything if e.g. you specified the site and species (because inlet, etc weren't defined). Is that right?

However, get_observations still doesn't work. It only returns one year of data. Is this because of this line:

```site_key = list(obs_results.keys())[0]```

(_observations.py Line 115)

I can't understand the logic of this, and it seems to then only be recombining one year of data