### PR TITLE
Moving code into BaseModule class

### DIFF
--- a/openghg/modules/_base.py
+++ b/openghg/modules/_base.py
@@ -9,6 +9,24 @@ T = TypeVar("T", bound="BaseModule")
 
 
 class BaseModule:
+    def __init__(self):
+        from openghg.util import timestamp_now
+        from collections import defaultdict
+
+        self._creation_datetime = timestamp_now()
+        self._stored = False
+
+        # We want to created a nested dictionary
+        def nested_dict():
+            return defaultdict(nested_dict)
+
+        # Stores metadata about the Datasource, keyed by site
+        self._datasource_table = nested_dict()
+        # Hashes of previously uploaded files
+        self._file_hashes = {}
+        # Keyed by UUID
+        self._rank_data = defaultdict(dict)
+
     def is_null(self):
         return not self.datasources
 

--- a/openghg/modules/_emissions.py
+++ b/openghg/modules/_emissions.py
@@ -11,28 +11,6 @@ class Emissions(BaseModule):
     _root = "Emissions"
     _uuid = "c5c88168-0498-40ac-9ad3-949e91a30872"
 
-    def __init__(self):
-        super().__init__()
-
-    def to_data(self) -> Dict:
-        """Return a JSON-serialisable dictionary of object
-        for storage in object store
-
-        Returns:
-            dict: Dictionary version of object
-        """
-        from Acquire.ObjectStore import datetime_to_string
-
-        data = {}
-        data["creation_datetime"] = datetime_to_string(self._creation_datetime)
-        data["stored"] = self._stored
-        data["datasource_uuids"] = self._datasource_uuids
-        data["datasource_names"] = self._datasource_names
-        data["file_hashes"] = self._file_hashes
-        data["rank_data"] = self._rank_data
-
-        return data
-
     def save(self, bucket: Optional[Dict] = None) -> None:
         """Save the object to the object store
 

--- a/openghg/modules/_emissions.py
+++ b/openghg/modules/_emissions.py
@@ -12,19 +12,7 @@ class Emissions(BaseModule):
     _uuid = "c5c88168-0498-40ac-9ad3-949e91a30872"
 
     def __init__(self):
-        from openghg.util import timestamp_now
-        from collections import defaultdict
-
-        self._creation_datetime = timestamp_now()
-        self._stored = False
-        # Keyed by name - allows retrieval of UUID from name
-        self._datasource_names = {}
-        # Keyed by UUID - allows retrieval of name by UUID
-        self._datasource_uuids = {}
-        # Hashes of previously uploaded files
-        self._file_hashes = {}
-        # Keyed by UUID
-        self._rank_data = defaultdict(dict)
+        super().__init__()
 
     def to_data(self) -> Dict:
         """Return a JSON-serialisable dictionary of object

--- a/openghg/modules/_footprints.py
+++ b/openghg/modules/_footprints.py
@@ -13,18 +13,7 @@ class FOOTPRINTS(BaseModule):
     _uuid = "62db5bdf-c88d-4e56-97f4-40336d37f18c"
 
     def __init__(self):
-        from openghg.util import timestamp_now
-
-        self._creation_datetime = timestamp_now()
-        self._stored = False
-        # How we identify a
-        self._datasource_uuids = {}
-        # TODO - remove this - currently here for compatibility with other 
-        # storage objects
-        self._datasource_names = {}
-        # Hashes of previously uploaded files
-        self._file_hashes = {}
-        self._rank_data = {}
+        super().__init__()
 
     @staticmethod
     def read_file(

--- a/openghg/modules/_footprints.py
+++ b/openghg/modules/_footprints.py
@@ -12,9 +12,6 @@ class FOOTPRINTS(BaseModule):
     _root = "Footprints"
     _uuid = "62db5bdf-c88d-4e56-97f4-40336d37f18c"
 
-    def __init__(self):
-        super().__init__()
-
     @staticmethod
     def read_file(
         filepath: Union[str, Path],
@@ -116,25 +113,6 @@ class FOOTPRINTS(BaseModule):
         fp.save()
 
         return {str(filepath.name): uid}
-
-    def to_data(self) -> Dict:
-        """ Return a JSON-serialisable dictionary of object
-        for storage in object store
-
-        Returns:
-            dict: Dictionary version of object
-        """
-        from Acquire.ObjectStore import datetime_to_string
-
-        data = {}
-        data["creation_datetime"] = datetime_to_string(self._creation_datetime)
-        data["stored"] = self._stored
-        data["datasource_uuids"] = self._datasource_uuids
-        data["datasource_names"] = self._datasource_names
-        data["file_hashes"] = self._file_hashes
-        data["rank_data"] = self._rank_data
-
-        return data
 
     def save(self) -> None:
         """ Save the object to the object store

--- a/openghg/modules/_metstore.py
+++ b/openghg/modules/_metstore.py
@@ -16,24 +16,7 @@ class METStore(BaseModule):
     _uuid = "9fcabd0c-9b68-4ab4-a116-bc30a4472d67"
 
     def __init__(self):
-        from Acquire.ObjectStore import get_datetime_now
-        from collections import defaultdict
-
-        self._creation_datetime = get_datetime_now()
-        self._stored = False
-
-        # We want to created a nested dictionary
-        def nested_dict():
-            return defaultdict(nested_dict)
-
-        self._datasource_table = nested_dict()
-        # Keyed by name - allows retrieval of UUID from name
-        self._datasource_names = {}  
-        # Keyed by UUID - allows retrieval of name by UUID
-        self._datasource_uuids = {}
-        # Hashes of retrieved data to ensure we aren't overwriting / duplicating
-        # already stored data. Keyed by hash
-        self._hashes = {}
+        super().__init__()
 
     def to_data(self) -> Dict:
         """Return a JSON-serialisable dictionary of object

--- a/openghg/modules/_metstore.py
+++ b/openghg/modules/_metstore.py
@@ -15,28 +15,6 @@ class METStore(BaseModule):
     _root = "METStore"
     _uuid = "9fcabd0c-9b68-4ab4-a116-bc30a4472d67"
 
-    def __init__(self):
-        super().__init__()
-
-    def to_data(self) -> Dict:
-        """Return a JSON-serialisable dictionary of object
-        for storage in object store
-
-        Returns:
-            dict: Dictionary version of object
-        """
-        from Acquire.ObjectStore import datetime_to_string
-
-        data = {}
-        data["creation_datetime"] = datetime_to_string(self._creation_datetime)
-        data["stored"] = self._stored
-        data["datasource_table"] = self._datasource_table
-        data["datasource_uuids"] = self._datasource_uuids
-        data["datasource_names"] = self._datasource_names
-        data["file_hashes"] = self._hashes
-
-        return data
-
     def save(self, bucket: Optional[Dict] = None) -> None:
         """Save the object to the object store
 

--- a/openghg/modules/_obs_surface.py
+++ b/openghg/modules/_obs_surface.py
@@ -13,26 +13,7 @@ class ObsSurface(BaseModule):
     _uuid = "da0b8b44-6f85-4d3c-b6a3-3dde34f6dea1"
 
     def __init__(self):
-        from Acquire.ObjectStore import get_datetime_now
-        from collections import defaultdict
-
-        self._creation_datetime = get_datetime_now()
-        self._stored = False
-
-        # We want to created a nested dictionary
-        def nested_dict():
-            return defaultdict(nested_dict)
-
-        # Stores metadata about the Datasource, keyed by site
-        self._datasource_table = nested_dict()
-        # Keyed by name - allows retrieval of UUID from name
-        self._datasource_names = {}
-        # Keyed by UUID - allows retrieval of name by UUID
-        self._datasource_uuids = {}
-        # Hashes of previously uploaded files
-        self._file_hashes = {}
-        # Keyed by UUID
-        self._rank_data = defaultdict(dict)
+        super().__init__()
 
     def to_data(self) -> Dict:
         """Return a JSON-serialisable dictionary of object

--- a/openghg/modules/_obs_surface.py
+++ b/openghg/modules/_obs_surface.py
@@ -12,28 +12,9 @@ class ObsSurface(BaseModule):
     _root = "ObsSurface"
     _uuid = "da0b8b44-6f85-4d3c-b6a3-3dde34f6dea1"
 
-    def __init__(self):
-        super().__init__()
-
-    def to_data(self) -> Dict:
-        """Return a JSON-serialisable dictionary of object
-        for storage in object store
-
-        Returns:
-            dict: Dictionary version of object
-        """
-        from Acquire.ObjectStore import datetime_to_string
-
-        data = {}
-        data["creation_datetime"] = datetime_to_string(self._creation_datetime)
-        data["stored"] = self._stored
-        data["datasource_table"] = self._datasource_table
-        data["datasource_uuids"] = self._datasource_uuids
-        data["datasource_names"] = self._datasource_names
-        data["file_hashes"] = self._file_hashes
-        data["rank_data"] = self._rank_data
-
-        return data
+    # We don't currently need to add anything here
+    # def __init__(self):
+    #     super().__init__()
 
     def save(self, bucket: Optional[Dict] = None) -> None:
         """Save the object to the object store
@@ -231,8 +212,4 @@ class ObsSurface(BaseModule):
         key = f"{Datasource._datasource_root}/uuid/{uuid}"
         delete_object(bucket=bucket, key=key)
 
-        # First remove from our dictionary of Datasources
-        name = self._datasource_uuids[uuid]
-
-        del self._datasource_names[name]
         del self._datasource_uuids[uuid]

--- a/tests/modules/test_obssurface.py
+++ b/tests/modules/test_obssurface.py
@@ -158,7 +158,7 @@ def test_read_GC():
     # Check we have the Datasource info saved
     obs = ObsSurface.load()
 
-    assert sorted(obs._datasource_names.keys()) == expected_keys
+    assert sorted(obs._datasource_uuids.values()) == expected_keys
 
     del hfc152a_data.attrs["File created"]
 
@@ -296,7 +296,7 @@ def test_read_icos():
 
     obs = ObsSurface.load()
 
-    assert list(obs._datasource_names.keys())[0] == "co2"
+    assert list(obs._datasource_uuids.values())[0] == "co2"
 
 
 def test_read_beaco2n():
@@ -366,7 +366,7 @@ def test_read_thames_barrier():
 
     obs = ObsSurface.load()
 
-    assert sorted(obs._datasource_names.keys()) == expected_keys
+    assert sorted(obs._datasource_uuids.values()) == expected_keys
 
 
 def test_upload_same_file_twice_raises():


### PR DESCRIPTION
This moves some code into the base class which makes it easier to create new classes (for footprints, emissions etc) and cuts down on code replication for the `from_data` / `to_data` functions.