### PR TITLE
Standardising species name for GC

### DIFF
--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional, Union, Tuple
 from pathlib import Path
 from pandas import DataFrame
-from openghg.util import clean_string, load_json
 
 
 def find_files(
@@ -403,7 +402,7 @@ def _split_species(
     """
     from addict import Dict as aDict
     from fnmatch import fnmatch
-    from openghg.util import clean_string
+    from openghg.util import load_json, clean_string
 
     # Load species translator so we can keep species names consistent
     attributes_data = load_json("attributes.json")

--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional, Union, Tuple
 from pathlib import Path
 from pandas import DataFrame
+from openghg.util import clean_string, load_json
 
 
 def find_files(
@@ -404,6 +405,10 @@ def _split_species(
     from fnmatch import fnmatch
     from openghg.util import clean_string
 
+    # Load species translator so we can keep species names consistent
+    attributes_data = load_json("attributes.json")
+    species_translator = attributes_data["species_translation"]
+
     # Read inlets from the parameters
     expected_inlets = _get_inlets(site_code=site, gc_params=gc_params)
 
@@ -425,7 +430,6 @@ def _split_species(
         for inlet, inlet_label in expected_inlets.items():
             # Create a copy of metadata for local modification
             spec_metadata = metadata.copy()
-            spec_metadata["species"] = clean_string(spec)
             spec_metadata["units"] = units[spec]
             spec_metadata["scale"] = scale[spec]
 
@@ -497,8 +501,17 @@ def _split_species(
 
             # We want an xarray Dataset
             spec_data = spec_data.to_xarray()
-            # A cleaned species label
-            comp_species = clean_string(spec)
+
+            # Create a standardised / cleaned species label
+            try:
+                comp_species = species_translator[spec.upper()]["chem"]
+            except KeyError:
+                comp_species = clean_string(spec.lower())
+
+            # Add the cleaned species name to the metadata and alternative name if present
+            spec_metadata["species"] = comp_species
+            if comp_species != spec.lower() and comp_species != spec.upper():
+                spec_metadata["species_alt"] = spec
 
             # Rename variables so they have lowercase and alphanumeric names
             to_rename = {}

--- a/tests/localclient/test_get_surface_obs.py
+++ b/tests/localclient/test_get_surface_obs.py
@@ -159,7 +159,9 @@ def test_gcwerks_retrieval():
         "data_type": "timeseries",
     }
 
-    assert metadata == expected_metadata
+    for key, expected_value in expected_metadata.items():
+        value = expected_metadata[key]
+        assert value == expected_value
 
     assert data.time[0] == Timestamp("2018-01-01T02:24:00")
     assert data.time[-1] == Timestamp("2018-01-31T23:33:00")

--- a/tests/localclient/test_get_surface_obs.py
+++ b/tests/localclient/test_get_surface_obs.py
@@ -5,23 +5,14 @@ from pathlib import Path
 from openghg.localclient import get_obs_surface
 from openghg.store import ObsSurface
 from openghg.objectstore import get_local_bucket
-
-
-def get_datapath(filename, data_type):
-    return (
-        Path(__file__)
-        .resolve(strict=True)
-        .parent.joinpath(f"../data/proc_test_data/{data_type}/{filename}")
-    )
+from helpers import get_datapath
 
 
 @pytest.fixture(scope="session", autouse=True)
 def read_data():
     get_local_bucket(empty=True)
 
-    hfd_filepath = get_datapath(
-        filename="hfd.picarro.1minute.100m.min.dat", data_type="CRDS"
-    )
+    hfd_filepath = get_datapath(filename="hfd.picarro.1minute.100m.min.dat", data_type="CRDS")
 
     cgo_data = get_datapath(filename="capegrim-medusa.18.C", data_type="GC")
     cgo_prec = get_datapath(filename="capegrim-medusa.18.precisions.C", data_type="GC")
@@ -136,6 +127,16 @@ def test_gcwerks_retrieval():
     del metadata["File created"]
 
     expected_metadata = {
+        "instrument": "medusa",
+        "site": "cgo",
+        "network": "agage",
+        "sampling_period": "1200",
+        "units": "ppt",
+        "scale": "SIO-05",
+        "inlet": "70m",
+        "species": "cfc11",
+        "species_alt": "CFC-11",
+        "data_type": "timeseries",
         "data_owner": "Paul Krummel",
         "data_owner_email": "paul.krummel@csiro.au",
         "inlet_height_magl": "70m",
@@ -144,24 +145,13 @@ def test_gcwerks_retrieval():
         "Source": "In situ measurements of air",
         "Conventions": "CF-1.6",
         "Processed by": "OpenGHG_Cloud",
-        "species": "cfc11",
         "station_longitude": 144.689,
         "station_latitude": -40.683,
         "station_long_name": "Cape Grim, Tasmania",
         "station_height_masl": 94.0,
-        "instrument": "medusa",
-        "site": "cgo",
-        "network": "agage",
-        "units": "ppt",
-        "scale": "SIO-05",
-        "inlet": "70m",
-        "sampling_period": "1200",
-        "data_type": "timeseries",
     }
 
-    for key, expected_value in expected_metadata.items():
-        value = expected_metadata[key]
-        assert value == expected_value
+    assert metadata == expected_metadata
 
     assert data.time[0] == Timestamp("2018-01-01T02:24:00")
     assert data.time[-1] == Timestamp("2018-01-31T23:33:00")

--- a/tests/retrieve/test_recombination.py
+++ b/tests/retrieve/test_recombination.py
@@ -49,9 +49,9 @@ def test_recombination_GC():
 
     data = parse_gcwerks(data_filepath=data, precision_filepath=precision, site="CGO", instrument="medusa", network="AGAGE")
 
-    toluene_data = data["toluene_70m"]["data"]
+    toluene_data = data["c6h5ch3_70m"]["data"]
 
-    species = "toluene"
+    species = "c6h5ch3"
     site = "CGO"
     inlet = "70m"
 

--- a/tests/services/test_process.py
+++ b/tests/services/test_process.py
@@ -103,7 +103,7 @@ def test_process_GCWERKS_files(authenticated_user):
 
     cgo_response = response["processed"]["capegrim-medusa.18.C"]
 
-    partial_expected_keys = ["benzene_70m", "c4f10_70m", "c6f14_70m", "ccl4_70m", "cf4_70m"]
+    partial_expected_keys = ['c2cl4_70m', 'c2f6_70m', 'c2h2_70m', 'c2h6_70m', 'c2hcl3_70m']
 
     assert len(cgo_response.keys()) == 56
     assert sorted(cgo_response.keys())[:5] == partial_expected_keys

--- a/tests/standardise/surface/test_gcwerks.py
+++ b/tests/standardise/surface/test_gcwerks.py
@@ -41,15 +41,17 @@ def test_read_file_capegrim(cgo_path, cgo_prec_path):
         network="agage",
     )
 
+    # 30/11/2021: Species labels were updated to be standardised in line with variable naming
+    # This list of expected labels was updated.
     expected_eight = [
-        "benzene_70m",
-        "c4f10_70m",
-        "c6f14_70m",
-        "ccl4_70m",
-        "cf4_70m",
-        "cfc112_70m",
-        "cfc113_70m",
-        "cfc114_70m",
+        'c2cl4_70m', 
+        'c2f6_70m', 
+        'c2h2_70m', 
+        'c2h6_70m', 
+        'c2hcl3_70m', 
+        'c3f8_70m', 
+        'c3h8_70m', 
+        'c4f10_70m',
     ]
 
     sorted_keys = sorted(list(gas_data.keys()))
@@ -89,7 +91,11 @@ def test_read_file_thd(data_thd, prec_thd):
         "sampling_period": "75",
     }
 
-    assert gas_data["ch3ccl3_10m"]["metadata"] == expected_metadata
+    # Check metadata contains *at least* expected data (may contain more items)
+    metadata = gas_data["ch3ccl3_10m"]["metadata"]
+    for key, expected_value in expected_metadata.items():
+        value = metadata[key]
+        assert value == expected_value
 
     meas_data = gas_data["ch3ccl3_10m"]["data"]
 

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -84,64 +84,66 @@ def test_read_GC():
         filepath=(data_filepath, precision_filepath), data_type="GCWERKS", site="CGO", network="AGAGE"
     )
 
+    # 30/11/2021: Species labels were updated to be standardised in line with variable naming
+    # This list of expected labels was updated.
     expected_keys = [
-        "benzene_70m",
-        "c4f10_70m",
-        "c6f14_70m",
-        "ccl4_70m",
-        "cf4_70m",
-        "cfc112_70m",
-        "cfc113_70m",
-        "cfc114_70m",
-        "cfc115_70m",
-        "cfc11_70m",
-        "cfc12_70m",
-        "cfc13_70m",
-        "ch2br2_70m",
-        "ch2cl2_70m",
-        "ch3br_70m",
-        "ch3ccl3_70m",
-        "ch3cl_70m",
-        "ch3i_70m",
-        "chbr3_70m",
-        "chcl3_70m",
-        "cos_70m",
-        "cpropane_70m",
-        "desflurane_70m",
-        "ethane_70m",
-        "ethyne_70m",
-        "h1211_70m",
-        "h1301_70m",
-        "h2402_70m",
-        "hcfc124_70m",
-        "hcfc132b_70m",
-        "hcfc133a_70m",
-        "hcfc141b_70m",
-        "hcfc142b_70m",
-        "hcfc22_70m",
-        "hfc125_70m",
-        "hfc134a_70m",
-        "hfc143a_70m",
-        "hfc152a_70m",
-        "hfc227ea_70m",
-        "hfc236fa_70m",
-        "hfc23_70m",
-        "hfc245fa_70m",
-        "hfc32_70m",
-        "hfc365mfc_70m",
-        "hfc4310mee_70m",
-        "nf3_70m",
-        "pce_70m",
-        "pfc116_70m",
-        "pfc218_70m",
-        "pfc318_70m",
-        "propane_70m",
-        "sf5cf3_70m",
-        "sf6_70m",
-        "so2f2_70m",
-        "tce_70m",
-        "toluene_70m",
-    ]
+        'c2cl4_70m', 
+        'c2f6_70m', 
+        'c2h2_70m', 
+        'c2h6_70m', 
+        'c2hcl3_70m', 
+        'c3f8_70m', 
+        'c3h8_70m', 
+        'c4f10_70m', 
+        'c4f8_70m', 
+        'c6f14_70m', 
+        'c6h5ch3_70m', 
+        'c6h6_70m', 
+        'cc3h8_70m', 
+        'ccl4_70m', 
+        'cf4_70m', 
+        'cfc112_70m', 
+        'cfc113_70m', 
+        'cfc114_70m', 
+        'cfc115_70m', 
+        'cfc11_70m', 
+        'cfc12_70m', 
+        'cfc13_70m', 
+        'ch2br2_70m', 
+        'ch2cl2_70m', 
+        'ch3br_70m', 
+        'ch3ccl3_70m', 
+        'ch3cl_70m', 
+        'ch3i_70m', 
+        'chbr3_70m', 
+        'chcl3_70m', 
+        'cos_70m', 
+        'desflurane_70m', 
+        'halon1211_70m', 
+        'halon1301_70m', 
+        'halon2402_70m', 
+        'hcfc124_70m', 
+        'hcfc132b_70m', 
+        'hcfc133a_70m', 
+        'hcfc141b_70m', 
+        'hcfc142b_70m', 
+        'hcfc22_70m', 
+        'hfc125_70m', 
+        'hfc134a_70m', 
+        'hfc143a_70m', 
+        'hfc152a_70m', 
+        'hfc227ea_70m', 
+        'hfc236fa_70m', 
+        'hfc23_70m', 
+        'hfc245fa_70m', 
+        'hfc32_70m', 
+        'hfc365mfc_70m', 
+        'hfc4310mee_70m', 
+        'nf3_70m', 
+        'sf5cf3_70m', 
+        'sf6_70m', 
+        'so2f2_70m'
+        ]
 
     assert sorted(list(results["processed"]["capegrim-medusa.18.C"].keys())) == expected_keys
 
@@ -183,6 +185,7 @@ def test_read_GC():
         "Conventions": "CF-1.6",
         "Processed by": "OpenGHG_Cloud",
         "species": "hfc152a",
+        "species_alt": "HFC-152a",
         "Calibration_scale": "SIO-05",
         "station_longitude": 144.689,
         "station_latitude": -40.683,
@@ -236,7 +239,7 @@ def test_read_GC():
 
     assert table["cgo"]["agage"]["nf3"]["70m"]
     assert table["cgo"]["agage"]["hfc236fa"]["70m"]
-    assert table["cgo"]["agage"]["h1211"]["70m"]
+    assert table["cgo"]["agage"]["halon1211"]["70m"]
 
     assert table["thd"]["agage"]["cfc11"]["10m"]
     assert table["thd"]["agage"]["n2o"]["10m"]
@@ -448,8 +451,8 @@ def test_add_new_data_correct_datasource():
 
     sorted_keys = sorted(list(results["processed"]["capegrim-medusa.05.C"].keys()))
 
-    assert sorted_keys[:4] == ["benzene_10m", "benzene_70m", "ccl4_10m", "ccl4_70m"]
-    assert sorted_keys[-4:] == ["so2f2_10m", "so2f2_70m", "toluene_10m", "toluene_70m"]
+    assert sorted_keys[:4] == ['c2cl4_10m', 'c2cl4_70m', 'c2f6_10m', 'c2f6_70m']
+    assert sorted_keys[-4:] == ['hfc32_70m', 'sf6_70m', 'so2f2_10m', 'so2f2_70m']
     assert len(sorted_keys) == 69
 
     data_filepath = get_datapath(filename="capegrim-medusa.06.C", data_type="GC")


### PR DESCRIPTION
Closes #169

Updated the species name to be the same between the label in the retrieved data and the variable within Dataset.

Uses attributes.json file (as does the attributes function) to look up standard name and use this when creating the species label e.g. "toluene_70m" would now be "c6h5ch3_70m"

Associated tests also updated to align with this new naming scheme.

