### PR TITLE
Inlet labels now used instead of labels read directly from data

### DIFF
--- a/openghg/processing/_recombination.py
+++ b/openghg/processing/_recombination.py
@@ -45,10 +45,6 @@ def recombine_datasets(keys: List[str], sort: Optional[bool] = True) -> Dataset:
 
     data = [Datasource.load_dataset(bucket=bucket, key=k) for k in keys]
 
-    # print(data)
-
-    # return False
-
     combined = xr_concat(data, dim="time")
 
     if sort:

--- a/tests/localclient/test_get_surface_obs.py
+++ b/tests/localclient/test_get_surface_obs.py
@@ -110,7 +110,7 @@ def test_gcwerks_retrieval():
     expected_metadata = {
         "data_owner": "Paul Krummel",
         "data_owner_email": "paul.krummel@csiro.au",
-        "inlet_height_magl": "75m_4",
+        "inlet_height_magl": "70m",
         "comment": "Medusa measurements. Output from GCWerks. See Miller et al. (2008).",
         "Conditions of use": "Ensure that you contact the data owner at the outset of your project.",
         "Source": "In situ measurements of air",
@@ -126,7 +126,7 @@ def test_gcwerks_retrieval():
         "network": "agage",
         "units": "ppt",
         "scale": "SIO-05",
-        "inlet": "75m_4",
+        "inlet": "70m",
     }
 
     assert metadata == expected_metadata

--- a/tests/mock/hugs/test_process.py
+++ b/tests/mock/hugs/test_process.py
@@ -146,8 +146,6 @@ def test_process_CRDS(authenticated_user, tempdir):
 
     results = response["results"]["bsd.picarro.1minute.248m.dat"]
 
-    return False
-
     assert sorted(results.keys()) == expected_keys
 
 

--- a/tests/modules/test_gcwerks.py
+++ b/tests/modules/test_gcwerks.py
@@ -14,45 +14,45 @@ def get_datapath(filename):
 
 
 @pytest.fixture(scope="session")
-def data_path():
+def cgo_path():
     return get_datapath(filename="capegrim-medusa.18.C")
 
 
 @pytest.fixture(scope="session")
-def precision_path():
+def cgo_prec_path():
     return get_datapath(filename="capegrim-medusa.18.precisions.C")
 
 
 @pytest.fixture(scope="session")
-def data_path_no_instrument():
+def data_thd():
     return get_datapath(filename="trinidadhead.01.C")
 
 
 @pytest.fixture(scope="session")
-def precision_path_no_instrument():
+def prec_thd():
     return get_datapath(filename="trinidadhead.01.precisions.C")
 
 
-def test_read_file(data_path, precision_path):
+def test_read_file_capegrim(cgo_path, cgo_prec_path):
     gc = GC()
 
     gas_data = gc.read_file(
-        data_filepath=data_path,
-        precision_filepath=precision_path,
+        data_filepath=cgo_path,
+        precision_filepath=cgo_prec_path,
         site="CGO",
         instrument="medusa",
         network="AGAGE",
     )
 
     expected_eight = [
-        "benzene_75m_4",
-        "c4f10_75m_4",
-        "c6f14_75m_4",
-        "ccl4_75m_4",
-        "cf4_75m_4",
-        "cfc112_75m_4",
-        "cfc113_75m_4",
-        "cfc114_75m_4",
+        "benzene_70m",
+        "c4f10_70m",
+        "c6f14_70m",
+        "ccl4_70m",
+        "cf4_70m",
+        "cfc112_70m",
+        "cfc113_70m",
+        "cfc114_70m",
     ]
 
     sorted_keys = sorted(list(gas_data.keys()))
@@ -62,30 +62,55 @@ def test_read_file(data_path, precision_path):
     assert len(sorted_keys) == 56
 
 
-def test_read_file_incorrect_inlet_raises(precision_path):
-    data_path = Path(__file__).resolve().parent.joinpath("../data/proc_test_data/GC/capegrim-incorrect-inlet.18.C")
+def test_read_file_thd(data_thd, prec_thd):
+    gc = GC()
+
+    gas_data = gc.read_file(
+        data_filepath=data_thd,
+        precision_filepath=prec_thd,
+        site="thd",
+        network="AGAGE",
+    )
+
+    expected_keys = ["ccl4_10m", "cfc113_10m", "cfc11_10m", "cfc12_10m", "ch3ccl3_10m", "ch4_10m", "chcl3_10m", "n2o_10m"]
+
+    assert sorted(list(gas_data.keys())) == expected_keys
+
+    expected_metadata = {
+        "instrument": "GCMD",
+        "site": "thd",
+        "network": "AGAGE",
+        "species": "ch3ccl3",
+        "units": "ppt",
+        "scale": "SIO-05",
+        "inlet": "10m",
+    }
+
+    assert gas_data["ch3ccl3_10m"]["metadata"] == expected_metadata
+
+    meas_data = gas_data["ch3ccl3_10m"]["data"]
+
+    assert meas_data.time[0] == pd.Timestamp("2001-01-01T01:05:22.5")
+    assert meas_data.time[-1] == pd.Timestamp("2001-12-31T23:18:22.5")
+
+    assert meas_data["ch3ccl3"][0] == 41.537
+    assert meas_data["ch3ccl3"][-1] == 34.649
+
+
+def test_read_file_incorrect_inlet_raises(cgo_prec_path):
+    data_path = get_datapath("capegrim-incorrect-inlet.18.C")
 
     gc = GC()
 
     with pytest.raises(ValueError):
-        gc.read_file(
-            data_filepath=data_path,
-            precision_filepath=precision_path,
-            site="CGO",
-            instrument="medusa",
-        )
+        gc.read_file(data_filepath=data_path, precision_filepath=cgo_prec_path, site="CGO", instrument="medusa", network="AGAGE")
 
 
-def test_read_invalid_instrument_raises(data_path_no_instrument, precision_path_no_instrument):
+def test_read_invalid_instrument_raises(data_thd, prec_thd):
     gc = GC()
 
     with pytest.raises(ValueError):
-        gc.read_file(
-            data_filepath=data_path_no_instrument,
-            precision_filepath=precision_path_no_instrument,
-            site="CGO",
-            instrument="fish",
-        )
+        gc.read_file(data_filepath=data_thd, precision_filepath=prec_thd, site="CGO", instrument="fish", network="AGAGE")
 
 
 def test_instrument_translator_works():
@@ -123,19 +148,17 @@ def test_instrument_translator_raises():
         gc.instrument_translator(instrument=instrument_suffix)
 
 
-def test_read_data(data_path, precision_path):
+def test_read_data(cgo_path, cgo_prec_path):
     # Capegrim
     site = "CGO"
     instrument = "GCMD"
 
     gc = GC()
     data = gc.read_data(
-        data_filepath=data_path, precision_filepath=precision_path, site=site, instrument=instrument, network="AGAGE"
+        data_filepath=cgo_path, precision_filepath=cgo_prec_path, site=site, instrument=instrument, network="AGAGE"
     )
 
-    return False
-
-    propane_data = data["propane_75m_4"]["data"]
+    propane_data = data["propane_70m"]["data"]
 
     head_data = propane_data.head(1)
     tail_data = propane_data.tail(1)
@@ -148,33 +171,26 @@ def test_read_data(data_path, precision_path):
     assert tail_data["propane"][0] == 4.136
     assert tail_data["propane repeatability"][0] == 0.16027
 
-    species = list(data.keys())
+    species = sorted(list(data.keys()))
 
-    assert species[:8] == [
-        "NF3",
-        "CF4",
-        "PFC-116",
-        "PFC-218",
-        "PFC-318",
-        "C4F10",
-        "C6F14",
-        "SF6",
-    ]
+    expected_species = ["benzene_70m", "c4f10_70m", "c6f14_70m", "ccl4_70m", "cf4_70m", "cfc112_70m", "cfc113_70m", "cfc114_70m"]
+
+    assert species[:8] == expected_species
 
     attributes = {
         "data_owner": "Paul Krummel",
         "data_owner_email": "paul.krummel@csiro.au",
-        "inlet_height_magl": "75m_4",
+        "inlet_height_magl": "70m",
         "comment": "Gas chromatograph measurements. Output from GCWerks.",
     }
 
-    assert data["NF3"]["attributes"] == attributes
+    assert data["nf3_70m"]["attributes"] == attributes
 
 
-def test_read_precision(precision_path):
+def test_read_precision(cgo_prec_path):
     gc = GC()
 
-    precision, precision_series = gc.read_precision(precision_path)
+    precision, precision_series = gc.read_precision(cgo_prec_path)
 
     prec_test = ["NF3", "CF4", "PFC-116", "PFC-218", "PFC-318", "C4F10", "C6F14", "SF6"]
     end_prec_test = [
@@ -200,10 +216,10 @@ def test_read_precision(precision_path):
     assert precision_head.iloc[0, 10] == 0.00565
 
 
-def test_no_precisions_species_raises(data_path):
+def test_no_precisions_species_raises(cgo_path):
     missing_species_prec = get_datapath(filename="capegrim-medusa.18.precisions.broke.C")
 
     gc = GC()
 
     with pytest.raises(ValueError):
-        gc.read_file(data_filepath=data_path, precision_filepath=missing_species_prec)
+        gc.read_file(data_filepath=cgo_path, precision_filepath=missing_species_prec, site="cgo", network="AGAGE")

--- a/tests/modules/test_obssurface.py
+++ b/tests/modules/test_obssurface.py
@@ -79,68 +79,68 @@ def test_read_GC():
     results = ObsSurface.read_file(filepath=(data_filepath, precision_filepath), data_type="GCWERKS", site="CGO", network="AGAGE")
 
     expected_keys = [
-        "benzene_75m_4",
-        "c4f10_75m_4",
-        "c6f14_75m_4",
-        "ccl4_75m_4",
-        "cf4_75m_4",
-        "cfc112_75m_4",
-        "cfc113_75m_4",
-        "cfc114_75m_4",
-        "cfc115_75m_4",
-        "cfc11_75m_4",
-        "cfc12_75m_4",
-        "cfc13_75m_4",
-        "ch2br2_75m_4",
-        "ch2cl2_75m_4",
-        "ch3br_75m_4",
-        "ch3ccl3_75m_4",
-        "ch3cl_75m_4",
-        "ch3i_75m_4",
-        "chbr3_75m_4",
-        "chcl3_75m_4",
-        "cos_75m_4",
-        "cpropane_75m_4",
-        "desflurane_75m_4",
-        "ethane_75m_4",
-        "ethyne_75m_4",
-        "h1211_75m_4",
-        "h1301_75m_4",
-        "h2402_75m_4",
-        "hcfc124_75m_4",
-        "hcfc132b_75m_4",
-        "hcfc133a_75m_4",
-        "hcfc141b_75m_4",
-        "hcfc142b_75m_4",
-        "hcfc22_75m_4",
-        "hfc125_75m_4",
-        "hfc134a_75m_4",
-        "hfc143a_75m_4",
-        "hfc152a_75m_4",
-        "hfc227ea_75m_4",
-        "hfc236fa_75m_4",
-        "hfc23_75m_4",
-        "hfc245fa_75m_4",
-        "hfc32_75m_4",
-        "hfc365mfc_75m_4",
-        "hfc4310mee_75m_4",
-        "nf3_75m_4",
-        "pce_75m_4",
-        "pfc116_75m_4",
-        "pfc218_75m_4",
-        "pfc318_75m_4",
-        "propane_75m_4",
-        "sf5cf3_75m_4",
-        "sf6_75m_4",
-        "so2f2_75m_4",
-        "tce_75m_4",
-        "toluene_75m_4",
+        "benzene_70m",
+        "c4f10_70m",
+        "c6f14_70m",
+        "ccl4_70m",
+        "cf4_70m",
+        "cfc112_70m",
+        "cfc113_70m",
+        "cfc114_70m",
+        "cfc115_70m",
+        "cfc11_70m",
+        "cfc12_70m",
+        "cfc13_70m",
+        "ch2br2_70m",
+        "ch2cl2_70m",
+        "ch3br_70m",
+        "ch3ccl3_70m",
+        "ch3cl_70m",
+        "ch3i_70m",
+        "chbr3_70m",
+        "chcl3_70m",
+        "cos_70m",
+        "cpropane_70m",
+        "desflurane_70m",
+        "ethane_70m",
+        "ethyne_70m",
+        "h1211_70m",
+        "h1301_70m",
+        "h2402_70m",
+        "hcfc124_70m",
+        "hcfc132b_70m",
+        "hcfc133a_70m",
+        "hcfc141b_70m",
+        "hcfc142b_70m",
+        "hcfc22_70m",
+        "hfc125_70m",
+        "hfc134a_70m",
+        "hfc143a_70m",
+        "hfc152a_70m",
+        "hfc227ea_70m",
+        "hfc236fa_70m",
+        "hfc23_70m",
+        "hfc245fa_70m",
+        "hfc32_70m",
+        "hfc365mfc_70m",
+        "hfc4310mee_70m",
+        "nf3_70m",
+        "pce_70m",
+        "pfc116_70m",
+        "pfc218_70m",
+        "pfc318_70m",
+        "propane_70m",
+        "sf5cf3_70m",
+        "sf6_70m",
+        "so2f2_70m",
+        "tce_70m",
+        "toluene_70m",
     ]
 
     assert sorted(list(results["processed"]["capegrim-medusa.18.C"].keys())) == expected_keys
 
     # Load in some data
-    uuid = results["processed"]["capegrim-medusa.18.C"]["hfc152a_75m_4"]
+    uuid = results["processed"]["capegrim-medusa.18.C"]["hfc152a_70m"]
 
     hfc152a_data = Datasource.load(uuid=uuid, shallow=False).data()
     hfc152a_data = hfc152a_data["2018-01-01-02:24:00+00:00_2018-01-31-23:33:00+00:00"]
@@ -170,7 +170,7 @@ def test_read_GC():
     assert hfc152a_data.attrs == {
         "data_owner": "Paul Krummel",
         "data_owner_email": "paul.krummel@csiro.au",
-        "inlet_height_magl": "75m_4",
+        "inlet_height_magl": "70m",
         "comment": "Medusa measurements. Output from GCWerks. See Miller et al. (2008).",
         "Conditions of use": "Ensure that you contact the data owner at the outset of your project.",
         "Source": "In situ measurements of air",
@@ -187,7 +187,7 @@ def test_read_GC():
         "network": "agage",
         "units": "ppt",
         "scale": "SIO-05",
-        "inlet": "75m_4",
+        "inlet": "70m",
     }
 
     # # Now test that if we add more data it adds it to the same Datasource
@@ -219,13 +219,13 @@ def test_read_GC():
     obs = ObsSurface.load()
     table = obs._datasource_table
 
-    assert table["cgo"]["agage"]["75m_4"]["nf3"]
-    assert table["cgo"]["agage"]["75m_4"]["hfc236fa"]
-    assert table["cgo"]["agage"]["75m_4"]["h1211"]
+    assert table["cgo"]["agage"]["70m"]["nf3"]
+    assert table["cgo"]["agage"]["70m"]["hfc236fa"]
+    assert table["cgo"]["agage"]["70m"]["h1211"]
 
-    assert table["thd"]["agage"]["any"]["cfc11"]
-    assert table["thd"]["agage"]["any"]["n2o"]
-    assert table["thd"]["agage"]["any"]["ccl4"]
+    assert table["thd"]["agage"]["10m"]["cfc11"]
+    assert table["thd"]["agage"]["10m"]["n2o"]
+    assert table["thd"]["agage"]["10m"]["ccl4"]
 
 
 def test_read_cranfield():

--- a/tests/processing/test_recombination.py
+++ b/tests/processing/test_recombination.py
@@ -69,7 +69,7 @@ def test_recombination_GC():
 
     data = gc.read_data(data_filepath=data, precision_filepath=precision, site="CGO", instrument="medusa", network="AGAGE")
 
-    toluene_data = data["toluene_75m_4"]["data"]
+    toluene_data = data["toluene_70m"]["data"]
 
     gas_name = "toluene"
     site = "CGO"

--- a/tests/processing/test_search.py
+++ b/tests/processing/test_search.py
@@ -67,7 +67,7 @@ def test_search_gc():
         "species": "nf3",
         "units": "ppt",
         "scale": "sio-12",
-        "inlet": "75m_4",
+        "inlet": "70m",
         "data_type": "timeseries",
         "network": "agage",
     }


### PR DESCRIPTION
This updates the labelling on inlets to use the `inlet_labels` values given in `process_gcwerks_parameters.json` rather than the inlet value given in the data. This fixes the duplication of datasources when inlets such as `75m_4` are used in the data. These now map to `70m` on read.