### PR TITLE
Fix for FutureWarning error in Datasource

### DIFF
--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -279,11 +279,11 @@ class Datasource:
             tuple (Timestamp, Timestamp): Start and end datetimes for DataSet
 
         """
-        from pandas import Timestamp
+        from openghg.util import timestamp_tzaware
 
         try:
-            start = Timestamp(dataset.time[0].values, tz="UTC")
-            end = Timestamp(dataset.time[-1].values, tz="UTC")
+            start = timestamp_tzaware(dataset.time[0].values)
+            end = timestamp_tzaware(dataset.time[-1].values)
 
             return start, end
         except AttributeError:

--- a/tests/store/test_datasource.py
+++ b/tests/store/test_datasource.py
@@ -72,8 +72,6 @@ def test_add_data(data):
 
     assert combined.equals(ch4_data)
 
-    print("d.metadata()", d.metadata())
-
     expected_metadata = {
         "site": "bsd",
         "instrument": "picarro",


### PR DESCRIPTION
This fixes the warning when finding dataset dateranges, closes #228.