### PR TITLE
Updating NetCDF output arguments

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -79,7 +79,7 @@ jobs:
           pip install -r requirements-doc.txt
       - name: Ensure notebooks can be executed correctly
         run: |
-          jupytext --sync --execute notebooks/tutorials/beginner_workflow/{1,2,3}_*.ipynb
+          jupytext --sync --execute notebooks/tutorials/beginner_workflow/{1,2}_*.ipynb
       - name: Build documentation
         run: |
           cd doc

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
-      max-parallel: 4
+      max-parallel: 8
       fail-fast: false
       matrix:
-        operating-system: [ubuntu-latest]
+        operating-system: [ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - name: Checkout

--- a/doc/source/api/api_plotting.rst
+++ b/doc/source/api/api_plotting.rst
@@ -3,5 +3,12 @@ Plotting functions
 
 These functions help in the creation of simple plots.
 
+You can plot multiple timeseries using the ``plot_timeseries`` function. This expects
+an ObsData object or a list of objects. By default it will try and find the species in the
+metadata stored within the object and plot that. You can modify the variables you'd like to plot
+using the `x_var` and `y_var` arguments. You can also make changes to the title and axes labels.
+
 .. autofunction:: openghg.plotting.plot_footprint
-    
+
+.. autofunction:: openghg.plotting.plot_timeseries
+

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -51,7 +51,7 @@ Here change ``/path/to/env`` with your own path.
 
 Next install OpenGHG
 
-.. cocde-block:: bash
+.. code-block:: bash
 
     pip install openghg
 

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -456,7 +456,7 @@ class Datasource:
                 # or work on a PR for xarray to allow returning a NetCDF as bytes
                 with tempfile.TemporaryDirectory() as tmpdir:
                     filepath = f"{tmpdir}/temp.nc"
-                    data.to_netcdf(filepath, format="NETCDF4", engine="h5netcdf")
+                    data.to_netcdf(filepath)
                     set_object_from_file(bucket=bucket, key=data_key, filename=filepath)
 
             # Copy the last version

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -456,7 +456,7 @@ class Datasource:
                 # or work on a PR for xarray to allow returning a NetCDF as bytes
                 with tempfile.TemporaryDirectory() as tmpdir:
                     filepath = f"{tmpdir}/temp.nc"
-                    data.to_netcdf(filepath)
+                    data.to_netcdf(filepath, format="NETCDF4", engine="h5netcdf")
                     set_object_from_file(bucket=bucket, key=data_key, filename=filepath)
 
             # Copy the last version

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ addict
 cdsapi
 dask
 lazy_import
+h5netcdf
+h5py
 matplotlib
 netcdf4
 numexpr


### PR DESCRIPTION
I encountered a strange error on macOS which resulted in lots of errors. I've added passing the netcdf type and netcdf output engine to the `to_netcdf` command in Datasource.