### PR TITLE
Ability to pass site long name to processing scripts

### DIFF
--- a/openghg/client/_rank_sources.py
+++ b/openghg/client/_rank_sources.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Union
 
 from openghg.store import ObsSurface
 from openghg.store.base import Datasource
-from openghg.util import InvalidSiteError, create_daterange_str, running_in_cloud, valid_site
+from openghg.util import create_daterange_str, running_in_cloud, verify_site
 
 
 class RankSources:
@@ -44,8 +44,7 @@ class RankSources:
             return self._get_sources_local(site=site, species=species)
 
     def _get_sources_cloud(self, site: str, species: str) -> Dict:
-        if not valid_site(site):
-            raise InvalidSiteError(f"{site} is not a valid site code")
+        site = verify_site(site=site)
 
         args = {"site": site, "species": species}
 
@@ -64,8 +63,7 @@ class RankSources:
         return self._user_info
 
     def _get_sources_local(self, site: str, species: str) -> Dict:
-        if not valid_site(site):
-            raise InvalidSiteError(f"{site} is not a valid site code")
+        site = verify_site(site=site)
 
         # Save these
         self.site = site

--- a/openghg/data/site_lookup.json
+++ b/openghg/data/site_lookup.json
@@ -1,0 +1,736 @@
+{
+  "AAO": {
+    "short_name": "airborne aerosol observatory",
+    "long_name": "airborne aerosol observatory bondville illinois united states"
+  },
+  "ABP": { "short_name": "arembepe", "long_name": "arembepe bahia brazil" },
+  "ACG": {
+    "short_name": "alaska coast guard",
+    "long_name": "alaska coast guard united states"
+  },
+  "ADR": { "short_name": "adrigole", "long_name": "adrigole ireland" },
+  "ALT": { "short_name": "alert", "long_name": "alert canada" },
+  "AMS": {
+    "short_name": "amsterdam island",
+    "long_name": "amsterdam island france"
+  },
+  "AMT": { "short_name": "argyle", "long_name": "argyle maine united states" },
+  "AMY": {
+    "short_name": "anmyeondo",
+    "long_name": "anmyeondo republic of korea"
+  },
+  "AND": { "short_name": "anmyeondo", "long_name": "anmyeondo south korea" },
+  "AOC": {
+    "short_name": "atlantic ocean cruise",
+    "long_name": "atlantic ocean cruise"
+  },
+  "ARH": {
+    "short_name": "arrival heights",
+    "long_name": "arrival heights new zealand"
+  },
+  "ASC": {
+    "short_name": "ascension island",
+    "long_name": "ascension island united kingdom"
+  },
+  "ASK": { "short_name": "assekrem", "long_name": "assekrem algeria" },
+  "ATO": {
+    "short_name": "amazon tall tower observatory",
+    "long_name": "amazon tall tower observatory state of amazonas brazil"
+  },
+  "AVI": {
+    "short_name": "st croix",
+    "long_name": "st croix virgin islands united states"
+  },
+  "AZR": {
+    "short_name": "terceira island",
+    "long_name": "terceira island azores portugal"
+  },
+  "BAL": { "short_name": "baltic sea", "long_name": "baltic sea poland" },
+  "BAO": {
+    "short_name": "boulder atmospheric observatory",
+    "long_name": "boulder atmospheric observatory colorado united states"
+  },
+  "BCK": {
+    "short_name": "behchoko",
+    "long_name": "behchoko northwest territories canada"
+  },
+  "BGI": {
+    "short_name": "bradgate",
+    "long_name": "bradgate iowa united states"
+  },
+  "BHD": {
+    "short_name": "baring head",
+    "long_name": "baring head new zealand"
+  },
+  "BIK": { "short_name": "bialystok", "long_name": "bialystok" },
+  "BIR": { "short_name": "birkenes", "long_name": "birkenes" },
+  "BIS": { "short_name": "biscarosse", "long_name": "biscarosse" },
+  "BKT": {
+    "short_name": "bukit kototabang",
+    "long_name": "bukit kototabang indonesia"
+  },
+  "BME": {
+    "short_name": "st davids head",
+    "long_name": "st davids head bermuda united kingdom"
+  },
+  "BMW": { "short_name": "tudor hill", "long_name": "tudor hill bermuda" },
+  "BNE": {
+    "short_name": "beaver crossing",
+    "long_name": "beaver crossing nebraska united states"
+  },
+  "BRA": {
+    "short_name": "bratts lake",
+    "long_name": "bratts lake saskatchewan canada"
+  },
+  "BRW": { "short_name": "barrow", "long_name": "barrow alaska" },
+  "BSC": {
+    "short_name": "black sea",
+    "long_name": "black sea constanta romania"
+  },
+  "BSD": { "short_name": "bilsdale", "long_name": "bilsdale uk" },
+  "BTT": { "short_name": "bt tower", "long_name": "bt tower uk" },
+  "BWD": {
+    "short_name": "brentwood",
+    "long_name": "brentwood maryland united states"
+  },
+  "CAR": {
+    "short_name": "briggsdale",
+    "long_name": "briggsdale colorado united states"
+  },
+  "CARIBIC": { "short_name": "caribic", "long_name": "caribic" },
+  "CBA": { "short_name": "cold bay", "long_name": "cold bay alaska" },
+  "CBW": {
+    "short_name": "cabauw tower",
+    "long_name": "cabauw tower netherlands"
+  },
+  "CBY": {
+    "short_name": "cambridge bay",
+    "long_name": "cambridge bay nunavut canada"
+  },
+  "CGO": { "short_name": "cape grim", "long_name": "cape grim tasmania" },
+  "CHL": {
+    "short_name": "churchill",
+    "long_name": "churchill manitoba canada"
+  },
+  "CHR": {
+    "short_name": "christmas island",
+    "long_name": "christmas island republic of kiribati"
+  },
+  "CHS": { "short_name": "cherskii", "long_name": "cherskii russia" },
+  "CIB": {
+    "short_name": "centro de investigacion de la baja atmosfera ciba",
+    "long_name": "centro de investigacion de la baja atmosfera ciba spain"
+  },
+  "CLA": { "short_name": "comilla", "long_name": "comilla bangladesh" },
+  "CMA": {
+    "short_name": "offshore cape may",
+    "long_name": "offshore cape may new jersey united states"
+  },
+  "CMN": { "short_name": "monte cimone", "long_name": "monte cimone italy" },
+  "CMO": { "short_name": "cape mears", "long_name": "cape mears oregon" },
+  "COI": { "short_name": "cape ochiishi", "long_name": "cape ochiishi japan" },
+  "COS": { "short_name": "cosmos", "long_name": "cosmos peru" },
+  "CPS": { "short_name": "chapais", "long_name": "chapais quebec canada" },
+  "CPT": { "short_name": "cape point", "long_name": "cape point south africa" },
+  "CRI": { "short_name": "cape rama", "long_name": "cape rama india" },
+  "CRV": {
+    "short_name": "carbon in arctic reservoirs vulnerability experiment carve",
+    "long_name": "carbon in arctic reservoirs vulnerability experiment carve united states"
+  },
+  "CRZ": { "short_name": "crozet island", "long_name": "crozet island france" },
+  "CVO": { "short_name": "cape verde", "long_name": "cape verde africa" },
+  "DJI": { "short_name": "darjeeling", "long_name": "darjeeling india" },
+  "DND": {
+    "short_name": "dahlen",
+    "long_name": "dahlen north dakota united states"
+  },
+  "DRP": { "short_name": "drake passage", "long_name": "drake passage na" },
+  "DSI": {
+    "short_name": "dongsha island",
+    "long_name": "dongsha island taiwan"
+  },
+  "EGB": { "short_name": "egbert", "long_name": "egbert ontario canada" },
+  "EHL": { "short_name": "earlshall", "long_name": "earlshall uk" },
+  "EIC": { "short_name": "easter island", "long_name": "easter island chile" },
+  "ESP": {
+    "short_name": "estevan point",
+    "long_name": "estevan point british columbia canada"
+  },
+  "EST": { "short_name": "esther", "long_name": "esther alberta canada" },
+  "ETL": {
+    "short_name": "east trout lake",
+    "long_name": "east trout lake saskatchewan canada"
+  },
+  "FLK": {
+    "short_name": "sapper hill",
+    "long_name": "sapper hill falkland islands malvinas"
+  },
+  "FMS": {
+    "short_name": "fort mckay south",
+    "long_name": "fort mckay south alberta canada"
+  },
+  "FSD": {
+    "short_name": "fraserdale",
+    "long_name": "fraserdale ontario canada"
+  },
+  "FTL": { "short_name": "fortaleza", "long_name": "fortaleza brazil" },
+  "FWI": {
+    "short_name": "fairchild",
+    "long_name": "fairchild wisconsin united states"
+  },
+  "GAUGE-FAAM": {
+    "short_name": "gauge flights",
+    "long_name": "gauge flights uk"
+  },
+  "GAUGE-FERRY": { "short_name": "gauge ferry", "long_name": "gauge ferry uk" },
+  "GLA": { "short_name": "glatton", "long_name": "glatton uk" },
+  "GMI": {
+    "short_name": "mariana islands",
+    "long_name": "mariana islands guam"
+  },
+  "GOSAT-BRAZIL": { "short_name": "gosat", "long_name": "gosat brazil" },
+  "GOSAT-BRAZIL-LAND": {
+    "short_name": "gosat",
+    "long_name": "gosat brazil land points"
+  },
+  "GOSAT-BRAZIL-LAND-low": {
+    "short_name": "gosat",
+    "long_name": "gosat brazil land points lower xco2 bound"
+  },
+  "GOSAT-BRAZIL-LAND-upp": {
+    "short_name": "gosat",
+    "long_name": "gosat brazil land points upper xco2 bound"
+  },
+  "GOSAT-BRAZIL-OCEAN": {
+    "short_name": "gosat",
+    "long_name": "gosat brazil ocean glint points"
+  },
+  "GOSAT-EUROPE": { "short_name": "gosat", "long_name": "gosat europe" },
+  "GOSAT-INDIA": { "short_name": "gosat", "long_name": "gosat india" },
+  "GOSAT-SAHARA": { "short_name": "gosat", "long_name": "gosat sahara" },
+  "GOSAT-SOUTHAMERICA": {
+    "short_name": "gosat",
+    "long_name": "gosat south america"
+  },
+  "GOSAT-SOUTHAMERICA-LAND": {
+    "short_name": "gosat",
+    "long_name": "gosat south america land points only"
+  },
+  "GOSAT-UK": { "short_name": "gosat", "long_name": "gosat uk" },
+  "GOZ": {
+    "short_name": "dwejra point",
+    "long_name": "dwejra point gozo malta"
+  },
+  "GSN": { "short_name": "gosan", "long_name": "gosan korea" },
+  "HAA": {
+    "short_name": "molokai island",
+    "long_name": "molokai island hawaii united states"
+  },
+  "HAD": { "short_name": "haddenham", "long_name": "haddenham uk" },
+  "HAT": { "short_name": "hateruma", "long_name": "hateruma japan" },
+  "HBA": {
+    "short_name": "halley station",
+    "long_name": "halley station antarctica united kingdom"
+  },
+  "HEI": { "short_name": "heidelberg", "long_name": "heidelberg germany" },
+  "HFD": { "short_name": "heathfield", "long_name": "heathfield uk" },
+  "HFM": {
+    "short_name": "harvard forest",
+    "long_name": "harvard forest massachusetts united states"
+  },
+  "HFT": { "short_name": "highfield tower", "long_name": "highfield tower" },
+  "HIL": { "short_name": "homer", "long_name": "homer illinois united states" },
+  "HPB": {
+    "short_name": "hohenpeissenberg",
+    "long_name": "hohenpeissenberg germany"
+  },
+  "HSU": {
+    "short_name": "humboldt state university",
+    "long_name": "humboldt state university united states"
+  },
+  "HUN": { "short_name": "hegyhatsal", "long_name": "hegyhatsal hungary" },
+  "ICE": {
+    "short_name": "storhofdi",
+    "long_name": "storhofdi vestmannaeyjar iceland"
+  },
+  "INU": {
+    "short_name": "inuvik",
+    "long_name": "inuvik northwest territories canada"
+  },
+  "INX": {
+    "short_name": "influx indianapolis flux experiment",
+    "long_name": "influx indianapolis flux experiment united states"
+  },
+  "ITN": {
+    "short_name": "grifton",
+    "long_name": "grifton north carolina united states"
+  },
+  "IZA": { "short_name": "izana", "long_name": "izana tenerife" },
+  "IZO": { "short_name": "izana", "long_name": "izana tenerife" },
+  "JFJ": {
+    "short_name": "jungfraujoch",
+    "long_name": "jungfraujoch switzerland"
+  },
+  "KAS": { "short_name": "kasprowy", "long_name": "kasprowy poland" },
+  "KCO": {
+    "short_name": "kaashidhoo",
+    "long_name": "kaashidhoo republic of maldives"
+  },
+  "KEY": { "short_name": "key biscane", "long_name": "key biscane florida" },
+  "KPA": {
+    "short_name": "kitt peak",
+    "long_name": "kitt peak arizona united states"
+  },
+  "KVH": {
+    "short_name": "killearn village hall",
+    "long_name": "killearn village hall"
+  },
+  "KUM": { "short_name": "cape kumukahi", "long_name": "cape kumukahi hawaii" },
+  "KZD": { "short_name": "sary taukum", "long_name": "sary taukum kazakhstan" },
+  "KZM": {
+    "short_name": "plateau assy",
+    "long_name": "plateau assy kazakhstan"
+  },
+  "LAC": {
+    "short_name": "la megacities",
+    "long_name": "la megacities united states"
+  },
+  "LEF": {
+    "short_name": "park falls",
+    "long_name": "park falls wisconsin united states"
+  },
+  "LEW": {
+    "short_name": "lewisburg",
+    "long_name": "lewisburg pennsylvania united states"
+  },
+  "LLB": {
+    "short_name": "lac la biche",
+    "long_name": "lac la biche alberta canada"
+  },
+  "LLN": { "short_name": "lulin", "long_name": "lulin taiwan" },
+  "LMP": { "short_name": "lampedusa", "long_name": "lampedusa italy" },
+  "LUT": { "short_name": "lutjewad", "long_name": "lutjewad netherlands" },
+  "MBC": { "short_name": "mould bay", "long_name": "mould bay canada" },
+  "MBO": {
+    "short_name": "mt bachelor observatory",
+    "long_name": "mt bachelor observatory usa"
+  },
+  "MCM": {
+    "short_name": "mcmurdo station",
+    "long_name": "mcmurdo station antarctica united states"
+  },
+  "MDO": { "short_name": "montana de oro", "long_name": "montana de oro usa" },
+  "MEX": {
+    "short_name": "high altitude global climate observation center",
+    "long_name": "high altitude global climate observation center mexico"
+  },
+  "MHD": { "short_name": "mace head", "long_name": "mace head ireland" },
+  "MID": {
+    "short_name": "sand island",
+    "long_name": "sand island midway united states"
+  },
+  "MKN": { "short_name": "mt kenya", "long_name": "mt kenya kenya" },
+  "MKO": {
+    "short_name": "mauna kea",
+    "long_name": "mauna kea hawaii united states"
+  },
+  "MLF": {
+    "short_name": "mauna loa",
+    "long_name": "mauna loa hawaii united states"
+  },
+  "MLO": { "short_name": "mauna loa", "long_name": "mauna loa hawaii" },
+  "MONSOON-FAAM": {
+    "short_name": "monsoon flights",
+    "long_name": "monsoon flights india"
+  },
+  "MRC": {
+    "short_name": "marcellus pennsylvania",
+    "long_name": "marcellus pennsylvania united states"
+  },
+  "MSH": {
+    "short_name": "mashpee",
+    "long_name": "mashpee massachusetts united states"
+  },
+  "MUG": { "short_name": "mugogo", "long_name": "mugogo rwanda" },
+  "MVY": {
+    "short_name": "marthas vineyard",
+    "long_name": "marthas vineyard massachusetts united states"
+  },
+  "MWO": {
+    "short_name": "mt wilson observatory",
+    "long_name": "mt wilson observatory united states"
+  },
+  "NAT": {
+    "short_name": "farol de mae luiza lighthouse",
+    "long_name": "farol de mae luiza lighthouse brazil"
+  },
+  "NDAO": {
+    "short_name": "namib desert atmospheric observatory",
+    "long_name": "namib desert atmospheric observatory"
+  },
+  "NEB": {
+    "short_name": "ne baltimore",
+    "long_name": "ne baltimore maryland united states"
+  },
+  "NHA": {
+    "short_name": "offshore portsmouth",
+    "long_name": "offshore portsmouth new hampshire isles of shoals united states"
+  },
+  "NMB": { "short_name": "gobabeb", "long_name": "gobabeb namibia" },
+  "NMY": { "short_name": "neumayer", "long_name": "neumayer antarctica" },
+  "NPL": {
+    "short_name": "national physical laboratory",
+    "long_name": "national physical laboratory"
+  },
+  "NWB": {
+    "short_name": "nw baltimore",
+    "long_name": "nw baltimore united states "
+  },
+  "NWF": {
+    "short_name": "niwot ridge forest",
+    "long_name": "niwot ridge forest colorado united states"
+  },
+  "NWR": {
+    "short_name": "niwot ridge",
+    "long_name": "niwot ridge colorado united states"
+  },
+  "NZL": {
+    "short_name": "kaitorete spit",
+    "long_name": "kaitorete spit new zealand"
+  },
+  "OIL": {
+    "short_name": "oglesby",
+    "long_name": "oglesby illinois united states"
+  },
+  "OPE": {
+    "short_name": "observatoire perenne de lenvironnement",
+    "long_name": "observatoire perenne de lenvironnement france"
+  },
+  "OPW": {
+    "short_name": "olympic peninsula",
+    "long_name": "olympic peninsula washington united states"
+  },
+  "ORG": { "short_name": "cape meares", "long_name": "cape meares oregon" },
+  "OXK": { "short_name": "ochsenkopf", "long_name": "ochsenkopf germany" },
+  "PAL": { "short_name": "pallas", "long_name": "pallas finland" },
+  "PAO": {
+    "short_name": "pacificatlantic ocean",
+    "long_name": "pacificatlantic ocean na"
+  },
+  "PCO": { "short_name": "pico", "long_name": "pico azores portugal" },
+  "PFA": {
+    "short_name": "poker flat",
+    "long_name": "poker flat alaska united states"
+  },
+  "POC": { "short_name": "pacific ocean", "long_name": "pacific ocean" },
+  "POCN00": {
+    "short_name": "pacific ocean 0 n",
+    "long_name": "pacific ocean 0 n na"
+  },
+  "POCN05": {
+    "short_name": "pacific ocean 5 n",
+    "long_name": "pacific ocean 5 n na"
+  },
+  "POCN10": {
+    "short_name": "pacific ocean 10 n",
+    "long_name": "pacific ocean 10 n na"
+  },
+  "POCN15": {
+    "short_name": "pacific ocean 15 n",
+    "long_name": "pacific ocean 15 n na"
+  },
+  "POCN20": {
+    "short_name": "pacific ocean 20 n",
+    "long_name": "pacific ocean 20 n na"
+  },
+  "POCN25": {
+    "short_name": "pacific ocean 25 n",
+    "long_name": "pacific ocean 25 n na"
+  },
+  "POCN30": {
+    "short_name": "pacific ocean 30 n",
+    "long_name": "pacific ocean 30 n na"
+  },
+  "POCN35": {
+    "short_name": "pacific ocean 35 n",
+    "long_name": "pacific ocean 35 n na"
+  },
+  "POCN40": {
+    "short_name": "pacific ocean 40 n",
+    "long_name": "pacific ocean 40 n na"
+  },
+  "POCN45": {
+    "short_name": "pacific ocean 45 n",
+    "long_name": "pacific ocean 45 n na"
+  },
+  "POCS05": {
+    "short_name": "pacific ocean 5 s",
+    "long_name": "pacific ocean 5 s na"
+  },
+  "POCS10": {
+    "short_name": "pacific ocean 10 s",
+    "long_name": "pacific ocean 10 s na"
+  },
+  "POCS15": {
+    "short_name": "pacific ocean 15 s",
+    "long_name": "pacific ocean 15 s na"
+  },
+  "POCS20": {
+    "short_name": "pacific ocean 20 s",
+    "long_name": "pacific ocean 20 s na"
+  },
+  "POCS25": {
+    "short_name": "pacific ocean 25 s",
+    "long_name": "pacific ocean 25 s na"
+  },
+  "POCS30": {
+    "short_name": "pacific ocean 30 s",
+    "long_name": "pacific ocean 30 s na"
+  },
+  "POCS35": {
+    "short_name": "pacific ocean 35 s",
+    "long_name": "pacific ocean 35 s na"
+  },
+  "PRS": { "short_name": "plateau rosa", "long_name": "plateau rosa" },
+  "PSA": {
+    "short_name": "palmer station",
+    "long_name": "palmer station antarctica"
+  },
+  "PSM": {
+    "short_name": "point six mountain",
+    "long_name": "point six mountain montana united states"
+  },
+  "PTA": {
+    "short_name": "point arena",
+    "long_name": "point arena california united states"
+  },
+  "RGL": { "short_name": "ridge hill", "long_name": "ridge hill uk" },
+  "RHL": {
+    "short_name": "royal holloway",
+    "long_name": "royal holloway university of london uk"
+  },
+  "RHO": { "short_name": "royal holloway", "long_name": "royal holloway" },
+  "RPB": { "short_name": "ragged point", "long_name": "ragged point barbados" },
+  "RTA": { "short_name": "rarotonga", "long_name": "rarotonga cook islands" },
+  "RWA": { "short_name": "mt mugogo", "long_name": "mt mugogo" },
+  "SAN": { "short_name": "santarem", "long_name": "santarem brazil" },
+  "SCA": {
+    "short_name": "offshore charleston",
+    "long_name": "offshore charleston south carolina united states"
+  },
+  "SCSN03": {
+    "short_name": "south china sea 3 n",
+    "long_name": "south china sea 3 n na"
+  },
+  "SCSN06": {
+    "short_name": "south china sea 6 n",
+    "long_name": "south china sea 6 n na"
+  },
+  "SCSN09": {
+    "short_name": "south china sea 9 n",
+    "long_name": "south china sea 9 n na"
+  },
+  "SCSN12": {
+    "short_name": "south china sea 12 n",
+    "long_name": "south china sea 12 n na"
+  },
+  "SCSN15": {
+    "short_name": "south china sea 15 n",
+    "long_name": "south china sea 15 n na"
+  },
+  "SCSN18": {
+    "short_name": "south china sea 18 n",
+    "long_name": "south china sea 18 n na"
+  },
+  "SCSN21": {
+    "short_name": "south china sea 21 n",
+    "long_name": "south china sea 21 n na"
+  },
+  "SCT": {
+    "short_name": "beech island",
+    "long_name": "beech island south carolina united states"
+  },
+  "SDZ": { "short_name": "shangdianzi", "long_name": "shangdianzi china" },
+  "SEY": { "short_name": "mahe island", "long_name": "mahe island seychelles" },
+  "SGI": {
+    "short_name": "bird island",
+    "long_name": "bird island south georgia united kingdom"
+  },
+  "SGP": {
+    "short_name": "southern great plains",
+    "long_name": "southern great plains oklahoma united states"
+  },
+  "SHM": { "short_name": "shemya island", "long_name": "shemya island alaska" },
+  "SIO": {
+    "short_name": "scripps institue of oceanography",
+    "long_name": "scripps institue of oceanography california"
+  },
+  "SMA": { "short_name": "st marys church", "long_name": "st marys church" },
+  "SMO": {
+    "short_name": "cape matatula",
+    "long_name": "cape matatula american samoa"
+  },
+  "SMR": {
+    "short_name": "smearhyytiala",
+    "long_name": "smearhyytiala finland"
+  },
+  "SNG": { "short_name": "sinhagad", "long_name": "sinhagad india" },
+  "SNP": {
+    "short_name": "shenandoah national park",
+    "long_name": "shenandoah national park united states"
+  },
+  "SPF": {
+    "short_name": "antarctic firn air",
+    "long_name": "antarctic firn air antarctica"
+  },
+  "SPO": { "short_name": "south pole", "long_name": "south pole antarctica" },
+  "SSL": { "short_name": "schauinsland", "long_name": "schauinsland germany" },
+  "STC": {
+    "short_name": "ocean station charlie",
+    "long_name": "ocean station charlie united states"
+  },
+  "STJ": { "short_name": "st judes church", "long_name": "st judes church" },
+  "STM": { "short_name": "ocean station m", "long_name": "ocean station m" },
+  "STR": {
+    "short_name": "sutro",
+    "long_name": "sutro tower san francisco united states"
+  },
+  "SUM": { "short_name": "summit", "long_name": "summit greenland" },
+  "SYO": {
+    "short_name": "syowa station",
+    "long_name": "syowa station antarctica"
+  },
+  "TAC": {
+    "short_name": "tacolneston",
+    "long_name": "tacolneston tower uk"
+  },
+  "TAP": {
+    "short_name": "taeahn peninsula",
+    "long_name": "taeahn peninsula korea"
+  },
+  "TBP": { "short_name": "tambopata", "long_name": "tambopata peru" },
+  "TGC": {
+    "short_name": "offshore corpus christi",
+    "long_name": "offshore corpus christi texas united states"
+  },
+  "THB": {
+    "short_name": "THB Cranfield",
+    "long_name": "THB Cranfield University"
+  },
+  "THD": {
+    "short_name": "trinidad head",
+    "long_name": "trinidad head california"
+  },
+  "TIK": {
+    "short_name": "hydrometeorological observatory of tiksi",
+    "long_name": "hydrometeorological observatory of tiksi russia"
+  },
+  "TIL": { "short_name": "tilney", "long_name": "tilney uk" },
+  "TMB": { "short_name": "thames barrier", "long_name": "thames barrier uk" },
+  "TMD": {
+    "short_name": "thurmont",
+    "long_name": "thurmont maryland united states"
+  },
+  "TOB": { "short_name": "taunus", "long_name": "taunus germany" },
+  "TPD": {
+    "short_name": "turkey point",
+    "long_name": "turkey point ontario canada"
+  },
+  "TPI": {
+    "short_name": "taiping island",
+    "long_name": "taiping island taiwan"
+  },
+  "TRN": { "short_name": "trainou", "long_name": "trainou france" },
+  "TTA": { "short_name": "angus tower", "long_name": "angus tower uk" },
+  "ULB": { "short_name": "ulaanbaatar", "long_name": "ulaanbaatar mongolia" },
+  "UOW": {
+    "short_name": "university of westminster",
+    "long_name": "university of westminster harrow campus"
+  },
+  "USH": { "short_name": "ushaia", "long_name": "ushaia argentina" },
+  "UTA": {
+    "short_name": "wendover",
+    "long_name": "wendover utah united states"
+  },
+  "UUM": { "short_name": "ulaan uul", "long_name": "ulaan uul mongolia" },
+  "WAO": {
+    "short_name": "weybourne observatory",
+    "long_name": "weybourne observatory uk"
+  },
+  "WBI": {
+    "short_name": "west branch",
+    "long_name": "west branch iowa united states"
+  },
+  "WGC": {
+    "short_name": "walnut grove",
+    "long_name": "walnut grove california united states"
+  },
+  "WGF": { "short_name": "woodgreen farm", "long_name": "woodgreen farm" },
+  "WIS": {
+    "short_name": "weizmann institute of science at arva institute",
+    "long_name": "weizmann institute of science at arva institute israel"
+  },
+  "WKT": { "short_name": "moody", "long_name": "moody texas united states" },
+  "WLG": { "short_name": "mt waliguan", "long_name": "mt waliguan china" },
+  "WPC": {
+    "short_name": "western pacific cruise",
+    "long_name": "western pacific cruise na"
+  },
+  "WPCN00": {
+    "short_name": "western pacific cruise 0 n",
+    "long_name": "western pacific cruise 0 n na"
+  },
+  "WPCN05": {
+    "short_name": "western pacific cruise 5 n",
+    "long_name": "western pacific cruise 5 n na"
+  },
+  "WPCN10": {
+    "short_name": "western pacific cruise 10 n",
+    "long_name": "western pacific cruise 10 n na"
+  },
+  "WPCN15": {
+    "short_name": "western pacific cruise 15 n",
+    "long_name": "western pacific cruise 15 n na"
+  },
+  "WPCN20": {
+    "short_name": "western pacific cruise 20 n",
+    "long_name": "western pacific cruise 20 n na"
+  },
+  "WPCN25": {
+    "short_name": "western pacific cruise 25 n",
+    "long_name": "western pacific cruise 25 n na"
+  },
+  "WPCN30": {
+    "short_name": "western pacific cruise 30 n",
+    "long_name": "western pacific cruise 30 n na"
+  },
+  "WPCS05": {
+    "short_name": "western pacific cruise 5 s",
+    "long_name": "western pacific cruise 5 s na"
+  },
+  "WPCS10": {
+    "short_name": "western pacific cruise 10 s",
+    "long_name": "western pacific cruise 10 s na"
+  },
+  "WPCS15": {
+    "short_name": "western pacific cruise 15 s",
+    "long_name": "western pacific cruise 15 s na"
+  },
+  "WPCS20": {
+    "short_name": "western pacific cruise 20 s",
+    "long_name": "western pacific cruise 20 s na"
+  },
+  "WPCS25": {
+    "short_name": "western pacific cruise 25 s",
+    "long_name": "western pacific cruise 25 s na"
+  },
+  "WPCS30": {
+    "short_name": "western pacific cruise 30 s",
+    "long_name": "western pacific cruise 30 s na"
+  },
+  "WSA": {
+    "short_name": "sable island",
+    "long_name": "sable island nova scotia canada"
+  },
+  "ZEP": { "short_name": "zeppelin", "long_name": "zeppelin ny alesund norway" }
+}

--- a/openghg/standardise/surface/_crds.py
+++ b/openghg/standardise/surface/_crds.py
@@ -28,17 +28,12 @@ def parse_crds(
     """
     from pathlib import Path
     from openghg.standardise.meta import assign_attributes
-    from openghg.util import verify_site
 
     if not isinstance(data_filepath, Path):
         data_filepath = Path(data_filepath)
 
-    # This verifies that the site code is correct, or if a site name is given, returns the correct site
-    # code if we find one.
-    site = verify_site(site=site)
-
     # This may seem like an almost pointless function as this is all we do
-    # but it makes it a lot easier to test that assign_attributes
+    # but it makes it a lot easier to test assign_attributes
     gas_data = _read_data(
         data_filepath=data_filepath,
         site=site,
@@ -83,6 +78,7 @@ def _read_data(
     from openghg.util import clean_string
 
     split_fname = data_filepath.stem.split(".")
+    site = site.lower()
 
     try:
         site_fname = clean_string(split_fname[0])

--- a/openghg/standardise/surface/_crds.py
+++ b/openghg/standardise/surface/_crds.py
@@ -28,9 +28,14 @@ def parse_crds(
     """
     from pathlib import Path
     from openghg.standardise.meta import assign_attributes
+    from openghg.util import verify_site
 
     if not isinstance(data_filepath, Path):
         data_filepath = Path(data_filepath)
+
+    # This verifies that the site code is correct, or if a site name is given, returns the correct site
+    # code if we find one.
+    site = verify_site(site=site)
 
     # This may seem like an almost pointless function as this is all we do
     # but it makes it a lot easier to test that assign_attributes
@@ -75,7 +80,7 @@ def _read_data(
     from datetime import datetime
     from pandas import RangeIndex, read_csv, NaT
     import warnings
-    from openghg.util import clean_string, valid_site
+    from openghg.util import clean_string
 
     split_fname = data_filepath.stem.split(".")
 
@@ -86,11 +91,6 @@ def _read_data(
         raise ValueError(
             "Error reading metadata from filename, we expect a form hfd.picarro.1minute.100m.dat"
         )
-
-    site = site.lower()
-
-    if not valid_site:
-        raise ValueError(f"{site} is not a valid site.")
 
     if site_fname != site:
         raise ValueError("Site mismatch between passed site code and that read from filename.")

--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -73,7 +73,7 @@ def parse_gcwerks(
     """
     from pathlib import Path
     from openghg.standardise.meta import assign_attributes
-    from openghg.util import verify_site, clean_string, load_json
+    from openghg.util import clean_string, load_json
 
     data_filepath = Path(data_filepath)
     precision_filepath = Path(precision_filepath)
@@ -91,7 +91,7 @@ def parse_gcwerks(
     if instrument is not None:
         instrument = clean_string(instrument)
 
-    site = verify_site(site=site)
+    # site = verify_site(site=site)
 
     # Check if the site code passed matches that read from the filename
     site = _check_site(

--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -73,7 +73,7 @@ def parse_gcwerks(
     """
     from pathlib import Path
     from openghg.standardise.meta import assign_attributes
-    from openghg.util import valid_site, clean_string, load_json
+    from openghg.util import verify_site, clean_string, load_json
 
     data_filepath = Path(data_filepath)
     precision_filepath = Path(precision_filepath)
@@ -83,7 +83,6 @@ def parse_gcwerks(
     gcwerks_data = load_json(filename="process_gcwerks_parameters.json")
     gc_params = gcwerks_data["GCWERKS"]
 
-    site = clean_string(site)
     network = clean_string(network)
     # We don't currently do anything with inlet here as it's always read from data
     # or taken from process_gcwerks_parameters.json
@@ -92,8 +91,7 @@ def parse_gcwerks(
     if instrument is not None:
         instrument = clean_string(instrument)
 
-    if not valid_site(site):
-        raise ValueError(f"Invalid site {site} passed.")
+    site = verify_site(site=site)
 
     # Check if the site code passed matches that read from the filename
     site = _check_site(

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -48,7 +48,7 @@ class ObsSurface(BaseStore):
         from pandas import Timedelta
         import sys
         from tqdm import tqdm
-        from openghg.util import load_surface_parser, hash_file, clean_string
+        from openghg.util import load_surface_parser, hash_file, clean_string, verify_site
         from openghg.types import SurfaceTypes
         from openghg.store import assign_data
 
@@ -63,7 +63,8 @@ class ObsSurface(BaseStore):
         # Test that the passed values are valid
         # Check validity of site, instrument, inlet etc in acrg_site_info.json
         # Clean the strings
-        site = clean_string(site)
+        site = verify_site(site=site)
+
         network = clean_string(network)
         inlet = clean_string(inlet)
         instrument = clean_string(instrument)

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -4,7 +4,7 @@
 
 from ._util import (
     unanimous,
-    valid_site,
+    verify_site,
     pairwise,
     multiple_inlets,
     running_in_cloud

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -11,7 +11,7 @@ from ._util import (
 )
 
 from ._hashing import hash_string, hash_file
-from ._strings import clean_string, to_lowercase
+from ._strings import clean_string, to_lowercase, remove_punctuation
 
 from ._time import (
     timestamp_tzaware,

--- a/openghg/util/_strings.py
+++ b/openghg/util/_strings.py
@@ -98,3 +98,18 @@ def is_number(s: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def remove_punctuation(s: str) -> str:
+    """Removes punctuation and converts the passed string
+    to lowercase
+
+    Args:
+        s: String to convert
+    Returns:
+        str: Unpunctuated, lowercased string
+    """
+    import re
+
+    s = s.lower()
+    return re.sub(r"[^\w\s]", "", s)

--- a/openghg/util/_util.py
+++ b/openghg/util/_util.py
@@ -65,50 +65,66 @@ def pairwise(iterable: Iterable) -> Iterator[Tuple[str, str]]:
     return zip(a, b)
 
 
-def find_matching_site(site_name: str) -> str:
-    """Try and find the matching site code for a given site name
+def find_matching_site(site_name: str, possible_sites: Dict) -> str:
+    """Try and find a similar name to site_name in site_list and return a suggestion or
+    error string.
 
     Args:
         site_name: Name of site
+        site_list: List of sites to check
     Returns:
-        str: Site code
+        str: Suggestion / error message
     """
     from rapidfuzz import process
-    from openghg.util import load_json, InvalidSiteError
 
-    name_code_lookup: Dict[str, str] = load_json(filename="name_code_lookup.json")
+    site_list = possible_sites.keys()
 
-    matches = process.extract(site_name, name_code_lookup.keys())
+    matches = process.extract(site_name, site_list)
+
     scores = [s for m, s, _ in matches]
 
     # This seems like a decent cutoff score for a decent find
     cutoff_score = 85
 
-    if scores[0] == scores[1] or scores[0] < cutoff_score:
-        raise InvalidSiteError(f"No definite match for {site_name}.")
-
-    best_match = matches[0][0]
-
-    return name_code_lookup[best_match]
+    if scores[0] < cutoff_score:
+        return f"No suggestion for {site_name}."
+    elif scores[0] > cutoff_score and scores[0] > scores[1]:
+        best_match = matches[0][0]
+        return f"Did you mean {best_match.title()}, code: {possible_sites[best_match]} ?"
+    elif scores[0] == scores[1]:
+        suggestions = [f"{match.title()}, code: {possible_sites[match]}" for match, _, _ in matches]
+        nl_char = "\n"
+        return f"Did you mean one of : \n {nl_char.join(suggestions)}"
+    else:
+        return f"Unknown site: {site_name}"
 
 
 def verify_site(site: str) -> str:
-    """Check if the passed site is a valid one
+    """Check if the passed site is a valid one and returns the three
+    letter site code if found. Otherwise we use fuzzy text matching to suggest
+    sites with similar names.
 
     Args:
-        site: Three letter site code
+        site: Three letter site code or site name
     Returns:
-        bool: True if site is valid
+        str: Verified three letter site code if valid site
     """
-    from openghg.util import load_json
+    from openghg.util import load_json, remove_punctuation, InvalidSiteError
 
-    site_data = load_json("acrg_site_info.json")
+    site_data = load_json("site_lookup.json")
 
     if site.upper() in site_data:
         return site.lower()
     else:
-        site_code = find_matching_site(site_name=site)
-        return site_code.lower()
+        site = remove_punctuation(site)
+        name_lookup: Dict[str, str] = {value["short_name"]: code for code, value in site_data.items()}
+
+        try:
+            return name_lookup[site].lower()
+        except KeyError:
+            long_names = {value["long_name"]: code for code, value in site_data.items()}
+            message = find_matching_site(site_name=site, possible_sites=long_names)
+            raise InvalidSiteError(message)
 
 
 def multiple_inlets(site: str) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Acquire @ git+https://github.com/openghg/acquire@devel#egg=Acquire
 addict
 cdsapi
 dask
-# cfchecker @ git+git://github.com/gareth-j/cf-checker@removeBasestring#egg=cfchecker
 lazy_import
 matplotlib
 netcdf4
@@ -12,6 +11,7 @@ nc-time-axis
 pandas
 paramiko
 pyvis
+rapidfuzz
 requests >= 2.25
 scipy
 tqdm

--- a/tests/standardise/surface/test_crds.py
+++ b/tests/standardise/surface/test_crds.py
@@ -13,7 +13,7 @@ from helpers import get_datapath, parsed_surface_metachecker
 def test_read_file():
     hfd_filepath = get_datapath(filename="hfd.picarro.1minute.100m.min.dat", data_type="CRDS")
 
-    gas_data = parse_crds(data_filepath=hfd_filepath, site="heathfield", network="DECC")
+    gas_data = parse_crds(data_filepath=hfd_filepath, site="hfd", network="DECC")
 
     ch4_data = gas_data["ch4"]["data"]
     co2_data = gas_data["co2"]["data"]

--- a/tests/standardise/surface/test_crds.py
+++ b/tests/standardise/surface/test_crds.py
@@ -13,7 +13,7 @@ from helpers import get_datapath, parsed_surface_metachecker
 def test_read_file():
     hfd_filepath = get_datapath(filename="hfd.picarro.1minute.100m.min.dat", data_type="CRDS")
 
-    gas_data = parse_crds(data_filepath=hfd_filepath, site="hfd", network="DECC")
+    gas_data = parse_crds(data_filepath=hfd_filepath, site="heathfield", network="DECC")
 
     ch4_data = gas_data["ch4"]["data"]
     co2_data = gas_data["co2"]["data"]

--- a/tests/standardise/surface/test_gcwerks.py
+++ b/tests/standardise/surface/test_gcwerks.py
@@ -36,7 +36,7 @@ def test_read_file_capegrim(cgo_path, cgo_prec_path):
     gas_data = parse_gcwerks(
         data_filepath=cgo_path,
         precision_filepath=cgo_prec_path,
-        site="cape grim",
+        site="cgo",
         instrument="medusa",
         network="agage",
     )

--- a/tests/standardise/surface/test_gcwerks.py
+++ b/tests/standardise/surface/test_gcwerks.py
@@ -36,7 +36,7 @@ def test_read_file_capegrim(cgo_path, cgo_prec_path):
     gas_data = parse_gcwerks(
         data_filepath=cgo_path,
         precision_filepath=cgo_prec_path,
-        site="CGO",
+        site="cape grim",
         instrument="medusa",
         network="agage",
     )

--- a/tests/standardise/surface/test_gcwerks.py
+++ b/tests/standardise/surface/test_gcwerks.py
@@ -1,6 +1,4 @@
-from ast import parse
 import logging
-from pathlib import Path
 import pandas as pd
 import pytest
 
@@ -33,8 +31,8 @@ def cgo_data():
     cgo_prec = get_datapath(filename="capegrim-medusa.18.precisions.C", data_type="GC")
 
     gas_data = parse_gcwerks(
-        data_filepath=cgo_path,
-        precision_filepath=cgo_prec_path,
+        data_filepath=cgo_data,
+        precision_filepath=cgo_prec,
         site="cgo",
         instrument="medusa",
         network="agage",

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from openghg import util
+from openghg.util import InvalidSiteError
 
 
 def test_read_header():
@@ -25,19 +26,24 @@ def test_verify_site():
 
     assert result == "tac"
 
+    site = "tacolneston"
+    result = util.verify_site(site=site)
+
+    assert result == "tac"
+
     site = "atlantis"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidSiteError):
         result = util.verify_site(site=site)
 
     site = "cape"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidSiteError):
         result = util.verify_site(site=site)
 
     site = "india"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidSiteError):
         result = util.verify_site(site=site)
 
 

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from openghg import util
 
 
@@ -13,21 +14,31 @@ def test_read_header():
     assert len(header) == 7
 
 
-def test_valid_site():
+def test_verify_site():
     site = "BSD"
-    result = util.valid_site(site=site)
+    result = util.verify_site(site=site)
 
-    assert result is True
+    assert result == "bsd"
 
     site = "tac"
-    result = util.valid_site(site=site)
+    result = util.verify_site(site=site)
 
-    assert result is True
+    assert result == "tac"
 
-    site = "Dover"
-    result = util.valid_site(site=site)
+    site = "atlantis"
 
-    assert result is False
+    with pytest.raises(ValueError):
+        result = util.verify_site(site=site)
+
+    site = "cape"
+
+    with pytest.raises(ValueError):
+        result = util.verify_site(site=site)
+
+    site = "india"
+
+    with pytest.raises(ValueError):
+        result = util.verify_site(site=site)
 
 
 def test_to_lowercase():


### PR DESCRIPTION
This allows the passing of names like `cape grim` instead of `CGO` and `angus tower` instead of `TTA`. Slightly mis-spelt words should also be matched as `rapidfuzz` has been used for some simple fuzzy text matching. This should close #204.