### PR TITLE
Rework of how ranks are stored and how overwriting happens

### DIFF
--- a/openghg/localclient/_rank_sources.py
+++ b/openghg/localclient/_rank_sources.py
@@ -9,8 +9,8 @@ __all__ = ["RankSources"]
 
 
 class RankSources:
-    # def __init__(self):
-    #     raise NotImplementedError()
+    def __init__(self):
+        raise NotImplementedError()
 
     def get_sources(self, site, species=None):
         """ Get the datasources for this site and species to allow a ranking to be set

--- a/openghg/modules/_base.py
+++ b/openghg/modules/_base.py
@@ -149,16 +149,16 @@ class BaseModule:
         del self._datasource_uuids[uuid]
 
     def get_rank(self: T, uuid: str, start_date: Timestamp, end_date: Timestamp) -> Dict:
-        """ Get the rank for the given Datasource for a given date range
+        """Get the rank for the given Datasource for a given date range
 
-            Args:
-                uuid: UUID of Datasource
-                start_date: Start date
-                end_date: End date
-            Returns:
-                dict: Dictionary of rank and daterange covered by that rank
+        Args:
+            uuid: UUID of Datasource
+            start_date: Start date
+            end_date: End date
+        Returns:
+            dict: Dictionary of rank and daterange covered by that rank
         """
-        from openghg.util import date_overlap, create_daterange_str
+        from openghg.util import daterange_overlap, create_daterange_str
         from collections import defaultdict
 
         if uuid not in self._rank_data:
@@ -172,7 +172,7 @@ class BaseModule:
         # Check if this Datasource is ranked for the dates passed
         for rank, dateranges in rank_data.items():
             for stored_daterange in dateranges:
-                if date_overlap(daterange_a=search_daterange, daterange_b=stored_daterange):
+                if daterange_overlap(daterange_a=search_daterange, daterange_b=stored_daterange):
                     # return {rank: stored_daterange}
                     ranked[rank].append(stored_daterange)
 
@@ -197,7 +197,8 @@ class BaseModule:
         Returns:
             None
         """
-        from openghg.util import combine_dateranges, date_overlap, valid_daterange
+        from openghg.util import combine_dateranges, daterange_overlap, valid_daterange, trim_daterange
+        from copy import deepcopy
 
         rank = int(rank)
 
@@ -207,36 +208,66 @@ class BaseModule:
         if not isinstance(date_range, list):
             date_range = [date_range]
 
-        overlap = False
+        # Used to store dateranges that need to be trimmed to ensure no daterange overlap
+        to_update = []
+        # Non-overlapping dateranges that can be stored directly
+        to_add = []
 
         if uuid in self._rank_data:
             rank_data = self._rank_data[uuid]
             # Check this source isn't ranked differently for the same dates
-            for d in date_range:
-                if not valid_daterange(d):
+            for new_daterange in date_range:
+                if not valid_daterange(new_daterange):
                     raise ValueError("Invalid daterange, please ensure start and end dates are correct.")
 
-                # Check we don't have any overlapping dateranges for other ranks
-                for existing_rank, existing_daterange in rank_data.items():
-                    for e in existing_daterange:
-                        if date_overlap(daterange_a=e, daterange_b=d):
-                            overlap = True
-                            if rank != existing_rank:
-                                raise ValueError(
-                                    f"This datasource has rank {existing_rank} for dates that overlap the ones given. \
-                                                    Overlapping dateranges are {e} and {d}"
-                                )
+                overlap = False
+                # Check for overlapping dateranges and add 
+                for existing_daterange, existing_rank in rank_data.items():
+                    if daterange_overlap(daterange_a=new_daterange, daterange_b=existing_daterange):
+                        overlap = True
 
-            # Combine the dateranges
-            if rank in rank_data:
-                rank_data[rank].extend(date_range)
-            else:
-                rank_data[rank] = [date_range]
+                        if rank != existing_rank and overwrite:
+                            # Save the daterange we need to update
+                            to_update.append((existing_daterange, new_daterange))
+                            continue
+                        # If the ranks are the same we just want to combine the dateranges
+                        elif rank == existing_rank:
+                            combined = combine_dateranges(new_daterange, existing_daterange)[0]
+                            to_add.append(combined)
+                        else:
+                            raise ValueError(
+                                f"This datasource has rank {existing_rank} for dates that overlap the ones given. \
+                                                Overlapping dateranges are {new_daterange} and {existing_daterange}"
+                            )
+                # Otherwise we just want to add the new daterange to the dict
+                if not overlap:
+                    to_add.append(new_daterange)
 
-            if overlap:
-                rank_data[rank] = combine_dateranges(rank_data[rank])
+            # If we've got dateranges to update and ranks to overwrite we need to trim the 
+            # previous ranking daterange down so we don't have overlapping dateranges
+            if overwrite and to_update:
+                # Here we first take a backup of the old ranking data, update
+                # it and then write it back
+                ranking_backup = deepcopy(rank_data)
+                for exisiting, new in to_update:
+                    rank_copy = rank_data[exisiting]
+                    # Remove the exisiting daterange rank
+                    del ranking_backup[existing_daterange]
+                    # Here we trim the existing daterange down and reassign its rank
+                    trimmed = trim_daterange(to_trim=exisiting, overlapping=new)
+                    # Set the old rank with the newly trimmed daterange
+                    ranking_backup[trimmed] = rank_copy
+                    # Add in the new daterange 
+                    ranking_backup[new] = rank
+
+                rank_data = ranking_backup
+
+            # Finally, store the dateranges that didn't overlap
+            for d in to_add:
+                rank_data[d] = rank
         else:
-            self._rank_data[uuid][rank] = date_range
+            for d in date_range:
+                self._rank_data[uuid][d] = rank    
 
         self.save()
 

--- a/openghg/modules/_base.py
+++ b/openghg/modules/_base.py
@@ -170,11 +170,9 @@ class BaseModule:
 
         ranked = defaultdict(list)
         # Check if this Datasource is ranked for the dates passed
-        for rank, dateranges in rank_data.items():
-            for stored_daterange in dateranges:
-                if daterange_overlap(daterange_a=search_daterange, daterange_b=stored_daterange):
-                    # return {rank: stored_daterange}
-                    ranked[rank].append(stored_daterange)
+        for daterange, rank in rank_data.items():
+            if daterange_overlap(daterange_a=search_daterange, daterange_b=daterange):
+                ranked[rank].append(daterange)
 
         return ranked
 

--- a/openghg/modules/_base.py
+++ b/openghg/modules/_base.py
@@ -190,12 +190,20 @@ class BaseModule:
         Args:
             uuid: UUID of Datasource
             rank: Rank of data
-            daterange: Daterange(s)
+            date_range: Daterange(s)
             overwrite: Overwrite current ranking data
         Returns:
             None
         """
-        from openghg.util import combine_dateranges, daterange_overlap, valid_daterange, trim_daterange
+        from openghg.util import (
+            combine_dateranges,
+            daterange_overlap,
+            valid_daterange,
+            trim_daterange,
+            daterange_contains,
+            split_encompassed_daterange,
+        )
+
         from copy import deepcopy
 
         rank = int(rank)
@@ -219,7 +227,7 @@ class BaseModule:
                     raise ValueError("Invalid daterange, please ensure start and end dates are correct.")
 
                 overlap = False
-                # Check for overlapping dateranges and add 
+                # Check for overlapping dateranges and add
                 for existing_daterange, existing_rank in rank_data.items():
                     if daterange_overlap(daterange_a=new_daterange, daterange_b=existing_daterange):
                         overlap = True
@@ -230,8 +238,9 @@ class BaseModule:
                             continue
                         # If the ranks are the same we just want to combine the dateranges
                         elif rank == existing_rank:
-                            combined = combine_dateranges(new_daterange, existing_daterange)[0]
-                            to_add.append(combined)
+                            to_combine = (new_daterange, existing_daterange)
+                            combined = combine_dateranges(dateranges=to_combine)[0]
+                            to_update.append((existing_daterange, combined))
                         else:
                             raise ValueError(
                                 f"This datasource has rank {existing_rank} for dates that overlap the ones given. \
@@ -241,31 +250,52 @@ class BaseModule:
                 if not overlap:
                     to_add.append(new_daterange)
 
-            # If we've got dateranges to update and ranks to overwrite we need to trim the 
+            # If we've got dateranges to update and ranks to overwrite we need to trim the
             # previous ranking daterange down so we don't have overlapping dateranges
-            if overwrite and to_update:
+            if to_update:
                 # Here we first take a backup of the old ranking data, update
                 # it and then write it back
                 ranking_backup = deepcopy(rank_data)
-                for exisiting, new in to_update:
-                    rank_copy = rank_data[exisiting]
-                    # Remove the exisiting daterange rank
-                    del ranking_backup[existing_daterange]
-                    # Here we trim the existing daterange down and reassign its rank
-                    trimmed = trim_daterange(to_trim=exisiting, overlapping=new)
-                    # Set the old rank with the newly trimmed daterange
-                    ranking_backup[trimmed] = rank_copy
-                    # Add in the new daterange 
-                    ranking_backup[new] = rank
 
-                rank_data = ranking_backup
+                for existing, new in to_update:
+                    # Remove the existing daterange key
+                    del ranking_backup[existing]
+                    # If we want to overwrite an existing rank we need to trim that daterange and
+                    # rewrite it back to the dictionary
+                    rank_copy = rank_data[existing]
+                    if overwrite:
+                        # Here we trim the existing daterange down and reassign its rank
+                        # If the existing daterange contains the new we need to split it out, save the old rank chunks
+                        # and add the new daterangea and rank in.
+                        if daterange_contains(container=existing, contained=new):
+                            result = split_encompassed_daterange(container=existing, contained=new)
+
+                            existing_start = result["container_start"]
+                            ranking_backup[existing_start] = rank_copy
+
+                            updated_new = result["contained"]
+                            ranking_backup[updated_new] = rank
+
+                            existing_end = result["container_end"]
+                            ranking_backup[existing_end] = rank_copy
+                        # If the new daterange contains the existing we can just overwrite it
+                        elif daterange_contains(container=new, contained=existing):
+                            ranking_backup[new] = rank_copy
+                        else:
+                            trimmed = trim_daterange(to_trim=existing, overlapping=new)
+                            ranking_backup[trimmed] = rank_copy
+                    elif rank_copy == rank:
+                        # If we're not overwriting we just need to update to use the new combined
+                        ranking_backup[new] = rank_copy
+
+                self._rank_data[uuid] = ranking_backup
 
             # Finally, store the dateranges that didn't overlap
             for d in to_add:
-                rank_data[d] = rank
+                self._rank_data[uuid][d] = rank
         else:
             for d in date_range:
-                self._rank_data[uuid][d] = rank    
+                self._rank_data[uuid][d] = rank
 
         self.save()
 

--- a/openghg/modules/_datasource.py
+++ b/openghg/modules/_datasource.py
@@ -146,7 +146,7 @@ class Datasource:
         Returns:
             None
         """
-        from openghg.util import date_overlap
+        from openghg.util import daterange_overlap
 
         # Group by year
         year_group = list(data.groupby("time.year"))
@@ -165,7 +165,7 @@ class Datasource:
             to_keep = []
             for current_daterange in self._data:
                 for new_daterange in additional_data:
-                    if not date_overlap(daterange_a=current_daterange, daterange_b=new_daterange):
+                    if not daterange_overlap(daterange_a=current_daterange, daterange_b=new_daterange):
                         to_keep.append(current_daterange)
 
             updated_data = {}
@@ -231,7 +231,7 @@ class Datasource:
         Returns:
             None
         """
-        from openghg.util import date_overlap
+        from openghg.util import daterange_overlap
 
         # Use a dictionary keyed with the daterange covered by each segment of data
         new_data = {}
@@ -246,7 +246,7 @@ class Datasource:
             to_keep = []
             for current_daterange in self._data:
                 for new_daterange in new_data:
-                    if not date_overlap(daterange_a=current_daterange, daterange_b=new_daterange):
+                    if not daterange_overlap(daterange_a=current_daterange, daterange_b=new_daterange):
                         to_keep.append(current_daterange)
 
             updated_data = {}

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -30,10 +30,11 @@ from ._time import (
     create_daterange_str,
     create_daterange,
     create_aligned_timestamp,
-    date_overlap,
+    daterange_overlap,
     combine_dateranges,
     split_daterange_str,
     closest_daterange,
     valid_daterange,
     find_daterange_gaps,
+    trim_daterange,
 )

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -37,4 +37,6 @@ from ._time import (
     valid_daterange,
     find_daterange_gaps,
     trim_daterange,
+    split_encompassed_daterange,
+    daterange_contains,
 )

--- a/openghg/util/_time.py
+++ b/openghg/util/_time.py
@@ -1,5 +1,5 @@
 from pandas import Timestamp, DatetimeIndex
-from typing import List, Tuple, Optional, Union
+from typing import Dict, List, Tuple, Optional, Union
 
 __all__ = [
     "timestamp_tzaware",
@@ -17,6 +17,8 @@ __all__ = [
     "valid_daterange",
     "find_daterange_gaps",
     "trim_daterange",
+    "split_encompassed_daterange",
+    "daterange_contains",
 ]
 
 
@@ -433,6 +435,21 @@ def find_daterange_gaps(start_search: Timestamp, end_search: Timestamp, daterang
     return gaps
 
 
+def daterange_contains(container: str, contained: str) -> bool:
+    """Check if container contains contained
+
+        Args:
+            container: Daterange
+            contained: Daterange
+        Returns:
+            bool
+    """
+    start_a, end_a = split_daterange_str(container)
+    start_b, end_b = split_daterange_str(contained)
+
+    return start_a < start_b and end_b < end_a
+
+
 def trim_daterange(to_trim: str, overlapping: str) -> str:
     """Trims a daterange
 
@@ -445,20 +462,67 @@ def trim_daterange(to_trim: str, overlapping: str) -> str:
         str: Trimmed daterange
     """
     from pandas import Timedelta
-    from openghg.util import create_daterange_str, split_daterange_str
 
     if not daterange_overlap(daterange_a=to_trim, daterange_b=overlapping):
-        raise ValueError("No overlap of dateranges.")
+        raise ValueError(f"Dateranges {to_trim} and {overlapping} do not overlap")
 
     # We need to work out which way round they overlap
     start_trim, end_trim = split_daterange_str(to_trim)
     start_overlap, end_overlap = split_daterange_str(overlapping)
-    gap = "1s"
+
+    delta_gap = Timedelta("1s")
 
     # Work out if to_trim is before or after the overlap_daterange
     if end_trim > start_overlap and end_overlap > end_trim:
-        new_end_trim = start_overlap - Timedelta(gap)
+        new_end_trim = start_overlap - delta_gap
         return create_daterange_str(start=start_trim, end=new_end_trim)
     else:
-        new_start_trim = end_overlap + Timedelta(gap)
+        new_start_trim = end_overlap + delta_gap
         return create_daterange_str(start=new_start_trim, end=end_trim)
+
+
+def split_encompassed_daterange(container: str, contained: str) -> Dict:
+    """ Checks if one of the passed dateranges contains the other, if so, then
+    split the larger daterange into three sections.
+
+          <---a--->
+    <---------b----------->
+
+    Here b is split into three and we end up with:
+
+    <-dr1-><---a---><-dr2->
+
+    Args:
+        daterange_a: Daterange
+        daterange_b: Daterange
+    Returns:
+        dict: Dictionary of results
+    """
+    from pandas import Timedelta
+
+    if not daterange_overlap(daterange_a=container, daterange_b=contained):
+        raise ValueError("No overlap of dateranges.")
+
+    container_start, container_end = split_daterange_str(daterange_str=container)
+    contained_start, contained_end = split_daterange_str(daterange_str=contained)
+
+    delta_gap = Timedelta("1s")
+
+    dr1_start = container_start
+    dr1_end = contained_start - delta_gap
+    dr1 = create_daterange_str(start=dr1_start, end=dr1_end)
+
+    dr3_start = contained_end + delta_gap
+    dr3_end = container_end
+    dr3 = create_daterange_str(start=dr3_start, end=dr3_end)
+
+    # Trim a gap off the end of contained
+    new_contained_end = contained_end - delta_gap
+    new_contained = create_daterange_str(start=contained_start, end=new_contained_end)
+
+    results = {}
+    results["container_start"] = dr1
+    results["contained"] = new_contained
+    results["container_end"] = dr3
+
+    return results


### PR DESCRIPTION
This adds some code to allow the overwriting of rankings in a better way. We can now overwrite ranks and the dateranges are all split and ranks reassigned automatically.