### PR TITLE
Date parsing speedup

### DIFF
--- a/openghg/standardise/surface/_crds.py
+++ b/openghg/standardise/surface/_crds.py
@@ -72,8 +72,7 @@ def _read_data(
     Returns:
         dict: Dictionary of gas data
     """
-    from datetime import datetime
-    from pandas import RangeIndex, read_csv, NaT, to_datetime
+    from pandas import RangeIndex, read_csv, to_datetime
     import warnings
     from openghg.util import clean_string
 

--- a/openghg/standardise/surface/_crds.py
+++ b/openghg/standardise/surface/_crds.py
@@ -73,7 +73,7 @@ def _read_data(
         dict: Dictionary of gas data
     """
     from datetime import datetime
-    from pandas import RangeIndex, read_csv, NaT
+    from pandas import RangeIndex, read_csv, NaT, to_datetime
     import warnings
     from openghg.util import clean_string
 
@@ -99,13 +99,6 @@ def _read_data(
     else:
         inlet = inlet_fname
 
-    # Function to parse the datetime format found in the datafile
-    def parse_date(date: str):  # type: ignore
-        try:
-            return datetime.strptime(date, "%y%m%d %H%M%S")
-        except ValueError:
-            return NaT
-
     # Catch dtype warnings
     # TODO - look at setting dtypes - read header and data separately?
     with warnings.catch_warnings():
@@ -115,12 +108,9 @@ def _read_data(
             header=None,
             skiprows=1,
             sep=r"\s+",
-            index_col=["0_1"],
-            parse_dates=[[0, 1]],
-            date_parser=parse_date,
+            parse_dates={"time": [0, 1]},
+            index_col="time",
         )
-
-    data.index.name = "time"
 
     # Drop any rows with NaNs
     # This is now done before creating metadata
@@ -179,6 +169,7 @@ def _read_data(
         header_rows = 2
         # Drop the first two rows now we have the name
         gas_data = gas_data.drop(index=gas_data.head(header_rows).index, inplace=False)
+        gas_data.index = to_datetime(gas_data.index, format="%y%m%d %H%M%S")
         # Cast data to float64 / double
         gas_data = gas_data.astype("float64")
 

--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -218,7 +218,7 @@ def _read_data(
         dict: Dictionary of gas data keyed by species
     """
     from datetime import datetime
-    from pandas import read_csv
+    from pandas import read_csv, to_datetime
     from pandas import Timedelta as pd_Timedelta
     import warnings
 
@@ -232,13 +232,14 @@ def _read_data(
     # Read the data in and automatically create a datetime column from the 5 columns
     # Dropping the yyyy', 'mm', 'dd', 'hh', 'mi' columns here
     data = read_csv(
-        data_filepath,
+        gc_data,
         skiprows=4,
         sep=r"\s+",
         index_col=["yyyy_mm_dd_hh_mi"],
-        parse_dates=[[1, 2, 3, 4, 5]],
-        date_parser=parser,
+        parse_dates=[[1, 2, 3, 4, 5]]        
     )
+
+    data.index = to_datetime(data.index, format="%Y %m %d %H %M")
 
     if data.empty:
         raise ValueError("Cannot process empty file.")

--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -232,7 +232,7 @@ def _read_data(
     # Read the data in and automatically create a datetime column from the 5 columns
     # Dropping the yyyy', 'mm', 'dd', 'hh', 'mi' columns here
     data = read_csv(
-        gc_data,
+        data_filepath,
         skiprows=4,
         sep=r"\s+",
         index_col=["yyyy_mm_dd_hh_mi"],


### PR DESCRIPTION
Whilst doing some profiling to look at the fragmented dataframe warning (#111) I found that the time parsing for GCWERKS and CRDS data was very slow. I've made some small changes to speed things up a bit.

The main change was removing the use of `date_parser` and doing pd.to_datetime(index) instead.