### PR TITLE
Updating FluxData and FootprintData to remove additional inputs

### DIFF
--- a/openghg/analyse/_footprint.py
+++ b/openghg/analyse/_footprint.py
@@ -245,12 +245,7 @@ def footprints_data_merge(
 
     return FootprintData(
         data=combined_dataset,
-        metadata={},
-        flux=flux_dict,
-        bc={},
-        species=species,
-        scales="scale",
-        units="units",
+        metadata={}
     )
 
 

--- a/openghg/dataobjects/_flux_data.py
+++ b/openghg/dataobjects/_flux_data.py
@@ -8,27 +8,14 @@ __all__ = ["FluxData"]
 
 @dataclass(frozen=True)
 class FluxData(_BaseData):
-    """This class is used to return observations data from the get_flux function
+    """This class is used to return flux/emissions data from the get_flux function
 
     Args:
         data: xarray Dataframe
         metadata: Dictionary of metadata including model run parameters
-        flux: Dictionary of flux data
-        bc: Boundary conditions dictionary
-        species: Species name
-        scales: Measurements scale
-        units: Measurements units
     """
-
-    flux: Dict
-    bc: Dict
-    species: str
-    scales: str
-    units: str
 
     def __str__(self) -> str:
         return (
             f"Data: {self.data}\nMetadata : {self.metadata}"
-            f"\nFlux : {self.flux}\nBC: {self.bc}"
-            f"\nSpecies : {self.species}\nScales: {self.scales}\nUnits: {self.units}"
         )

--- a/openghg/dataobjects/_footprint_data.py
+++ b/openghg/dataobjects/_footprint_data.py
@@ -20,15 +20,7 @@ class FootprintData(_BaseData):
         units: Measurements units
     """
 
-    flux: Dict
-    bc: Dict
-    species: str
-    scales: str
-    units: str
-
     def __str__(self) -> str:
         return (
             f"Data: {self.data}\nMetadata : {self.metadata}"
-            f"\nFlux : {self.flux}\nBC: {self.bc}"
-            f"\nSpecies : {self.species}\nScales: {self.scales}\nUnits: {self.units}"
         )

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -303,15 +303,7 @@ def get_flux(
     if species is None:
         species = metadata.get("species", "NA")
 
-    return FluxData(
-        data=em_ds,
-        metadata=metadata,
-        flux={},
-        bc={},
-        species=species,
-        scales="FIXME",
-        units="FIXME",
-    )
+    return FluxData(data=em_ds, metadata=metadata)
 
 
 def get_bc(
@@ -453,18 +445,11 @@ def get_footprint(
     # fp_ds = recombine_datasets(keys=keys, sort=False) # Why did this have sort=False before?
     fp_ds = recombine_datasets(keys=keys, sort=True)
 
-    if species is None:
-        species = metadata.get("species", "NA")
+    # TODO: Could incorporate this somewhere? Setting species to INERT?
+    # if species is None:
+    #     species = metadata.get("species", "INERT")
 
-    return FootprintData(
-        data=fp_ds,
-        metadata=metadata,
-        flux={},
-        bc={},
-        species=species,
-        scales="FIXME",
-        units="FIXME",
-    )
+    return FootprintData(data=fp_ds, metadata=metadata)
 
 
 def _synonyms(species: str) -> str:

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -537,15 +537,7 @@ def footprint_dummy():
     # - data_type="footprints"
     metadata = {"site": "TESTSITE", "height": "10m", "domain": "TESTDOMAIN", "data_type": "footprints"}
 
-    footprintdata = FootprintData(
-        data=data,
-        metadata=metadata,
-        flux={},
-        bc={},
-        species="INERT",
-        scales="",
-        units="",
-    )
+    footprintdata = FootprintData(data=data, metadata=metadata)
 
     return footprintdata
 
@@ -582,15 +574,7 @@ def flux_ch4_dummy():
     species = "ch4"
     metadata = {"species": species, "source": "TESTSOURCE", "domain": "TESTDOMAIN"}
 
-    fluxdata = FluxData(
-        data=flux,
-        metadata=metadata,
-        flux={},
-        bc={},
-        species=species,
-        scales="",
-        units="",
-    )
+    fluxdata = FluxData(data=flux, metadata=metadata)
 
     return fluxdata
 
@@ -866,15 +850,7 @@ def footprint_co2_dummy():
         "species": species,
     }
 
-    footprintdata = FootprintData(
-        data=data,
-        metadata=metadata,
-        species=species,
-        flux={},
-        bc={},
-        scales="",
-        units="",
-    )
+    footprintdata = FootprintData(data=data, metadata=metadata)
 
     return footprintdata
 
@@ -913,15 +889,7 @@ def flux_co2_dummy():
     species = "co2"
     metadata = {"species": species, "source": "TESTSOURCE", "domain": "TESTDOMAIN"}
 
-    fluxdata = FluxData(
-        data=flux,
-        metadata=metadata,
-        flux={},
-        bc={},
-        species=species,
-        scales="",
-        units="",
-    )
+    fluxdata = FluxData(data=flux, metadata=metadata)
 
     return fluxdata
 
@@ -1073,15 +1041,7 @@ def footprint_radon_dummy(footprint_dummy):
 
     footprint_ds = footprint_ds.assign(data_vars)
 
-    footprintdata = FootprintData(
-        data=footprint_ds,
-        metadata=footprint_metadata,
-        flux={},
-        bc={},
-        species=species,
-        scales="",
-        units="",
-    )
+    footprintdata = FootprintData(data=footprint_ds, metadata=footprint_metadata)
 
     return footprintdata
 


### PR DESCRIPTION
For the `FluxData` and `FootprintData` objects these had additional inputs which weren't being used e.g. in `get_flux` these were being set to:

 - flux={}
 - bc={}
 - species=species
 - scales="FIXME"
 - units="FIXME"

These extra inputs have now been removed.

Closes #251
Closes #252