### PR TITLE
Updated resampling when combining footprints and obs data

### DIFF
--- a/openghg/processing/_observations.py
+++ b/openghg/processing/_observations.py
@@ -122,6 +122,10 @@ def get_obs_surface(
         # keep_attrs doesn't seem to work for some reason, so manually copy
         ds_resampled.attrs = data.attrs.copy()
 
+        average_in_seconds = Timedelta(average).total_seconds()
+        ds_resampled.attrs["averaged_period"] = average_in_seconds
+        ds_resampled.attrs["averaged_period_str"] = average
+
         # For some variables, need a different type of resampling
         for var in data.variables:
             if "repeatability" in var:

--- a/openghg/processing/_process_footprint.py
+++ b/openghg/processing/_process_footprint.py
@@ -274,7 +274,8 @@ def align_datasets(
 
     if platform is not None:
         platform = platform.lower()
-        if platform in ("satellite"):#, "flask"):
+        # Do not apply resampling for "satellite" (but have re-included "flask" for now)
+        if platform in ("satellite"):
             return obs_data, footprint_data
 
     # Get the period of measurements in time
@@ -285,15 +286,15 @@ def align_datasets(
         obs_data_period_s = obs_attributes["sampling_period"]
     else:
         # Attempt to derive sampling period from frequency of data
-        obs_data_period_s = np.nanmedian((obs_data.time.data[1:] - obs_data.time.data[0:-1])/1e9).astype(int64)
-        
-        obs_data_period_s_min = (np.diff(obs_data.time.data).min()/1e9)
-        obs_data_period_s_max = (np.diff(obs_data.time.data).max()/1e9)
-        
+        obs_data_period_s = np.nanmedian((obs_data.time.data[1:] - obs_data.time.data[0:-1]) / 1e9).astype("int64")
+
+        obs_data_period_s_min = (np.diff(obs_data.time.data).min() / 1e9)
+        obs_data_period_s_max = (np.diff(obs_data.time.data).max() / 1e9)
+
         # Check if the periods differ by more than 1 second
         if np.isclose(obs_data_period_s_min, obs_data_period_s_max, 1):
             raise ValueError("Sample period can be not be derived from observations")
-   
+
     obs_data_timeperiod = Timedelta(seconds=obs_data_period_s)
 
     # Derive the footprint period from the frequency of the data
@@ -319,7 +320,7 @@ def align_datasets(
 
     # Only non satellite datasets with different periods need to be resampled
     timeperiod_diff_s = np.abs(obs_data_timeperiod - footprint_data_timeperiod).total_seconds()
-    tolerance = 1e-9 # seconds
+    tolerance = 1e-9  # seconds
     if timeperiod_diff_s >= tolerance:
         base = start_date.hour + start_date.minute / 60.0 + start_date.second / 3600.0
 

--- a/openghg/processing/_process_footprint.py
+++ b/openghg/processing/_process_footprint.py
@@ -38,7 +38,7 @@ def single_site_footprint(
                        This is useful for example if the same site footprints are run with a different met and
                        they are named slightly differently from the obs file. E.g.
                        site="DJI", site_modifier = "DJI-SAM" - station called DJI, footprint site called DJI-SAM
-        platform:
+        platform: Observation platform used to decide whether to resample
         instrument:
         species:
     Returns:
@@ -133,7 +133,26 @@ def footprints_data_merge(
     TODO - Should this be renamed?
 
     Args:
-        TODO
+        site: Three letter site code
+        height: Height of inlet in metres
+        network: Network name
+        domain: Domain name
+        start_date: Start date
+        end_date: End date
+        resample_to: Overrides resampling to coarsest time resolution, can be one of ["coarsest", "footprint", "obs"]
+        site_modifier: The name of the site given in the footprint.
+                This is useful for example if the same site footprints are run with a different met and
+                they are named slightly differently from the obs file. E.g.
+                site="DJI", site_modifier = "DJI-SAM" - station called DJI, footprint site called DJI-SAM
+        platform: Observation platform used to decide whether to resample
+        instrument: Instrument name
+        species: Species name
+        load_flux: Load flux
+        flux_sources: Flux source names
+        load_bc: Load boundary conditions (not currently implemented)
+        calc_timeseries: Calculate timeseries data (not currently implemented)
+        calc_bc: Calculate boundary conditions (not currently implemented)
+        time_resolution: One of ["standard", "high"]
     Returns:
         dict: Dictionary footprint data objects
     """
@@ -275,7 +294,7 @@ def align_datasets(
     if platform is not None:
         platform = platform.lower()
         # Do not apply resampling for "satellite" (but have re-included "flask" for now)
-        if platform in ("satellite"):
+        if platform == "satellite":
             return obs_data, footprint_data
 
     # Get the period of measurements in time
@@ -288,8 +307,8 @@ def align_datasets(
         # Attempt to derive sampling period from frequency of data
         obs_data_period_s = np.nanmedian((obs_data.time.data[1:] - obs_data.time.data[0:-1]) / 1e9).astype("int64")
 
-        obs_data_period_s_min = (np.diff(obs_data.time.data).min() / 1e9)
-        obs_data_period_s_max = (np.diff(obs_data.time.data).max() / 1e9)
+        obs_data_period_s_min = np.diff(obs_data.time.data).min() / 1e9
+        obs_data_period_s_max = np.diff(obs_data.time.data).max() / 1e9
 
         # Check if the periods differ by more than 1 second
         if np.isclose(obs_data_period_s_min, obs_data_period_s_max, 1):

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .helpers import get_datapath

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -1,0 +1,9 @@
+""" Some helper functions for things we do in tests frequently
+"""
+from pathlib import Path
+
+__all__ = ["get_datapath"]
+
+
+def get_datapath(filename, data_type):
+    return Path(__file__).resolve(strict=True).parent.joinpath(f"../data/proc_test_data/{data_type}/{filename}")


### PR DESCRIPTION
Uses input "sampling_period" attribute when deciding on resampling strategy for footprints and data.

If this attribute is not present this will still attempt to derive this from the obs data frequency but will produce an error is this is too variable. This is an alternative to the suggested approach on applying a default sample_period of "1H".

Other changes:
 - The default for the `resample_to` input parameter has also been updated to "coarsest" (instead of "obs") as this is more appropriate for expected inputs.
 - This can now be used for "flask" samples as long as the "sample_period" is specified.
 - Using `get_obs_surface()` will now add "averaged_period" and "averaged_period_str" attributes to the output Dataset (this is not used anywhere yet but plan to use this within `footprint_data_merge()` in future).

This does not allow for the case of a variable sampling period per measurement.
