### PR TITLE
Fix for cloud shortcut, improve ICOS and CEDA retrieval.

### DIFF
--- a/openghg/analyse/__init__.py
+++ b/openghg/analyse/__init__.py
@@ -1,8 +1,8 @@
-from ._footprint import single_site_footprint, footprints_data_merge
+from ._footprint import footprints_data_merge, single_site_footprint
 from ._scenario import (
     ModelScenario,
-    combine_datasets,
-    stack_datasets,
     calc_dim_resolution,
+    combine_datasets,
     match_dataset_dims,
+    stack_datasets,
 )

--- a/openghg/analyse/_footprint.py
+++ b/openghg/analyse/_footprint.py
@@ -2,10 +2,11 @@
 This hopes to recreate the functionality of the ACRG repo function
 footprints_data_merge
 """
-from pandas import Timestamp
-from xarray import Dataset, DataArray
-from typing import Optional, Tuple, Union, Dict, Any, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
+
 from openghg.dataobjects import FootprintData, ObsData
+from pandas import Timestamp
+from xarray import DataArray, Dataset
 
 # from openghg.dataobjects import FluxData
 
@@ -47,7 +48,7 @@ def single_site_footprint(
     Returns:
         xarray.Dataset
     """
-    from openghg.retrieve import get_obs_surface, get_footprint
+    from openghg.retrieve import get_footprint, get_obs_surface
     from openghg.util import timestamp_tzaware
 
     start_date = timestamp_tzaware(start_date)
@@ -554,11 +555,12 @@ def timeseries_HiTRes(
      TODO: mypy having trouble with different types options and incompatible types,
      included as Any for now.
     """
-    import numpy as np
-    import dask.array as da  # type: ignore
-    from tqdm import tqdm
-    from pandas import date_range
     from math import gcd
+
+    import dask.array as da  # type: ignore
+    import numpy as np
+    from pandas import date_range
+    from tqdm import tqdm
 
     fp_HiTRes = combined_dataset.fp_HiTRes
 

--- a/openghg/cloud/__init__.py
+++ b/openghg/cloud/__init__.py
@@ -1,3 +1,4 @@
 __all__ = ["call_function", "create_file_package", "create_post_dict"]
 
 from ._call import call_function, create_file_package, create_post_dict
+from ._packaging import package_from_function, unpackage

--- a/openghg/cloud/_call.py
+++ b/openghg/cloud/_call.py
@@ -92,49 +92,49 @@ def call_function(data: Dict) -> Dict:
     Returns:
         dict: Dictionary containing response status, headers and content.
     """
-    hub = running_on_hub()
-    cloud = running_in_cloud()
+    # hub = running_on_hub()
+    # cloud = running_in_cloud()
 
-    if hub and cloud:
-        raise ValueError("We can't be running in the cloud and on the hub at the same time.")
+    # if hub and cloud:
+    #     raise ValueError("We can't be running in the cloud and on the hub at the same time.")
 
     # If we're running on the OpenGHG Hub we need to make a call to
     # the serverless functions
-    if hub:
-        # First lookup the function URL
-        fn_url = _get_function_url()
-        auth_key = _get_auth_key()
+    # if hub:
+    # First lookup the function URL
+    fn_url = _get_function_url()
+    auth_key = _get_auth_key()
 
-        headers = {}
-        headers["Content-Type"] = "application/octet-stream"
-        headers["authorization"] = auth_key
+    headers = {}
+    headers["Content-Type"] = "application/octet-stream"
+    headers["authorization"] = auth_key
 
-        packed_data = msgpack.packb(data)
-        response = requests.post(url=fn_url, data=packed_data, headers=headers)
+    packed_data = msgpack.packb(data)
+    response = requests.post(url=fn_url, data=packed_data, headers=headers)
 
-        if response.status_code != 200:
-            raise FunctionError(f"Function call error: {str(response.content)}")
+    if response.status_code != 200:
+        raise FunctionError(f"Function call error: {str(response.content)}")
 
-        return {
-            "status": response.status_code,
-            "headers": dict(headers),
-            "content": msgpack.unpackb(response.content),
-        }
+    return {
+        "status": response.status_code,
+        "headers": dict(headers),
+        "content": msgpack.unpackb(response.content),
+    }
     # Otherwise if one of the functions has made a call that's been passed here
     # and we're running within a serverless function already we can just route that
     # data to the function requested.
-    elif cloud:
-        try:
-            # openghg/functions
-            from functions import route_local  # type: ignore
+    # elif cloud:
+    #     try:
+    #         # openghg/functions
+    #         from functions import route_local  # type: ignore
 
-            response = route_local(data=data)
-        except Exception:
-            raise FunctionError(f"Cannot pass to routing function - {str(traceback.format_exc())}")
+    #         response = route_local(data=data)
+    #     except Exception:
+    #         raise FunctionError(f"Cannot pass to routing function - {str(traceback.format_exc())}")
 
-        return {"status": 200, "headers": {}, "content": response}
-    else:
-        raise ValueError("Neither hub nor cloud, check environment.")
+    #     return {"status": 200, "headers": {}, "content": response}
+    # else:
+    #     raise ValueError("Neither hub nor cloud, check environment.")
 
 
 def _get_function_url() -> str:

--- a/openghg/cloud/_packaging.py
+++ b/openghg/cloud/_packaging.py
@@ -1,0 +1,81 @@
+from collections import defaultdict
+from typing import DefaultDict, Dict, Optional
+
+from openghg.util import (
+    compress,
+    compress_json,
+    compress_str,
+    decompress,
+    decompress_json,
+    hash_bytes,
+)
+
+
+def unpackage(data: Dict) -> Dict:
+    """Unpackages and checks a dictionary created by the package_from_function function.
+    This checks the SHA1 sums and decompresses the data.
+
+    Args:
+        data: Dictionary
+    Returns:
+        dict: Dictionary containing data and metadata if given
+    """
+    unpacked = {}
+
+    file_metadata = data["file_metadata"]
+    remote_sum = file_metadata["data"]["sha1_hash"]
+
+    decompressed_data = decompress(data=data["data"])
+    local_sum = hash_bytes(data=decompressed_data)
+
+    unpacked["data"] = decompressed_data
+
+    if not remote_sum == local_sum:
+        raise ValueError(f"Hash mismatch, remote {remote_sum} - local {local_sum}.")
+
+    try:
+        compressed_metadata = data["metadata"]
+    except KeyError:
+        pass
+    else:
+        unpacked["metadata"] = decompress_json(data=compressed_metadata)
+
+    return unpacked
+
+
+def package_from_function(data: bytes, metadata: Optional[str] = None) -> Dict:
+    """Creates a package of data ready to be sent back to the caller.
+    This calculates the SHA1 sum of the passed data and compresses it.
+    If metadata is passed this is added to the returned dictionary. No SHA1
+    is calculated for the metadata.
+
+    NOTE: This function should only be used internally by a serverless function.
+
+    Args:
+        data: Binary data
+        metadata: Result of json.dumps
+    Returns:
+        dict: Dictionary of compressed data and file metadata.
+    """
+    sha1_hash = hash_bytes(data=data)
+    compressed_data = compress(data=data)
+    compression_type = "bz2"
+
+    packaged: DefaultDict = defaultdict(dict)
+    packaged["found"] = True
+    packaged["data"] = compressed_data
+    packaged["file_metadata"]["data"] = {"sha1_hash": sha1_hash, "compression_type": compression_type}
+
+    if metadata is not None:
+        try:
+            compressed_metadata = compress_str(s=metadata)
+        except AttributeError:
+            try:
+                compressed_metadata = compress_json(data=metadata)
+            except Exception as e:
+                raise TypeError(f"Unable to process this object: {e}")
+
+        packaged["metadata"] = compressed_metadata
+        packaged["file_metadata"]["metadata"] = {"sha1_hash": False, "compression_type": compression_type}
+
+    return dict(packaged)

--- a/openghg/dataobjects/__init__.py
+++ b/openghg/dataobjects/__init__.py
@@ -1,6 +1,6 @@
 from ._basedata import _BaseData
-from ._flux_data import FluxData
 from ._bc_data import BoundaryConditionsData
+from ._flux_data import FluxData
 from ._footprint_data import FootprintData
 from ._metdata import METData
 from ._obsdata import ObsData

--- a/openghg/dataobjects/_basedata.py
+++ b/openghg/dataobjects/_basedata.py
@@ -2,8 +2,9 @@
 This is used as a base for the other dataclasses and shouldn't be used directly.
 """
 from dataclasses import dataclass
-from xarray import Dataset
 from typing import Dict
+
+from xarray import Dataset
 
 
 @dataclass(frozen=True)

--- a/openghg/dataobjects/_metdata.py
+++ b/openghg/dataobjects/_metdata.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from xarray import Dataset
 from typing import Dict
+
+from xarray import Dataset
 
 
 @dataclass(frozen=True)

--- a/openghg/dataobjects/_obsdata.py
+++ b/openghg/dataobjects/_obsdata.py
@@ -1,10 +1,12 @@
-from dataclasses import dataclass
 from collections import abc
-from typing import Any, Dict, Iterator, Union
+from dataclasses import dataclass
 from json import dumps
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import Any, Dict, Iterator, Union
+
 import plotly.graph_objects as go
+
 from ._basedata import _BaseData
 
 __all__ = ["ObsData"]

--- a/openghg/dataobjects/_searchresults.py
+++ b/openghg/dataobjects/_searchresults.py
@@ -10,7 +10,7 @@ from openghg.util import (
     create_daterange_str,
     find_daterange_gaps,
     first_last_dates,
-    running_locally,
+    running_on_hub,
     split_daterange_str,
 )
 from xarray import Dataset, open_dataset
@@ -32,7 +32,7 @@ class SearchResults:
     def __init__(self, results: Optional[Dict] = None, ranked_data: bool = False):
         self.results = results if results is not None else {}
         self.ranked_data = ranked_data
-        self.cloud = not running_locally()
+        self.hub = running_on_hub()
 
     def __str__(self) -> str:
         if not self.results:
@@ -73,7 +73,7 @@ class SearchResults:
         return {
             "results": self.results,
             "ranked_data": self.ranked_data,
-            "cloud": self.cloud,
+            "cloud": self.hub,
         }
 
     def to_json(self) -> str:
@@ -393,7 +393,7 @@ class SearchResults:
         """
         from openghg.cloud import call_function
 
-        if self.cloud:
+        if self.hub:
             to_post: Dict[str, Union[Dict, List, bool, str]] = {}
             to_post["keys"] = keys
             to_post["sort"] = sort

--- a/openghg/jobs/__init__.py
+++ b/openghg/jobs/__init__.py
@@ -1,4 +1,4 @@
-from ._sshconnect import SSHConnect
 from ._create import JobCreator
 from ._jobdrive import JobDrive
 from ._run import run_job
+from ._sshconnect import SSHConnect

--- a/openghg/objectstore/__init__.py
+++ b/openghg/objectstore/__init__.py
@@ -3,6 +3,7 @@ from openghg.util import running_locally
 cloud_env = not running_locally()
 
 if cloud_env:
+    print("\n\n\nImporting cloud functions.")
     from ._oci_store import (
         create_bucket,
         create_par,

--- a/openghg/objectstore/__init__.py
+++ b/openghg/objectstore/__init__.py
@@ -3,7 +3,6 @@ from openghg.util import running_locally
 cloud_env = not running_locally()
 
 if cloud_env:
-    print("\n\n\nImporting cloud functions.")
     from ._oci_store import (
         create_bucket,
         create_par,

--- a/openghg/objectstore/_encoding.py
+++ b/openghg/objectstore/_encoding.py
@@ -1,5 +1,5 @@
-import datetime
 import base64
+import datetime
 
 
 def datetime_to_datetime(d: datetime.datetime) -> datetime.datetime:

--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -1,12 +1,13 @@
 import glob
 import json
 import os
-from pathlib import Path
 import threading
-from openghg.types import ObjectStoreError
-import pyvis
-from uuid import uuid4
+from pathlib import Path
 from typing import Dict, List, Optional, Union
+from uuid import uuid4
+
+import pyvis
+from openghg.types import ObjectStoreError
 
 rlock = threading.RLock()
 
@@ -253,8 +254,8 @@ def query_store() -> Dict:
     Returns:
         dict: Dictionary for data to be shown in force graph
     """
-    from openghg.store.base import Datasource
     from openghg.store import ObsSurface
+    from openghg.store.base import Datasource
 
     obs = ObsSurface.load()
 

--- a/openghg/objectstore/_oci_store.py
+++ b/openghg/objectstore/_oci_store.py
@@ -1,11 +1,12 @@
-from typing import Dict, List, Optional, Union
+import json
+from functools import lru_cache
 from io import BytesIO
 from pathlib import Path
+from typing import Dict, List, Optional, Union
+
 from oci.object_storage import ObjectStorageClient
 from oci.response import Response
-from functools import lru_cache
 from openghg.types import ObjectStoreError
-import json
 
 
 def _clean_key(key: str) -> str:
@@ -40,10 +41,11 @@ def _load_config() -> Dict:
     Returns:
         dict: Config as dictionary
     """
-    from json import loads
     import os
-    from cryptography.fernet import Fernet
+    from json import loads
     from pathlib import Path
+
+    from cryptography.fernet import Fernet
     from oci.config import validate_config
     from openghg.objectstore import string_to_bytes
 
@@ -307,10 +309,11 @@ def create_par(
     Returns:
         PAR: OpenGHG wrapper of OSPar
     """
-    from oci.object_storage.models import CreatePreauthenticatedRequestDetails
     from datetime import timedelta
     from uuid import uuid4
-    from openghg.objectstore import get_datetime_now, PAR
+
+    from oci.object_storage.models import CreatePreauthenticatedRequestDetails
+    from openghg.objectstore import PAR, get_datetime_now
 
     oci_config = _load_config()
     object_storage = _load_client()

--- a/openghg/objectstore/_par.py
+++ b/openghg/objectstore/_par.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import json
+from datetime import datetime
 from typing import Optional, TypeVar
 
 PAR_TYPE = TypeVar("PAR_TYPE", bound="PAR")

--- a/openghg/plotting/_footprint.py
+++ b/openghg/plotting/_footprint.py
@@ -14,8 +14,8 @@ def plot_footprint(data: Dataset, label: str = None, vmin: float = None, vmax: f
     Returns:
         None
     """
-    import matplotlib.pyplot as plt
     import matplotlib.colors as colors
+    import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots()
 

--- a/openghg/plotting/_timeseries.py
+++ b/openghg/plotting/_timeseries.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Union
-from openghg.dataobjects import ObsData
+
 import plotly.graph_objects as go
+from openghg.dataobjects import ObsData
 
 
 def plot_timeseries(

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from typing import Dict, List, Optional, Union
 
 from openghg.dataobjects import BoundaryConditionsData, FluxData, FootprintData, ObsData
-from openghg.util import decompress, decompress_str, hash_bytes, running_locally, running_on_hub
+from openghg.util import decompress, decompress_str, hash_bytes, running_on_hub
 from pandas import Timestamp
 from xarray import Dataset, load_dataset
 
@@ -42,7 +42,7 @@ def get_obs_surface(
     """
     from openghg.cloud import call_function
 
-    if not running_locally():
+    if running_on_hub():
         to_post: Dict[str, Union[str, Dict]] = {}
 
         to_post["function"] = "get_obs_surface"

--- a/openghg/retrieve/_export.py
+++ b/openghg/retrieve/_export.py
@@ -30,8 +30,9 @@ def get_ceda_file(  # type: ignore
 
     """
     import json
-    import yaml
     from pathlib import Path
+
+    import yaml
     from openghg.util import get_datapath
 
     if filepath:

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -6,7 +6,7 @@
 from typing import Any, Dict, List, Optional, Union, cast
 
 from openghg.dataobjects import SearchResults
-from openghg.util import decompress, running_locally
+from openghg.util import decompress, running_on_hub
 from tinydb.database import TinyDB
 
 
@@ -136,7 +136,7 @@ def search(**kwargs: Any) -> Union[SearchResults, Dict]:
     """
     from openghg.cloud import call_function
 
-    if not running_locally():
+    if running_on_hub():
         post_data: Dict[str, Union[str, Dict]] = {}
         post_data["function"] = "search"
         post_data["search_terms"] = kwargs

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -139,7 +139,7 @@ def search(**kwargs: Any) -> Union[SearchResults, Dict]:
     if not running_locally():
         post_data: Dict[str, Union[str, Dict]] = {}
         post_data["function"] = "search"
-        post_data["data"] = kwargs
+        post_data["search_terms"] = kwargs
 
         result = call_function(data=post_data)
 

--- a/openghg/retrieve/ceda/_retrieve.py
+++ b/openghg/retrieve/ceda/_retrieve.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from openghg.dataobjects import ObsData
-from openghg.util import running_locally
+from openghg.util import running_on_hub
 
 
 def retrieve_surface(
@@ -73,7 +73,7 @@ def retrieve(**kwargs: Any) -> Union[List[ObsData], ObsData, None]:
     from openghg.cloud import call_function, unpackage
     from xarray import load_dataset
 
-    if not running_locally():
+    if running_on_hub():
         post_data: Dict[str, Union[str, Dict]] = {}
         post_data["function"] = "retrieve_ceda"
         post_data["arguments"] = kwargs

--- a/openghg/retrieve/ceda/_retrieve.py
+++ b/openghg/retrieve/ceda/_retrieve.py
@@ -10,7 +10,7 @@ def retrieve_surface(
     url: Optional[str] = None,
     force_retrieval: bool = False,
     additional_metadata: Optional[Dict] = None,
-) -> Union[ObsData, List[ObsData], None]:
+) -> ObsData:
     """Retrieve surface observations data from the CEDA archive. You can pass
     search terms and the object store will be searched. To retrieve data from th
     CEDA Archive please browse the website (https://data.ceda.ac.uk/badc) to find

--- a/openghg/retrieve/ceda/_retrieve.py
+++ b/openghg/retrieve/ceda/_retrieve.py
@@ -1,6 +1,7 @@
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from openghg.dataobjects import ObsData
+from openghg.util import running_locally
 
 
 def retrieve_surface(
@@ -11,8 +12,110 @@ def retrieve_surface(
     force_retrieval: bool = False,
     additional_metadata: Optional[Dict] = None,
 ) -> ObsData:
+    """Retrieve surface measurements from the CEDA archive. This function will route the call
+    to either local or cloud functions based on the environment.
+
+    Args:
+        site: Site name
+        species: Species name
+        inlet: Inlet height
+        url: URL of data in CEDA archive
+        force_retrieval: Force the retrieval of data from a URL
+        additional_metadata: Additional metadata to pass if the returned data
+        doesn't contain everythging we need. At the moment we try and find site and inlet
+        keys if they aren't found in the dataset's attributes.
+        For example:
+            {"site": "AAA", "inlet": "10m"}
+    Returns:
+        ObsData or None: ObsData if data found / retrieved successfully.
+
+    Example:
+        To retrieve new data from the CEDA archive using a URL
+        >>> retrieve_surface(url=https://dap.ceda.ac.uk/badc/...)
+        To retrieve already cached data from the object store
+        >>> retrieve_surface(site="BSD", species="ch4)
+
+    """
+    return retrieve(
+        site=site,
+        species=species,
+        inlet=inlet,
+        url=url,
+        force_retrieval=force_retrieval,
+        additional_metadata=additional_metadata,
+    )
+
+
+def retrieve(**kwargs: Any) -> ObsData:
+    """Retrieve surface from the CEDA Archive. This function
+    should not be used directly and is called by the retrieve_* functions,
+    such as retrieve_surface, that retrieve specific data from the archive.
+
+    To retrieve data from the CEDA Archive please browse the
+    website (https://data.ceda.ac.uk/badc) to find the URL of the dataset to retrieve.
+
+    Args:
+        site: Site name
+        species: Species name
+        inlet: Inlet height
+        url: URL of data in CEDA archive
+        force_retrieval: Force the retrieval of data from a URL
+        additional_metadata: Additional metadata to pass if the returned data
+        doesn't contain everythging we need. At the moment we try and find site and inlet
+        keys if they aren't found in the dataset's attributes.
+        For example:
+            {"site": "AAA", "inlet": "10m"}
+    Returns:
+        ObsData or None: ObsData if data found / retrieved successfully.
+    """
+    from io import BytesIO
+
+    from openghg.cloud import call_function, unpackage
+    from xarray import load_dataset
+
+    if not running_locally():
+        post_data: Dict[str, Union[str, Dict]] = {}
+        post_data["function"] = "retrieve_ceda"
+        post_data["arguments"] = kwargs
+
+        call_result = call_function(data=post_data)
+
+        content = call_result["content"]
+        found = content["found"]
+
+        if not found:
+            return None
+
+        observations = content["data"]
+
+        obs_data = []
+        for package in observations.values():
+            unpackaged = unpackage(data=package)
+            buf = BytesIO(unpackaged["data"])
+            ds = load_dataset(buf)
+            obs = ObsData(data=ds, metadata=unpackaged["metadata"])
+
+            obs_data.append(obs)
+
+        if len(obs_data) == 1:
+            return obs_data[0]
+        else:
+            return obs_data
+    else:
+        return local_retrieve_surface(**kwargs)
+
+
+def local_retrieve_surface(
+    site: Optional[str] = None,
+    species: Optional[str] = None,
+    inlet: Optional[str] = None,
+    url: Optional[str] = None,
+    force_retrieval: bool = False,
+    additional_metadata: Optional[Dict] = None,
+    **kwargs,
+) -> ObsData:
     """Retrieve surface observations data from the CEDA archive. You can pass
-    search terms and the object store will be searched. To retrieve data from th
+    search terms and the object store will be searched. To retrieve data from the
     CEDA Archive please browse the website (https://data.ceda.ac.uk/badc) to find
     the URL of the dataset to retrieve.
 
@@ -29,6 +132,12 @@ def retrieve_surface(
             {"site": "AAA", "inlet": "10m"}
     Returns:
         ObsData or None: ObsData if data found / retrieved successfully.
+
+    Example:
+        To retrieve new data from the CEDA archive using a URL
+        >>> retrieve_surface(url=https://dap.ceda.ac.uk/badc/...)
+        To retrieve already cached data from the object store
+        >>> retrieve_surface(site="BSD", species="ch4)
     """
     import io
 

--- a/openghg/retrieve/ceda/_retrieve.py
+++ b/openghg/retrieve/ceda/_retrieve.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from openghg.dataobjects import ObsData
 from openghg.util import running_locally
@@ -11,7 +11,7 @@ def retrieve_surface(
     url: Optional[str] = None,
     force_retrieval: bool = False,
     additional_metadata: Optional[Dict] = None,
-) -> ObsData:
+) -> Union[List[ObsData], ObsData, None]:
     """Retrieve surface measurements from the CEDA archive. This function will route the call
     to either local or cloud functions based on the environment.
 
@@ -46,7 +46,7 @@ def retrieve_surface(
     )
 
 
-def retrieve(**kwargs: Any) -> ObsData:
+def retrieve(**kwargs: Any) -> Union[List[ObsData], ObsData, None]:
     """Retrieve surface from the CEDA Archive. This function
     should not be used directly and is called by the retrieve_* functions,
     such as retrieve_surface, that retrieve specific data from the archive.
@@ -112,8 +112,8 @@ def local_retrieve_surface(
     url: Optional[str] = None,
     force_retrieval: bool = False,
     additional_metadata: Optional[Dict] = None,
-    **kwargs,
-) -> ObsData:
+    **kwargs: Any,
+) -> Union[List[ObsData], ObsData, None]:
     """Retrieve surface observations data from the CEDA archive. You can pass
     search terms and the object store will be searched. To retrieve data from the
     CEDA Archive please browse the website (https://data.ceda.ac.uk/badc) to find

--- a/openghg/retrieve/icos/__init__.py
+++ b/openghg/retrieve/icos/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["retrieve"]
 
-from ._retrieve import retrieve
+from ._retrieve import retrieve_atmospheric

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from openghg.dataobjects import ObsData
-from openghg.util import running_locally
+from openghg.util import running_on_hub
 
 
 def retrieve_atmospheric(
@@ -30,6 +30,8 @@ def retrieve_atmospheric(
                         to be distributed through the Carbon Portal.
                         This level is the ICOS-data product and free available for users.
         See https://icos-carbon-portal.github.io/pylib/modules/#stationdatalevelnone
+        bypass_call: Bypass the remote function call, used to shortcut calls within a the serverless
+        function call environment.
     Returns:
         ObsData, list[ObsData] or None
     """
@@ -48,7 +50,6 @@ def retrieve(**kwargs: Any) -> Union[ObsData, List[ObsData], None]:
     """Retrieve data from the ICOS Carbon Portal. If data is found in the local object store
     it will be retrieved from there first.
 
-
     This function detects the running environment and routes the call
     to either the cloud or local search function.
 
@@ -66,6 +67,8 @@ def retrieve(**kwargs: Any) -> Union[ObsData, List[ObsData], None]:
                         to be distributed through the Carbon Portal.
                         This level is the ICOS-data product and free available for users.
         See https://icos-carbon-portal.github.io/pylib/modules/#stationdatalevelnone
+        bypass_call: Bypass the remote function call, used to shortcut calls within a the serverless
+        function call environment.
     Returns:
         ObsData, list[ObsData] or None
     """
@@ -74,7 +77,8 @@ def retrieve(**kwargs: Any) -> Union[ObsData, List[ObsData], None]:
     from openghg.cloud import call_function, unpackage
     from xarray import load_dataset
 
-    if not running_locally():
+    # The hub is the only place we want to make remote calls
+    if running_on_hub():
         post_data: Dict[str, Union[str, Dict]] = {}
         post_data["function"] = "retrieve_icos"
         post_data["search_terms"] = kwargs

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -114,7 +114,7 @@ def local_retrieve(
     end_date: Optional[str] = None,
     force_retrieval: bool = False,
     data_level: int = 2,
-    **kwargs,
+    **kwargs: Any,
 ) -> Union[ObsData, List[ObsData], None]:
     """Retrieve ICOS atmospheric measurement data. If data is found in the object store it is returned. Otherwise
     data will be retrieved from the ICOS Carbon Portal. Data retrieval from the Carbon Portal may take a short time.

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -33,7 +33,7 @@ def retrieve_atmospheric(
     Returns:
         ObsData, list[ObsData] or None
     """
-    results = retrieve(
+    return retrieve(
         site=site,
         species=species,
         sampling_height=sampling_height,
@@ -42,8 +42,6 @@ def retrieve_atmospheric(
         force_retrieval=force_retrieval,
         data_level=data_level,
     )
-
-    return results
 
 
 def retrieve(**kwargs: Any) -> Union[ObsData, List[ObsData], None]:
@@ -105,10 +103,10 @@ def retrieve(**kwargs: Any) -> Union[ObsData, List[ObsData], None]:
         else:
             return obs_data
     else:
-        return retrieve_local(**kwargs)
+        return local_retrieve(**kwargs)
 
 
-def retrieve_local(
+def local_retrieve(
     site: str,
     species: Optional[Union[str, List]] = None,
     sampling_height: Optional[str] = None,
@@ -116,6 +114,7 @@ def retrieve_local(
     end_date: Optional[str] = None,
     force_retrieval: bool = False,
     data_level: int = 2,
+    **kwargs,
 ) -> Union[ObsData, List[ObsData], None]:
     """Retrieve ICOS atmospheric measurement data. If data is found in the object store it is returned. Otherwise
     data will be retrieved from the ICOS Carbon Portal. Data retrieval from the Carbon Portal may take a short time.

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -12,7 +12,7 @@ def retrieve_atmospheric(
     end_date: Optional[str] = None,
     force_retrieval: bool = False,
     data_level: int = 2,
-):
+) -> Union[ObsData, List[ObsData], None]:
     """Retrieve ICOS atmospheric measurement data. If data is found in the object store it is returned. Otherwise
     data will be retrieved from the ICOS Carbon Portal. Data retrieval from the Carbon Portal may take a short time.
     If only a single data source is found an ObsData object is returned, if multiple a list of ObsData objects
@@ -46,7 +46,7 @@ def retrieve_atmospheric(
     return results
 
 
-def retrieve(**kwargs) -> Union[ObsData, List[ObsData], None]:
+def retrieve(**kwargs: Any) -> Union[ObsData, List[ObsData], None]:
     """Retrieve data from the ICOS Carbon Portal. If data is found in the local object store
     it will be retrieved from there first.
 
@@ -74,7 +74,7 @@ def retrieve(**kwargs) -> Union[ObsData, List[ObsData], None]:
     from io import BytesIO
 
     from openghg.cloud import call_function, unpackage
-    from xarray import open_dataset
+    from xarray import load_dataset
 
     if not running_locally():
         post_data: Dict[str, Union[str, Dict]] = {}
@@ -93,10 +93,10 @@ def retrieve(**kwargs) -> Union[ObsData, List[ObsData], None]:
 
         obs_data = []
         for package in observations.values():
-            binary_data, metadata = unpackage(data=package)
-            buf = BytesIO(binary_data)
-            ds = open_dataset(buf).load()
-            obs = ObsData(data=ds, metadata=metadata)
+            unpackaged = unpackage(data=package)
+            buf = BytesIO(unpackaged["data"])
+            ds = load_dataset(buf)
+            obs = ObsData(data=ds, metadata=unpackaged["metadata"])
 
             obs_data.append(obs)
 

--- a/openghg/retrieve/met/_ecmwf.py
+++ b/openghg/retrieve/met/_ecmwf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 # import cdsapi  # type: ignore
 # import numpy as np
-from typing import TYPE_CHECKING, List, Union, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
 
 # import requests
 # from xarray import open_dataset, Dataset

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 from openghg.cloud import create_file_package, create_post_dict
-from openghg.util import running_locally
+from openghg.util import running_on_hub
 
 
 def standardise_surface(
@@ -34,7 +34,7 @@ def standardise_surface(
     if not isinstance(filepaths, list):
         filepaths = [filepaths]
 
-    if not running_locally():
+    if running_on_hub():
         # To convert bytes to megabytes
         MB = 1e6
         # The largest file we'll just directly POST to the standardisation
@@ -151,7 +151,7 @@ def standardise_bc(
 
     filepath = Path(filepath)
 
-    if not running_locally():
+    if running_on_hub():
         compressed_data, file_metadata = create_file_package(filepath=filepath, obs_type="bc")
 
         metadata = {
@@ -223,7 +223,7 @@ def standardise_footprint(
 
     filepath = Path(filepath)
 
-    if not running_locally():
+    if running_on_hub():
         compressed_data, file_metadata = create_file_package(filepath=filepath, obs_type="footprints")
 
         metadata = {
@@ -305,7 +305,7 @@ def standardise_flux(
 
     filepath = Path(filepath)
 
-    if not running_locally():
+    if running_on_hub():
         compressed_data, file_metadata = create_file_package(filepath=filepath, obs_type="flux")
 
         metadata = {

--- a/openghg/standardise/_summarise.py
+++ b/openghg/standardise/_summarise.py
@@ -1,4 +1,5 @@
 from typing import Dict
+
 import pandas as pd
 from openghg.types import SurfaceTypes
 

--- a/openghg/standardise/emissions/_openghg.py
+++ b/openghg/standardise/emissions/_openghg.py
@@ -20,10 +20,10 @@ def parse_openghg(
     Returns:
         dict: Dictionary of data
     """
-    from xarray import open_dataset
-    from openghg.util import timestamp_now
-    from openghg.store import infer_date_range
     from openghg.standardise.meta import assign_flux_attributes
+    from openghg.store import infer_date_range
+    from openghg.util import timestamp_now
+    from xarray import open_dataset
 
     em_data = open_dataset(filepath)
 

--- a/openghg/standardise/surface/__init__.py
+++ b/openghg/standardise/surface/__init__.py
@@ -10,5 +10,5 @@ from ._glasgow_picarro import parse_glasow_picarro
 from ._icos import parse_icos
 from ._noaa import parse_noaa
 from ._npl import parse_npl
-from ._thamesbarrier import parse_tmb
 from ._openghg import parse_openghg
+from ._thamesbarrier import parse_tmb

--- a/openghg/standardise/surface/_aqmesh.py
+++ b/openghg/standardise/surface/_aqmesh.py
@@ -1,6 +1,5 @@
-from typing import Dict, Union, Optional
 from pathlib import Path
-
+from typing import Dict, Optional, Union
 
 pathType = Union[str, Path]
 
@@ -82,8 +81,8 @@ def _parse_metadata(filepath: pathType) -> Dict:
         dict: Dictionary of metadata
     """
     from addict import Dict as aDict
-    from pandas import read_csv
     from openghg.util import check_date
+    from pandas import read_csv
 
     filepath = Path(filepath)
     raw_metadata = read_csv(filepath)

--- a/openghg/standardise/surface/_beaco2n.py
+++ b/openghg/standardise/surface/_beaco2n.py
@@ -1,5 +1,6 @@
-from typing import DefaultDict, Dict, Optional, Union
 from pathlib import Path
+from typing import DefaultDict, Dict, Optional, Union
+
 from pandas import DataFrame
 
 __all__ = ["parse_beaco2n"]
@@ -26,10 +27,10 @@ def parse_beaco2n(
     Returns:
         dict: Dictionary of data
     """
-    import pandas as pd
-    from openghg.util import load_json
     from collections import defaultdict
-    from openghg.util import clean_string
+
+    import pandas as pd
+    from openghg.util import clean_string, load_json
 
     if sampling_period is None:
         sampling_period = "NOT_SET"

--- a/openghg/standardise/surface/_btt.py
+++ b/openghg/standardise/surface/_btt.py
@@ -1,5 +1,5 @@
-from typing import Dict, Optional, Union
 from pathlib import Path
+from typing import Dict, Optional, Union
 
 
 def parse_btt(
@@ -18,10 +18,10 @@ def parse_btt(
     Returns:
         dict: Dictionary of gas data
     """
-    from openghg.standardise.meta import assign_attributes
-    from pandas import read_csv, Timestamp, to_timedelta, isnull
     from numpy import nan as np_nan
+    from openghg.standardise.meta import assign_attributes
     from openghg.util import clean_string, load_json
+    from pandas import Timestamp, isnull, read_csv, to_timedelta
 
     # TODO: Decide what to do about inputs which aren't use anywhere
     # at present - inlet, instrument, sampling_period, measurement_type

--- a/openghg/standardise/surface/_cranfield.py
+++ b/openghg/standardise/surface/_cranfield.py
@@ -1,5 +1,5 @@
-from typing import Dict, List, Optional, Union
 from pathlib import Path
+from typing import Dict, List, Optional, Union
 
 
 def parse_cranfield(
@@ -21,8 +21,8 @@ def parse_cranfield(
     Returns:
         dict: Dictionary of gas data
     """
-    from pandas import read_csv
     from openghg.util import clean_string
+    from pandas import read_csv
 
     if sampling_period is None:
         sampling_period = "NOT_SET"

--- a/openghg/standardise/surface/_crds.py
+++ b/openghg/standardise/surface/_crds.py
@@ -1,7 +1,8 @@
-from openghg.util import load_json
-from pandas import DataFrame, Timedelta
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
+
+from openghg.util import load_json
+from pandas import DataFrame, Timedelta
 
 
 def parse_crds(
@@ -30,6 +31,7 @@ def parse_crds(
         dict: Dictionary of gas data
     """
     from pathlib import Path
+
     from openghg.standardise.meta import assign_attributes
 
     if not isinstance(data_filepath, Path):
@@ -78,9 +80,10 @@ def _read_data(
     Returns:
         dict: Dictionary of gas data
     """
-    from pandas import RangeIndex, read_csv, to_datetime
     import warnings
+
     from openghg.util import clean_string, find_duplicate_timestamps
+    from pandas import RangeIndex, read_csv, to_datetime
 
     split_fname = data_filepath.stem.split(".")
     site = site.lower()

--- a/openghg/standardise/surface/_eurocom.py
+++ b/openghg/standardise/surface/_eurocom.py
@@ -1,5 +1,5 @@
-from typing import Dict, Optional, Union
 from pathlib import Path
+from typing import Dict, Optional, Union
 
 
 def parse_eurocom(
@@ -23,8 +23,8 @@ def parse_eurocom(
         dict: Dictionary of measurement data
     """
     from openghg.standardise.meta import assign_attributes, get_attributes
-    from pandas import read_csv, Timestamp
-    from openghg.util import read_header, load_json
+    from openghg.util import load_json, read_header
+    from pandas import Timestamp, read_csv
 
     data_filepath = Path(data_filepath)
 

--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -1,5 +1,6 @@
-from typing import Dict, List, Optional, Union, Tuple
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
 from pandas import DataFrame
 
 
@@ -72,6 +73,7 @@ def parse_gcwerks(
         dict: Dictionary of source_name : UUIDs
     """
     from pathlib import Path
+
     from openghg.standardise.meta import assign_attributes
     from openghg.util import clean_string, load_json
 
@@ -217,8 +219,9 @@ def _read_data(
     Returns:
         dict: Dictionary of gas data keyed by species
     """
-    from pandas import read_csv, to_datetime, Series
+    from pandas import Series
     from pandas import Timedelta as pd_Timedelta
+    from pandas import read_csv, to_datetime
 
     # Read header
     header = read_csv(data_filepath, skiprows=2, nrows=2, header=None, sep=r"\s+")
@@ -340,8 +343,9 @@ def _read_precision(filepath: Path) -> Tuple[DataFrame, List]:
         tuple (Pandas.DataFrame, list): Precision DataFrame and list of species in
         precision data
     """
-    from pandas import read_csv
     from datetime import datetime
+
+    from pandas import read_csv
 
     # Function for parsing datetime
     def prec_date_parser(date: str) -> datetime:
@@ -393,8 +397,9 @@ def _split_species(
     Returns:
         dict: Dataframe of gas data and metadata
     """
-    from addict import Dict as aDict
     from fnmatch import fnmatch
+
+    from addict import Dict as aDict
     from openghg.standardise.meta import define_species_label
 
     # Read inlets from the parameters

--- a/openghg/standardise/surface/_glasgow_licor.py
+++ b/openghg/standardise/surface/_glasgow_licor.py
@@ -1,7 +1,8 @@
-from pandas import read_csv, to_datetime
 from pathlib import Path
 from typing import Dict, Optional
+
 from addict import Dict as aDict
+from pandas import read_csv, to_datetime
 
 
 def parse_glasow_licor(filepath: Path, sampling_period: Optional[str] = None, **kwargs: Dict) -> Dict:

--- a/openghg/standardise/surface/_glasgow_picarro.py
+++ b/openghg/standardise/surface/_glasgow_picarro.py
@@ -1,7 +1,8 @@
-import pandas as pd
-from typing import Dict, Union, Optional
 from pathlib import Path
+from typing import Dict, Optional, Union
 from warnings import warn
+
+import pandas as pd
 from addict import Dict as aDict
 
 

--- a/openghg/standardise/surface/_icos.py
+++ b/openghg/standardise/surface/_icos.py
@@ -1,5 +1,5 @@
-from typing import Dict, Optional, Union
 from pathlib import Path
+from typing import Dict, Optional, Union
 
 
 def parse_icos(
@@ -28,6 +28,7 @@ def parse_icos(
         dict: Dictionary of gas data
     """
     from pathlib import Path
+
     from openghg.standardise.meta import assign_attributes
     from openghg.util import clean_string
 
@@ -90,8 +91,8 @@ def _read_data_large_header(
     Returns:
         dict: Dictionary of gas data
     """
-    from pandas import read_csv, to_datetime
     from openghg.util import read_header
+    from pandas import read_csv, to_datetime
 
     # Read metadata from the filename and cross check to make sure the passed
     # arguments match
@@ -262,8 +263,8 @@ def _read_data_small_header(
     Returns:
         dict: Dictionary of gas data
     """
-    from pandas import read_csv, Timestamp
     from openghg.util import read_header
+    from pandas import Timestamp, read_csv
 
     # Read some metadata from the filename
     split_filename = data_filepath.name.split(".")

--- a/openghg/standardise/surface/_noaa.py
+++ b/openghg/standardise/surface/_noaa.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Any, Dict, Hashable, Optional, Union, cast
+
 import numpy as np
 import xarray as xr
 

--- a/openghg/standardise/surface/_npl.py
+++ b/openghg/standardise/surface/_npl.py
@@ -1,10 +1,11 @@
-from openghg.types import pathType
-from typing import Dict
-from pandas import read_csv, NaT
 from datetime import datetime
-from openghg.util import clean_string, load_json
-from openghg.standardise.meta import assign_attributes
 from pathlib import Path
+from typing import Dict
+
+from openghg.standardise.meta import assign_attributes
+from openghg.types import pathType
+from openghg.util import clean_string, load_json
+from pandas import NaT, read_csv
 
 
 def parse_npl(

--- a/openghg/standardise/surface/_openghg.py
+++ b/openghg/standardise/surface/_openghg.py
@@ -1,5 +1,6 @@
-from typing import Union, Optional, Dict, cast
 from pathlib import Path
+from typing import Dict, Optional, Union, cast
+
 import xarray as xr
 
 
@@ -46,8 +47,8 @@ def parse_openghg(
     Returns:
         Dict : Dictionary of source_name : data, metadata, attributes
     """
+    from openghg.standardise.meta import assign_attributes, metadata_default_keys
     from openghg.util import clean_string, load_json, synonyms
-    from openghg.standardise.meta import metadata_default_keys, assign_attributes
 
     data_filepath = Path(data_filepath)
 

--- a/openghg/standardise/surface/_thamesbarrier.py
+++ b/openghg/standardise/surface/_thamesbarrier.py
@@ -1,5 +1,6 @@
-from typing import Dict, Optional
 from pathlib import Path
+from typing import Dict, Optional
+
 from openghg.types import pathType
 
 
@@ -22,8 +23,8 @@ def parse_tmb(
         list: UUIDs of Datasources data has been assigned to
     """
     from openghg.standardise.meta import assign_attributes
-    from pandas import read_csv as pd_read_csv
     from openghg.util import clean_string, load_json
+    from pandas import read_csv as pd_read_csv
 
     if sampling_period is None:
         sampling_period = "NOT_SET"

--- a/openghg/store/_data_schema.py
+++ b/openghg/store/_data_schema.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
-from typing import Optional, Dict, List, Tuple
-from xarray import Dataset
+from typing import Dict, List, Optional, Tuple
+
 import numpy as np
+from xarray import Dataset
 
 __all__ = ["DataSchema"]
 

--- a/openghg/store/_emissions.py
+++ b/openghg/store/_emissions.py
@@ -1,11 +1,12 @@
 from pathlib import Path
-from typing import Dict, Optional, Union, Tuple, Any
-from xarray import Dataset, DataArray
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, Optional, Tuple, Union
+
 import numpy as np
 from numpy import ndarray
-from tempfile import TemporaryDirectory
 from openghg.store import DataSchema
 from openghg.store.base import BaseStore
+from xarray import DataArray, Dataset
 
 __all__ = ["Emissions"]
 
@@ -77,13 +78,9 @@ class Emissions(BaseStore):
         Returns:
             dict: Dictionary of datasource UUIDs data assigned to
         """
-        from openghg.store import assign_data, load_metastore, datasource_lookup
+        from openghg.store import assign_data, datasource_lookup, load_metastore
         from openghg.types import EmissionsTypes
-        from openghg.util import (
-            clean_string,
-            hash_file,
-            load_emissions_parser,
-        )
+        from openghg.util import clean_string, hash_file, load_emissions_parser
 
         species = clean_string(species)
         source = clean_string(source)
@@ -179,7 +176,8 @@ class Emissions(BaseStore):
         TODO: Could allow Callable[..., Dataset] type for a pre-defined function be passed
         """
         import inspect
-        from openghg.store import assign_data, load_metastore, datasource_lookup
+
+        from openghg.store import assign_data, datasource_lookup, load_metastore
         from openghg.types import EmissionsDatabases
         from openghg.util import load_emissions_database_parser
 

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -1,6 +1,7 @@
-from openghg.store.base import BaseStore
 from pathlib import Path
 from typing import DefaultDict, Dict, Optional, Union
+
+from openghg.store.base import BaseStore
 from xarray import Dataset
 
 __all__ = ["EulerianModel"]
@@ -46,15 +47,11 @@ class EulerianModel(BaseStore):
         # May need to split out into multiple modules (like with ObsSurface) or into separate retrieve functions as needed.
 
         from collections import defaultdict
-        from openghg.util import (
-            clean_string,
-            hash_file,
-            timestamp_now,
-            timestamp_tzaware,
-        )
-        from openghg.store import assign_data, load_metastore, datasource_lookup
-        from xarray import open_dataset
+
+        from openghg.store import assign_data, datasource_lookup, load_metastore
+        from openghg.util import clean_string, hash_file, timestamp_now, timestamp_tzaware
         from pandas import Timestamp as pd_Timestamp
+        from xarray import open_dataset
 
         model = clean_string(model)
         species = clean_string(species)

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -1,13 +1,13 @@
-from typing import DefaultDict, Dict, List, Optional, Union, NoReturn, Tuple
+from collections import defaultdict
 from pathlib import Path
-from pandas import Timestamp
-from xarray import Dataset
-import numpy as np
+from tempfile import TemporaryDirectory
+from typing import DefaultDict, Dict, List, NoReturn, Optional, Tuple, Union
 
+import numpy as np
 from openghg.store import DataSchema
 from openghg.store.base import BaseStore
-from collections import defaultdict
-from tempfile import TemporaryDirectory
+from pandas import Timestamp
+from xarray import Dataset
 
 __all__ = ["Footprints"]
 
@@ -223,14 +223,9 @@ class Footprints(BaseStore):
         Returns:
             dict: UUIDs of Datasources data has been assigned to
         """
+        from openghg.store import assign_data, datasource_lookup, infer_date_range, load_metastore
+        from openghg.util import clean_string, hash_file, species_lifetime, timestamp_now
         from xarray import open_dataset
-        from openghg.util import (
-            hash_file,
-            timestamp_now,
-            clean_string,
-            species_lifetime,
-        )
-        from openghg.store import assign_data, infer_date_range, load_metastore, datasource_lookup
 
         filepath = Path(filepath)
 

--- a/openghg/store/_infer_time.py
+++ b/openghg/store/_infer_time.py
@@ -1,15 +1,11 @@
-from typing import Optional, Union, Tuple
-from pathlib import Path
 import re
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
 import pandas as pd
+from openghg.util import create_frequency_str, parse_period, relative_time_offset, timestamp_tzaware
 from pandas import DateOffset, Timedelta, Timestamp
 from xarray import DataArray
-from openghg.util import (
-    timestamp_tzaware,
-    parse_period,
-    create_frequency_str,
-    relative_time_offset,
-)
 
 TupleTimeType = Tuple[Union[int, float], str]
 

--- a/openghg/store/_metstore.py
+++ b/openghg/store/_metstore.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Union
+
 from openghg.store.base import BaseStore
 from pandas import Timestamp
-from typing import TYPE_CHECKING, List, Union
 
 if TYPE_CHECKING:
     from openghg.dataobjects import METData
@@ -88,8 +90,8 @@ class METStore(BaseStore):
         Returns:
             METData or None: METData object if found else None
         """
-        from openghg.store.base import Datasource
         from openghg.dataobjects import METData
+        from openghg.store.base import Datasource
 
         datasources = (Datasource.load(uuid=uuid, shallow=True) for uuid in self._datasource_uuids)
 

--- a/openghg/store/_obsmobile.py
+++ b/openghg/store/_obsmobile.py
@@ -1,6 +1,7 @@
-from openghg.store.base import BaseStore
 from pathlib import Path
 from typing import Union
+
+from openghg.store.base import BaseStore
 
 pathType = Union[str, Path]
 

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -1,11 +1,11 @@
-from openghg.store.base import BaseStore
-from openghg.types import pathType, multiPathType, resultsType
 from pathlib import Path
-from typing import DefaultDict, Dict, Optional, Sequence, Union, Tuple
-from xarray import Dataset
-import numpy as np
+from typing import DefaultDict, Dict, Optional, Sequence, Tuple, Union
 
+import numpy as np
 from openghg.store import DataSchema
+from openghg.store.base import BaseStore
+from openghg.types import multiPathType, pathType, resultsType
+from xarray import Dataset
 
 __all__ = ["ObsSurface"]
 
@@ -113,13 +113,14 @@ class ObsSurface(BaseStore):
         Returns:
             dict: Dictionary of Datasource UUIDs
         """
-        from collections import defaultdict
-        from pandas import Timedelta
         import sys
-        from tqdm import tqdm
-        from openghg.util import load_surface_parser, hash_file, clean_string, verify_site
+        from collections import defaultdict
+
+        from openghg.store import assign_data, datasource_lookup, load_metastore
         from openghg.types import SurfaceTypes
-        from openghg.store import assign_data, load_metastore, datasource_lookup
+        from openghg.util import clean_string, hash_file, load_surface_parser, verify_site
+        from pandas import Timedelta
+        from tqdm import tqdm
 
         if not isinstance(filepath, list):
             filepath = [filepath]
@@ -298,10 +299,11 @@ class ObsSurface(BaseStore):
 
         This data is different in that it contains multiple sites in the same file.
         """
-        from openghg.standardise.surface import parse_aqmesh
-        from openghg.store import assign_data, load_metastore, datasource_lookup
-        from openghg.util import hash_file
         from collections import defaultdict
+
+        from openghg.standardise.surface import parse_aqmesh
+        from openghg.store import assign_data, datasource_lookup, load_metastore
+        from openghg.util import hash_file
         from tqdm import tqdm
 
         data_filepath = Path(data_filepath)
@@ -433,7 +435,7 @@ class ObsSurface(BaseStore):
         Returns:
             Dict or None:
         """
-        from openghg.store import assign_data, load_metastore, datasource_lookup
+        from openghg.store import assign_data, datasource_lookup, load_metastore
         from openghg.util import hash_retrieved_data
 
         obs = ObsSurface.load()

--- a/openghg/store/_populate.py
+++ b/openghg/store/_populate.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Dict, List, Optional, Union
+
 from openghg.store import ObsSurface
 
 

--- a/openghg/store/_recombination.py
+++ b/openghg/store/_recombination.py
@@ -3,9 +3,10 @@
 
 """
 from typing import Dict, List, Optional, Union
-from xarray.core.coordinates import DatasetCoordinates
+
 import numpy as np
 import xarray as xr
+from xarray.core.coordinates import DatasetCoordinates
 
 __all__ = ["recombine_multisite", "recombine_datasets"]
 
@@ -46,9 +47,9 @@ def recombine_datasets(
     Returns:
         xarray.Dataset: Combined Dataset
     """
-    from xarray import concat as xr_concat
-    from openghg.store.base import Datasource
     from openghg.objectstore import get_bucket
+    from openghg.store.base import Datasource
+    from xarray import concat as xr_concat
 
     if not keys:
         raise ValueError("No data keys passed.")

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -1,7 +1,8 @@
 """ This file contains the BaseStore class from which other retrieve
     modules inherit.
 """
-from typing import Dict, List, Optional, Union, Type, TypeVar
+from typing import Dict, List, Optional, Type, TypeVar, Union
+
 from pandas import Timestamp
 from tinydb import TinyDB
 
@@ -15,8 +16,8 @@ class BaseStore:
     _uuid = "root_uuid"
 
     def __init__(self) -> None:
-        from openghg.util import timestamp_now
         from addict import Dict as aDict
+        from openghg.util import timestamp_now
 
         self._creation_datetime = timestamp_now()
         self._stored = False
@@ -62,8 +63,8 @@ class BaseStore:
         Returns:
             cls: Class object of cls type
         """
-        from openghg.util import timestamp_tzaware
         from addict import Dict as aDict
+        from openghg.util import timestamp_tzaware
 
         if not data:
             raise ValueError("Unable to create object with empty dictionary")
@@ -195,8 +196,9 @@ class BaseStore:
         Returns:
             dict: Dictionary of rank and daterange covered by that rank
         """
-        from openghg.util import daterange_overlap, create_daterange_str
         from collections import defaultdict
+
+        from openghg.util import create_daterange_str, daterange_overlap
 
         if uuid not in self._rank_data:
             return {}
@@ -251,13 +253,14 @@ class BaseStore:
             None
         """
         from copy import deepcopy
+
         from openghg.util import (
             combine_dateranges,
-            daterange_overlap,
-            trim_daterange,
             daterange_contains,
-            split_encompassed_daterange,
+            daterange_overlap,
             sanitise_daterange,
+            split_encompassed_daterange,
+            trim_daterange,
         )
 
         rank = int(rank)

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -1,7 +1,8 @@
-from pandas import DataFrame, Timestamp
-from typing import DefaultDict, Dict, List, Optional, Tuple, Union, TypeVar, Type
-from xarray import Dataset
+from typing import DefaultDict, Dict, List, Optional, Tuple, Type, TypeVar, Union
+
 import numpy as np
+from pandas import DataFrame, Timestamp
+from xarray import Dataset
 
 dataKeyType = DefaultDict[str, Dict[str, Dict[str, str]]]
 
@@ -20,9 +21,10 @@ class Datasource:
     _data_root = "data"
 
     def __init__(self) -> None:
-        from openghg.util import timestamp_now
         from collections import defaultdict
         from uuid import uuid4
+
+        from openghg.util import timestamp_now
 
         self._uuid: str = str(uuid4())
         self._creation_datetime = timestamp_now()
@@ -118,9 +120,9 @@ class Datasource:
         Returns:
             None
         """
+        from numpy import unique as np_unique
         from openghg.util import daterange_overlap
         from xarray import concat as xr_concat
-        from numpy import unique as np_unique
 
         # Group by year
         year_group = data.groupby("time.year")
@@ -227,8 +229,8 @@ class Datasource:
         Returns:
             tuple (Timestamp, Timestamp): Start and end Timestamps for data
         """
-        from pandas import DatetimeIndex
         from openghg.util import timestamp_tzaware
+        from pandas import DatetimeIndex
 
         if not isinstance(dataframe.index, DatetimeIndex):
             raise TypeError("Only DataFrames with a DatetimeIndex must be passed")
@@ -407,10 +409,11 @@ class Datasource:
         Returns:
             xarray.Dataset: Dataset from NetCDF file
         """
-        from openghg.objectstore import get_object
-        from xarray import load_dataset
         import tempfile
         from pathlib import Path
+
+        from openghg.objectstore import get_object
+        from xarray import load_dataset
 
         data = get_object(bucket, key)
 
@@ -470,12 +473,8 @@ class Datasource:
         import tempfile
         from copy import deepcopy
 
+        from openghg.objectstore import get_bucket, set_object_from_file, set_object_from_json
         from openghg.util import timestamp_now
-        from openghg.objectstore import (
-            get_bucket,
-            set_object_from_file,
-            set_object_from_json,
-        )
 
         if bucket is None:
             bucket = get_bucket()

--- a/openghg/transform/_regrid.py
+++ b/openghg/transform/_regrid.py
@@ -1,10 +1,11 @@
 # TODO: Add import for xesmf within specific functions and NOT general import at the top.
 # TODO: Add try-except around xesmf import with helpful error message
 
+from typing import Optional, Tuple, TypeVar, Union, cast
+
 import numpy as np
-from numpy import ndarray
 import xarray as xr
-from typing import Union, Optional, Tuple, TypeVar, cast
+from numpy import ndarray
 
 xesmf_error_message = (
     "Unable to import xesmf for use with regridding algorithms"
@@ -68,7 +69,7 @@ def convert_to_ndarray(array: Union[ndarray, xr.DataArray]) -> ndarray:
 
 # Create types for ndarray or xr.DataArray inputs
 # Using TypeVar means - whichever type is passed in will be the one which is returned.
-ArrayLikeMatch = TypeVar('ArrayLikeMatch', np.ndarray, xr.DataArray)
+ArrayLikeMatch = TypeVar("ArrayLikeMatch", np.ndarray, xr.DataArray)
 ArrayLike = Union[ndarray, xr.DataArray]
 
 
@@ -161,7 +162,6 @@ def regrid_uniform_cc(
 
         # Checking dimensions and mapping back lat_out and lon_out
         # May be overkill but attempting to make sure this is done correctly.
-
         # The regridded DataArray will contain dimensions of ('x', 'y') for
         # data, 'lat' and 'lon' coordinates e.g. lon = [[-10,-10],[0,0]]
         # This is to allow for the generic case where ('lat', 'lon') is not

--- a/openghg/transform/emissions/_edgar.py
+++ b/openghg/transform/emissions/_edgar.py
@@ -1,12 +1,12 @@
 import re
-import numpy as np
-from numpy import ndarray
-import xarray as xr
-from pathlib import Path
 import zipfile
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple, Union, cast
 from zipfile import ZipFile
-from typing import Dict, Tuple, Optional, Union, Any, cast
 
+import numpy as np
+import xarray as xr
+from numpy import ndarray
 
 ArrayType = Optional[Union[ndarray, xr.DataArray]]
 
@@ -60,16 +60,16 @@ def parse_edgar(
     TODO: Add monthly parsing and sector stacking options
     """
     import tempfile
-    from openghg.util import synonyms, molar_mass, timestamp_now, clean_string, convert_longitude
+
+    from openghg.standardise.meta import assign_flux_attributes, define_species_label
     from openghg.store import infer_date_range
-    from openghg.standardise.meta import define_species_label, assign_flux_attributes
+    from openghg.util import clean_string, convert_longitude, molar_mass, synonyms, timestamp_now
 
     # Currently based on acrg.name.emissions_helperfuncs.getedgarannualtotals()
     # Additional edgar functions which could be incorporated.
     # - getedgarv5annualsectors
     # - getedgarv432annualsectors
     # - (monthly sectors?)
-
     # TODO: Work out how to select frequency
     # - could try and relate to period e.g. "monthly" versus "yearly" etc.
     period = None
@@ -391,7 +391,7 @@ def _check_lat_lon(
         ndarray, ndarray: Latitude and longitude arrays
         None, None: if all inputs are None, a tuple of Nones will be returned.
     """
-    from openghg.util import find_domain, convert_longitude
+    from openghg.util import convert_longitude, find_domain
 
     if lat_out is not None or lon_out is not None:
         if domain is None:

--- a/openghg/types/__init__.py
+++ b/openghg/types/__init__.py
@@ -1,9 +1,9 @@
-from ._enum import SurfaceTypes, DataTypes, ObsTypes, EmissionsTypes, EmissionsDatabases
-from ._types import pathType, multiPathType, resultsType
+from ._enum import DataTypes, EmissionsDatabases, EmissionsTypes, ObsTypes, SurfaceTypes
 from ._errors import (
-    InvalidSiteError,
-    UnknownDataError,
-    FunctionError,
-    ObjectStoreError,
     DatasourceLookupError,
+    FunctionError,
+    InvalidSiteError,
+    ObjectStoreError,
+    UnknownDataError,
 )
+from ._types import multiPathType, pathType, resultsType

--- a/openghg/types/_types.py
+++ b/openghg/types/_types.py
@@ -1,5 +1,5 @@
-from typing import DefaultDict, Dict, List, Tuple, Union
 from pathlib import Path
+from typing import DefaultDict, Dict, List, Tuple, Union
 
 pathType = Union[str, Path]
 multiPathType = Union[str, Path, Tuple, List]

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -7,8 +7,10 @@ from ._download import download_data, parse_url_filename
 from ._export import to_dashboard, to_dashboard_mobile
 from ._file import (
     compress,
+    compress_json,
     compress_str,
     decompress,
+    decompress_json,
     decompress_str,
     get_datapath,
     load_emissions_database_parser,

--- a/openghg/util/_download.py
+++ b/openghg/util/_download.py
@@ -30,12 +30,13 @@ def download_data(
         bytes / None: Bytes if no filepath given
     """
     import functools
-    import shutil
-    import requests
     import io
-    from tqdm.auto import tqdm  # type: ignore
+    import shutil
     from urllib.parse import urlparse
+
+    import requests
     from requests.adapters import HTTPAdapter
+    from tqdm.auto import tqdm  # type: ignore
     from urllib3.util.retry import Retry  # type: ignore
 
     retriable_status_codes = [

--- a/openghg/util/_export.py
+++ b/openghg/util/_export.py
@@ -1,9 +1,9 @@
-from addict import Dict as aDict
-from typing import Dict, List, Union
-from json import loads, dump
+from json import dump, loads
 from pathlib import Path
-from openghg.dataobjects import ObsData
+from typing import Dict, List, Union
 
+from addict import Dict as aDict
+from openghg.dataobjects import ObsData
 
 __all__ = ["to_dashboard", "to_dashboard_mobile"]
 

--- a/openghg/util/_file.py
+++ b/openghg/util/_file.py
@@ -1,6 +1,6 @@
-from pathlib import Path
-from typing import Any, Dict, List, Union, Optional, Callable
 import gzip
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union
 
 
 def load_surface_parser(data_type: str) -> Callable:

--- a/openghg/util/_file.py
+++ b/openghg/util/_file.py
@@ -1,4 +1,5 @@
-import gzip
+import bz2
+import json
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -129,7 +130,7 @@ def compress(data: bytes) -> bytes:
     Returns:
         bytes: Compressed data
     """
-    return gzip.compress(data=data)
+    return bz2.compress(data=data)
 
 
 def decompress(data: bytes) -> bytes:
@@ -140,7 +141,7 @@ def decompress(data: bytes) -> bytes:
     Returns:
         bytes: Decompressed data
     """
-    return gzip.decompress(data=data)
+    return bz2.decompress(data=data)
 
 
 def compress_str(s: str) -> bytes:
@@ -163,3 +164,27 @@ def decompress_str(data: bytes) -> str:
         str: Decompressed str
     """
     return decompress(data=data).decode(encoding="utf-8")
+
+
+def decompress_json(data: bytes) -> Any:
+    """Decompress a string and load to JSON
+
+    Args:
+        data: Compressed binary data
+    Returns:
+        Object loaded from JSON
+    """
+    decompressed = decompress_str(data=data)
+    return json.loads(decompressed)
+
+
+def compress_json(data: Any) -> bytes:
+    """Convert object to JSON string and compress
+
+    Args:
+        data: Object to pass to json.dumps
+    Returns:
+        bytes: Compressed binary data
+    """
+    json_str = json.dumps(data)
+    return compress_str(json_str)

--- a/openghg/util/_hashing.py
+++ b/openghg/util/_hashing.py
@@ -65,6 +65,7 @@ def hash_retrieved_data(to_hash: Dict[str, Dict]) -> Dict:
     """
     from hashlib import sha1
     from json import dumps
+
     from openghg.util import timestamp_now
 
     current_timestamp = str(timestamp_now())

--- a/openghg/util/_species.py
+++ b/openghg/util/_species.py
@@ -1,6 +1,6 @@
-from typing import Optional, Union, List
-from openghg.util import load_json
+from typing import List, Optional, Union
 
+from openghg.util import load_json
 
 __all__ = ["synonyms", "species_lifetime", "check_lifetime_monthly", "molar_mass"]
 

--- a/openghg/util/_strings.py
+++ b/openghg/util/_strings.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Set, List, Union, Tuple, Optional, overload
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, overload
 
 __all__ = ["clean_string", "to_lowercase"]
 

--- a/openghg/util/_time.py
+++ b/openghg/util/_time.py
@@ -1,6 +1,7 @@
 from datetime import date
-from pandas import DataFrame, Timestamp, DatetimeIndex, DateOffset, Timedelta
-from typing import Dict, List, Tuple, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
+
+from pandas import DataFrame, DateOffset, DatetimeIndex, Timedelta, Timestamp
 from xarray import Dataset
 
 __all__ = [
@@ -363,8 +364,8 @@ def find_daterange_gaps(start_search: Timestamp, end_search: Timestamp, daterang
     Returns:
         list: List of dateranges
     """
-    from pandas import Timedelta
     from openghg.util import pairwise
+    from pandas import Timedelta
 
     if not dateranges:
         return []

--- a/openghg/util/_tutorial.py
+++ b/openghg/util/_tutorial.py
@@ -25,8 +25,9 @@ def retrieve_example_data(
     """Retrieve data from the OpenGHG example data repository and write it to a temporary file
     for reading.
     """
-    import tempfile
     import shutil
+    import tempfile
+
     from openghg.util import download_data, parse_url_filename
 
     url = f"https://github.com/openghg/example_data/raw/main/{path}"

--- a/openghg/util/_util.py
+++ b/openghg/util/_util.py
@@ -15,12 +15,9 @@ def running_in_cloud() -> bool:
     """
     from os import environ
 
-    cloud_env = environ.get("OPENGHG_CLOUD", False)
+    cloud_env = environ.get("OPENGHG_CLOUD", "0")
 
-    if cloud_env:
-        return bool(int(cloud_env))
-    else:
-        return False
+    return bool(int(cloud_env))
 
 
 def running_on_hub() -> bool:
@@ -33,12 +30,9 @@ def running_on_hub() -> bool:
     """
     from os import environ
 
-    hub_env = environ.get("OPENGHG_HUB", False)
+    hub_env = environ.get("OPENGHG_HUB", "0")
 
-    if hub_env:
-        return bool(int(hub_env))
-    else:
-        return False
+    return bool(int(hub_env))
 
 
 def running_locally() -> bool:

--- a/tests/analyse/conftest.py
+++ b/tests/analyse/conftest.py
@@ -1,9 +1,10 @@
 import os
 import tempfile
+
 import pytest
-from helpers import get_datapath, get_emissions_datapath, get_bc_datapath, get_footprint_datapath
+from helpers import get_bc_datapath, get_datapath, get_emissions_datapath, get_footprint_datapath
 from openghg.objectstore import get_bucket
-from openghg.store import ObsSurface, Emissions, BoundaryConditions, Footprints
+from openghg.store import BoundaryConditions, Emissions, Footprints, ObsSurface
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/analyse/test_footprint.py
+++ b/tests/analyse/test_footprint.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 from openghg.analyse import footprints_data_merge
 
 

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -1,13 +1,13 @@
 from typing import Optional
-import pytest
+
 import numpy as np
-import xarray as xr
 import pandas as pd
+import pytest
+import xarray as xr
+from openghg.analyse import ModelScenario, calc_dim_resolution, match_dataset_dims, stack_datasets
+from openghg.retrieve import get_bc, get_flux, get_footprint, get_obs_surface
+from pandas import Timedelta, Timestamp
 from xarray import Dataset
-from pandas import Timestamp, Timedelta
-from openghg.analyse import ModelScenario
-from openghg.analyse import match_dataset_dims, calc_dim_resolution, stack_datasets
-from openghg.retrieve import get_obs_surface, get_footprint, get_flux, get_bc
 
 #%% Test ModelScenario initialisation and update options
 

--- a/tests/cloud/test_calls.py
+++ b/tests/cloud/test_calls.py
@@ -12,24 +12,7 @@ def set_env(monkeypatch):
     monkeypatch.setenv("AUTH_KEY", "test-key-123")
 
 
-def test_call_function_raises_both(monkeypatch):
-    monkeypatch.setenv("OPENGHG_CLOUD", "1")
-    monkeypatch.setenv("OPENGHG_HUB", "1")
-
-    with pytest.raises(ValueError):
-        call_function(data={"function": "sweet_function"})
-
-
-def test_call_cloud(monkeypatch):
-    monkeypatch.setenv("OPENGHG_CLOUD", "1")
-
-    with pytest.raises(FunctionError):
-        call_function(data={"function": "sweet_function"})
-
-
 def test_call_hub(monkeypatch, requests_mock):
-    monkeypatch.setenv("OPENGHG_HUB", "1")
-
     to_send = {"data": b"1234"}
     resp = msgpack.packb(to_send)
     requests_mock.post("https://localhost/t/openghg", content=resp)
@@ -38,3 +21,9 @@ def test_call_hub(monkeypatch, requests_mock):
 
     assert result["content"] == to_send
     assert result["status"] == 200
+
+def test_incorrect_call_raises_functionerror(requests_mock):
+    requests_mock.post("https://localhost/t/openghg", status_code=400, content=b"Error")
+
+    with pytest.raises(FunctionError):
+        call_function(data={"function": "sweet_function"})

--- a/tests/cloud/test_packaging.py
+++ b/tests/cloud/test_packaging.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+from openghg.cloud import package_from_function, unpackage
+from openghg.util import decompress, decompress_json
+
+
+def test_package_from_function_metadata():
+    mock_data = b"123-123-123"
+    mock_metadata = {"spam": "eggs", "healthy": "snacks"}
+
+    package = package_from_function(data=mock_data, metadata=mock_metadata)
+
+    compressed_data = package["data"]
+
+    file_metadata = package["file_metadata"]
+
+    decompressed_data = decompress(data=compressed_data)
+    assert decompressed_data == mock_data
+    expected_sha1 = "2eb96245c157893cead0dd271dc5f2f302b1128c"
+
+    assert file_metadata["data"]["sha1_hash"] == expected_sha1
+    assert file_metadata["data"]["compression_type"] == "bz2"
+
+    compressed_metadata = package["metadata"]
+    metadata = decompress_json(data=compressed_metadata)
+
+    assert metadata == mock_metadata
+
+    mock_data = b"123-123-123"
+    mock_metadata_str = json.dumps({"spam": "eggs", "healthy": "snacks"})
+
+    package = package_from_function(data=mock_data, metadata=mock_metadata_str)
+
+    compressed_metadata = package["metadata"]
+    metadata = decompress_json(data=compressed_metadata)
+
+    assert metadata == mock_metadata
+
+
+def test_unpackage():
+    mock_data = b"123-123-123"
+    mock_metadata = {"spam": "eggs", "healthy": "snacks"}
+
+    package = package_from_function(data=mock_data, metadata=mock_metadata)
+
+    unpackaged = unpackage(data=package)
+
+    assert unpackaged["data"] == mock_data
+    assert unpackaged["metadata"] == mock_metadata
+
+
+def test_package_sha1_mismatch():
+    mock_data = b"123-123-123"
+    mock_metadata = {"spam": "eggs", "healthy": "snacks"}
+
+    package = package_from_function(data=mock_data, metadata=mock_metadata)
+
+    package["file_metadata"]["data"]["sha1_hash"] = 888
+
+    with pytest.raises(ValueError):
+        unpackage(data=package)

--- a/tests/dataobjects/test_obs_dataclass.py
+++ b/tests/dataobjects/test_obs_dataclass.py
@@ -1,6 +1,7 @@
-from openghg.dataobjects import ObsData
 from dataclasses import FrozenInstanceError
+
 import pytest
+from openghg.dataobjects import ObsData
 
 # Some of these tests are really just testing that Python does Python correctly but
 # I plan on extending the dataclass so I'll leave these to be filled out later

--- a/tests/dataobjects/test_searchresults.py
+++ b/tests/dataobjects/test_searchresults.py
@@ -33,7 +33,7 @@ def test_retrieve_unranked():
     results = search(species="ch4", skip_ranking=True)
 
     assert results.ranked_data is False
-    assert results.cloud is False
+    assert results.hub is False
 
     raw_results = results.raw()
     assert raw_results["tac"]["ch4"]["100m"]
@@ -336,7 +336,7 @@ def test_create_obsdata_no_data_raises():
 
 
 def test_search_result_retrieve_cloud_and_hub(monkeypatch, mocker, tmpdir):
-    monkeypatch.setenv("OPENGHG_CLOUD", "1")
+    monkeypatch.setenv("OPENGHG_HUB", "1")
 
     df = pd.DataFrame({"A": range(0, 64), "B": range(0, 64)}, columns=list("AB"))
     ds = df.to_xarray()
@@ -363,10 +363,6 @@ def test_search_result_retrieve_cloud_and_hub(monkeypatch, mocker, tmpdir):
 
     assert retrieved.data.equals(ds)
     assert mock_call.call_count == 1
-
-    monkeypatch.delenv("OPENGHG_CLOUD")
-    monkeypatch.delenv("OPENGHG_PATH")
-    monkeypatch.setenv("OPENGHG_HUB", "1")
 
     s = SearchResults(
         results={

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,18 +1,17 @@
+from .cfchecking import check_cf_compliance
 from .helpers import (
-    get_datapath,
-    glob_files,
-    get_emissions_datapath,
+    call_function_packager,
     get_bc_datapath,
+    get_datapath,
+    get_emissions_datapath,
     get_footprint_datapath,
     get_mobile_datapath,
     get_retrieval_data_file,
-    call_function_packager,
+    glob_files,
 )
 from .meta import (
-    metadata_checker_obssurface,
-    attributes_checker_obssurface,
-    parsed_surface_metachecker,
     attributes_checker_get_obs,
+    attributes_checker_obssurface,
+    metadata_checker_obssurface,
+    parsed_surface_metachecker,
 )
-
-from .cfchecking import check_cf_compliance

--- a/tests/helpers/cfchecking.py
+++ b/tests/helpers/cfchecking.py
@@ -1,6 +1,7 @@
-from tempfile import NamedTemporaryFile
-import xarray as xr
 import warnings
+from tempfile import NamedTemporaryFile
+
+import xarray as xr
 
 
 def check_cf_compliance(dataset: xr.Dataset, debug: bool = False) -> bool:

--- a/tests/helpers/meta.py
+++ b/tests/helpers/meta.py
@@ -1,5 +1,6 @@
 # Check if obssurface metadata contains the minimum expected
 from typing import Dict
+
 from openghg.dataobjects import SearchResults
 
 

--- a/tests/objectstore/test_local_object_store.py
+++ b/tests/objectstore/test_local_object_store.py
@@ -1,8 +1,8 @@
-import pytest
 from pathlib import Path
 
-from openghg.store import ObsSurface
+import pytest
 from openghg.objectstore import get_bucket, query_store
+from openghg.store import ObsSurface
 
 
 def get_datapath(filename, data_type):

--- a/tests/retrieve/ceda/test_ceda_retrieve.py
+++ b/tests/retrieve/ceda/test_ceda_retrieve.py
@@ -1,7 +1,7 @@
-from pandas import Timestamp
-from openghg.retrieve.ceda import retrieve_surface
-from openghg.dataobjects import SearchResults
 from helpers import get_retrieval_data_file
+from openghg.dataobjects import SearchResults
+from openghg.retrieve.ceda import retrieve_surface
+from pandas import Timestamp
 
 
 def test_ceda_retrieve(mocker):

--- a/tests/retrieve/conftest.py
+++ b/tests/retrieve/conftest.py
@@ -1,7 +1,7 @@
 import pytest
-from openghg.objectstore import get_bucket
-from openghg.store import ObsSurface, Emissions, Footprints
 from helpers import get_datapath, get_emissions_datapath, get_footprint_datapath
+from openghg.objectstore import get_bucket
+from openghg.store import Emissions, Footprints, ObsSurface
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -220,7 +220,7 @@ def test_timeslice_slices_correctly_exclusive():
 
 
 def test_get_obs_surface_cloud(mocker, monkeypatch):
-    monkeypatch.setenv("OPENGHG_CLOUD", "1")
+    monkeypatch.setenv("OPENGHG_HUB", "1")
 
     n_days = 100
     epoch = datetime.datetime(1970, 1, 1, 1, 1)

--- a/tests/retrieve/test_ceda_export.py
+++ b/tests/retrieve/test_ceda_export.py
@@ -1,8 +1,8 @@
 import json
 from pathlib import Path
+
 import pytest
 import yaml
-
 from openghg.retrieve import get_ceda_file
 
 # flake8: noqa : E501

--- a/tests/retrieve/test_process_footprint.py
+++ b/tests/retrieve/test_process_footprint.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from openghg.objectstore import get_bucket
-from openghg.store import ObsSurface, Emissions, Footprints
+
 from openghg.analyse import footprints_data_merge
+from openghg.objectstore import get_bucket
+from openghg.store import Emissions, Footprints, ObsSurface
 
 
 def get_datapath(filename, data_type):

--- a/tests/retrieve/test_recombination.py
+++ b/tests/retrieve/test_recombination.py
@@ -1,11 +1,10 @@
 import logging
 
-from openghg.standardise.surface import parse_crds, parse_gcwerks
-from openghg.store import ObsSurface
-from openghg.objectstore import get_bucket
-from openghg.store import recombine_datasets
-from openghg.retrieve import search
 from helpers import get_datapath
+from openghg.objectstore import get_bucket
+from openghg.retrieve import search
+from openghg.standardise.surface import parse_crds, parse_gcwerks
+from openghg.store import ObsSurface, recombine_datasets
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -1,11 +1,10 @@
 import pytest
-
-from openghg.retrieve import search, metadata_lookup
+from helpers import metadata_checker_obssurface
+from openghg.retrieve import metadata_lookup, search
 from openghg.store import metastore_manager
+from openghg.types import DatasourceLookupError
 from openghg.util import timestamp_tzaware
 from pandas import Timestamp
-from helpers import metadata_checker_obssurface
-from openghg.types import DatasourceLookupError
 
 
 def test_specific_keyword_search():

--- a/tests/services/fixtures/mocked_services.py
+++ b/tests/services/fixtures/mocked_services.py
@@ -9,18 +9,16 @@ import uuid
 import Acquire
 import Acquire.Stubs
 import pytest
-
-from Acquire.Service import create_handler
 from access.route import route as access_functions
 from accounting.route import route as accounting_functions
+from Acquire.Service import create_handler
 from compute.route import route as compute_functions
 from identity.route import route as identity_functions
 from registry.route import route as registry_functions
-from storage.route import route as storage_functions
-
 # We no longer have the openghg_service folder but just have the service functions
 # in their respective files
 from route import route as openghg_functions
+from storage.route import route as storage_functions
 
 identity_handler = create_handler(identity_functions)
 accounting_handler = create_handler(accounting_functions)
@@ -83,7 +81,7 @@ class MockedRequests:
         if "identity" not in _services:
             raise ValueError("NO SERVICES? %s" % str)
 
-        from Acquire.Service import push_testing_objstore, pop_testing_objstore
+        from Acquire.Service import pop_testing_objstore, push_testing_objstore
 
         if url.startswith("http://"):
             url = url[7:]
@@ -154,8 +152,7 @@ def _login_admin(service_url, username, password, otp):
     """Internal function used to get a valid login to the specified
     service for the passed username, password and otp
     """
-    from Acquire.Client import User
-    from Acquire.Client import Wallet
+    from Acquire.Client import User, Wallet
 
     wallet = Wallet()
 
@@ -185,9 +182,9 @@ def aaai_services(tmpdir_factory):
     a dictionary (which is passed to the test functions as the
     fixture)
     """
+    from Acquire.Crypto import OTP, PrivateKey
     from Acquire.Identity import Authorisation
-    from Acquire.Crypto import PrivateKey, OTP
-    from Acquire.Service import call_function, Service
+    from Acquire.Service import Service, call_function
 
     _services = {}
     _services["registry"] = tmpdir_factory.mktemp("registry")
@@ -339,8 +336,8 @@ def aaai_services(tmpdir_factory):
 
 @pytest.fixture(scope="session")
 def authenticated_user(aaai_services):
-    from Acquire.Crypto import PrivateKey, OTP
     from Acquire.Client import User, Wallet
+    from Acquire.Crypto import OTP, PrivateKey
 
     username = str(uuid.uuid4())
     password = PrivateKey.random_passphrase()

--- a/tests/standardise/surface/test_aqmesh.py
+++ b/tests/standardise/surface/test_aqmesh.py
@@ -1,6 +1,6 @@
+from helpers import get_datapath
 from openghg.standardise.surface import parse_aqmesh
 from pandas import Timestamp
-from helpers import get_datapath
 
 
 def test_aqmesh_read():

--- a/tests/standardise/surface/test_beaco2n.py
+++ b/tests/standardise/surface/test_beaco2n.py
@@ -1,9 +1,8 @@
-from openghg.standardise.surface import parse_beaco2n
-from pandas import Timestamp
 import pytest
 from helpers import get_datapath
 from numpy import isnan
-
+from openghg.standardise.surface import parse_beaco2n
+from pandas import Timestamp
 
 # def test_read_file():
 #     beacon = BEACO2N()

--- a/tests/standardise/surface/test_btt.py
+++ b/tests/standardise/surface/test_btt.py
@@ -1,9 +1,9 @@
 import logging
+
 import pandas as pd
 import pytest
-
+from helpers import check_cf_compliance, get_datapath, parsed_surface_metachecker
 from openghg.standardise.surface import parse_btt
-from helpers import get_datapath, parsed_surface_metachecker, check_cf_compliance
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/tests/standardise/surface/test_cranfield.py
+++ b/tests/standardise/surface/test_cranfield.py
@@ -1,7 +1,7 @@
 import pytest
-
+from helpers import check_cf_compliance, get_datapath, parsed_surface_metachecker
 from openghg.standardise.surface import parse_cranfield
-from helpers import get_datapath, parsed_surface_metachecker, check_cf_compliance
+
 
 @pytest.mark.skip_if_no_cfchecker
 @pytest.mark.xfail(reason="Bug: No attributes for Cranfield - see #201")

--- a/tests/standardise/surface/test_crds.py
+++ b/tests/standardise/surface/test_crds.py
@@ -1,9 +1,9 @@
 import logging
-import pytest
 import tempfile
 
-from openghg.standardise.surface import parse_crds
+import pytest
 from helpers import check_cf_compliance
+from openghg.standardise.surface import parse_crds
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/tests/standardise/surface/test_gcwerks.py
+++ b/tests/standardise/surface/test_gcwerks.py
@@ -1,9 +1,9 @@
 import logging
+
 import pandas as pd
 import pytest
-
+from helpers import check_cf_compliance, get_datapath, parsed_surface_metachecker
 from openghg.standardise.surface import parse_gcwerks
-from helpers import get_datapath, parsed_surface_metachecker, check_cf_compliance
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/tests/standardise/surface/test_glasgow_licor.py
+++ b/tests/standardise/surface/test_glasgow_licor.py
@@ -1,7 +1,7 @@
+import pytest
 from helpers import get_mobile_datapath
 from openghg.standardise.surface import parse_glasow_licor
 from pandas import Timestamp
-import pytest
 
 
 def test_glasgow_licor_read():

--- a/tests/standardise/surface/test_icos.py
+++ b/tests/standardise/surface/test_icos.py
@@ -1,7 +1,7 @@
 import logging
+
 import pytest
 from helpers import get_datapath
-
 from openghg.standardise.surface import parse_icos
 
 mpl_logger = logging.getLogger("matplotlib")

--- a/tests/standardise/surface/test_noaa.py
+++ b/tests/standardise/surface/test_noaa.py
@@ -1,10 +1,14 @@
 import logging
-from pandas import Timestamp
-import pytest
 
-from helpers import get_datapath, parsed_surface_metachecker
+import pytest
+from helpers import (
+    attributes_checker_obssurface,
+    check_cf_compliance,
+    get_datapath,
+    parsed_surface_metachecker,
+)
 from openghg.standardise.surface import parse_noaa
-from helpers import attributes_checker_obssurface, check_cf_compliance
+from pandas import Timestamp
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/tests/standardise/surface/test_npl.py
+++ b/tests/standardise/surface/test_npl.py
@@ -1,9 +1,9 @@
 import logging
+
 import pandas as pd
 import pytest
-
+from helpers import check_cf_compliance, get_datapath, parsed_surface_metachecker
 from openghg.standardise.surface import parse_npl
-from helpers import get_datapath, parsed_surface_metachecker, check_cf_compliance
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/tests/standardise/surface/test_openghg.py
+++ b/tests/standardise/surface/test_openghg.py
@@ -1,11 +1,11 @@
 import logging
-import numpy as np
-from pandas import Timestamp
-import pytest
 
-from openghg.standardise.surface import parse_openghg
+import numpy as np
+import pytest
+from helpers import check_cf_compliance, get_datapath, parsed_surface_metachecker
 from openghg.standardise.meta import metadata_default_keys
-from helpers import get_datapath, parsed_surface_metachecker, check_cf_compliance
+from openghg.standardise.surface import parse_openghg
+from pandas import Timestamp
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)
@@ -13,7 +13,7 @@ mpl_logger.setLevel(logging.WARNING)
 
 def test_read_file():
     """
-    Test file in OpenGHG format (variables and attributes) can be 
+    Test file in OpenGHG format (variables and attributes) can be
     correctly parsed.
     """
     filepath = get_datapath(filename="tac_co2_openghg.nc", data_type="OPENGHG")
@@ -87,7 +87,7 @@ def test_read_file_no_attr():
     assert metadata.items() >= expected_metadata.items()
 
 
-# TODO: Add tests for new site (i.e. no current data stored) 
+# TODO: Add tests for new site (i.e. no current data stored)
 # - when/if possible!
 # - [] Check this can read in a file if *all* keywords specified manually
 #   - for this create file for *new* site and with no attributes

--- a/tests/standardise/surface/test_thamesbarrier.py
+++ b/tests/standardise/surface/test_thamesbarrier.py
@@ -1,9 +1,9 @@
 import logging
+
 import pandas as pd
 import pytest
-
+from helpers import check_cf_compliance, get_datapath, parsed_surface_metachecker
 from openghg.standardise.surface import parse_tmb
-from helpers import get_datapath, parsed_surface_metachecker, check_cf_compliance
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -73,13 +73,8 @@ def test_standardise_emissions():
     assert "co2_gppcardamom_europe_2012" in proc_results
 
 
-# Test cloud functions
-@pytest.fixture()
-def set_cloud(monkeypatch):
-    monkeypatch.setenv("OPENGHG_CLOUD", "1")
-
-
-def test_standardise(set_cloud, mocker, tmpdir):
+def test_standardise(monkeypatch, mocker, tmpdir):
+    monkeypatch.setenv("OPENGHG_HUB", "1")
     call_fn_mock = mocker.patch("openghg.cloud.call_function", autospec=True)
     test_string = "some_text"
     tmppath = Path(tmpdir).joinpath("test_file.txt")

--- a/tests/store/test_boundary_conditions.py
+++ b/tests/store/test_boundary_conditions.py
@@ -1,9 +1,8 @@
-from openghg.store import BoundaryConditions
-from openghg.retrieve import search
-from openghg.store import recombine_datasets, metastore_manager
-from xarray import open_dataset
 from helpers import get_bc_datapath
+from openghg.retrieve import search
+from openghg.store import BoundaryConditions, metastore_manager, recombine_datasets
 from openghg.util import hash_bytes
+from xarray import open_dataset
 
 
 def test_read_data_monthly(mocker):

--- a/tests/store/test_data_schema.py
+++ b/tests/store/test_data_schema.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 import xarray as xr
 from openghg.store import DataSchema
 
@@ -12,7 +12,7 @@ def test_data_schema():
 
     assert data_schema.data_vars == data_vars
     assert data_schema.dtypes is None
-    assert data_schema.dims is None 
+    assert data_schema.dims is None
 
 
 @pytest.fixture(scope="module")
@@ -26,7 +26,7 @@ def dummy_data_1():
     values = np.zeros(shape, dtype=np.float64)
 
     ds = xr.Dataset({"fp": (("time", "lat", "lon"), values)},
-                     coords = {"time": time, "lat": lat, "lon": lon})    
+                     coords = {"time": time, "lat": lat, "lon": lon})
 
     return ds
 
@@ -44,7 +44,7 @@ def data_schema_1():
     data_schema = DataSchema(data_vars=data_vars,
                              dims=dims,
                              dtypes=dtypes)
-    
+
     return data_schema
 
 
@@ -71,6 +71,3 @@ def test_data_schema_empty(dummy_data_1):
     data_schema = DataSchema()
 
     data_schema.validate_data(dummy_data_1)
-
-
-

--- a/tests/store/test_datasource.py
+++ b/tests/store/test_datasource.py
@@ -2,18 +2,17 @@ import datetime
 import os
 import uuid
 from pathlib import Path
-from addict import Dict as aDict
 
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-
-from openghg.store.base import Datasource
-from openghg.standardise.surface import parse_crds
-from openghg.objectstore import get_bucket, get_object_names
-from openghg.util import create_daterange_str, timestamp_tzaware, pairwise, daterange_overlap
+from addict import Dict as aDict
 from helpers import get_datapath
+from openghg.objectstore import get_bucket, get_object_names
+from openghg.standardise.surface import parse_crds
+from openghg.store.base import Datasource
+from openghg.util import create_daterange_str, daterange_overlap, pairwise, timestamp_tzaware
 
 mocked_uuid = "00000000-0000-0000-00000-000000000000"
 mocked_uuid2 = "10000000-0000-0000-00000-000000000001"

--- a/tests/store/test_emissions.py
+++ b/tests/store/test_emissions.py
@@ -1,11 +1,10 @@
 import pytest
-from openghg.store import Emissions
-from openghg.retrieve import search
-from openghg.store import recombine_datasets, metastore_manager, datasource_lookup
-from xarray import open_dataset
 from helpers import get_emissions_datapath
-from openghg.util import hash_bytes
 from openghg.objectstore import get_bucket
+from openghg.retrieve import search
+from openghg.store import Emissions, datasource_lookup, metastore_manager, recombine_datasets
+from openghg.util import hash_bytes
+from xarray import open_dataset
 
 
 def test_read_binary_data(mocker):

--- a/tests/store/test_eulerian_model.py
+++ b/tests/store/test_eulerian_model.py
@@ -1,8 +1,8 @@
 from pathlib import Path
-from openghg.store import EulerianModel
-from openghg.retrieve import search
-from openghg.store import recombine_datasets
+
 from openghg.objectstore import get_bucket
+from openghg.retrieve import search
+from openghg.store import EulerianModel, recombine_datasets
 from xarray import open_dataset
 
 

--- a/tests/store/test_footprints.py
+++ b/tests/store/test_footprints.py
@@ -1,9 +1,8 @@
 import pytest
-
-from openghg.store import Footprints, recombine_datasets, metastore_manager, datasource_lookup
-from openghg.retrieve import search
-from openghg.objectstore import get_bucket
 from helpers import get_footprint_datapath
+from openghg.objectstore import get_bucket
+from openghg.retrieve import search
+from openghg.store import Footprints, datasource_lookup, metastore_manager, recombine_datasets
 from openghg.util import hash_bytes
 
 

--- a/tests/store/test_infer_time.py
+++ b/tests/store/test_infer_time.py
@@ -1,10 +1,9 @@
-import pytest
-from xarray import DataArray
-from pandas import Timedelta
 import numpy as np
-
+import pytest
 from openghg.store import infer_date_range
 from openghg.util import timestamp_tzaware
+from pandas import Timedelta
+from xarray import DataArray
 
 #%% Infer period when one time point present
 

--- a/tests/store/test_metstore.py
+++ b/tests/store/test_metstore.py
@@ -1,8 +1,9 @@
-import pytest
-from openghg.store import METStore
-from openghg.objectstore import get_bucket
-from requests_mock import ANY
 from pathlib import Path
+
+import pytest
+from openghg.objectstore import get_bucket
+from openghg.store import METStore
+from requests_mock import ANY
 
 
 @pytest.fixture(scope="session")

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -1,13 +1,13 @@
-import pytest
-from pandas import Timestamp
-import xarray as xr
 import json
 
-from openghg.store.base import Datasource
+import pytest
+import xarray as xr
+from helpers import attributes_checker_obssurface, get_datapath
+from openghg.objectstore import exists, get_bucket
 from openghg.store import ObsSurface
-from openghg.objectstore import get_bucket, exists
+from openghg.store.base import Datasource
 from openghg.util import create_daterange_str
-from helpers import get_datapath, attributes_checker_obssurface
+from pandas import Timestamp
 
 
 def test_different_sampling_periods_diff_datasources():

--- a/tests/transform/emissions/test_edgar.py
+++ b/tests/transform/emissions/test_edgar.py
@@ -1,9 +1,8 @@
-import pytest
 import numpy as np
+import pytest
 from helpers import get_emissions_datapath
 from openghg.transform.emissions import parse_edgar
 from openghg.transform.emissions._edgar import _extract_file_info
-
 
 # TODO: Add tests
 # - single sector EDGAR data can be read and intepreted correctly for v6.0

--- a/tests/transform/test_regrid.py
+++ b/tests/transform/test_regrid.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 import xarray as xr
 from openghg.transform import regrid_uniform_cc
 

--- a/tests/util/test_domain.py
+++ b/tests/util/test_domain.py
@@ -1,6 +1,6 @@
-import pytest
 import numpy as np
-from openghg.util import find_domain, convert_longitude
+import pytest
+from openghg.util import convert_longitude, find_domain
 from openghg.util._domain import _get_coord_data
 
 

--- a/tests/util/test_download.py
+++ b/tests/util/test_download.py
@@ -1,4 +1,4 @@
-from openghg.util import parse_url_filename, download_data
+from openghg.util import download_data, parse_url_filename
 
 
 def test_url_parser():

--- a/tests/util/test_export.py
+++ b/tests/util/test_export.py
@@ -1,13 +1,13 @@
-from pandas import DataFrame, date_range
-from pathlib import Path
 import datetime
-from openghg.util import to_dashboard, to_dashboard_mobile
-from openghg.dataobjects import ObsData
-from openghg.standardise.surface import parse_glasow_licor
-from tempfile import TemporaryDirectory
 import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from helpers import get_mobile_datapath
+from openghg.dataobjects import ObsData
+from openghg.standardise.surface import parse_glasow_licor
+from openghg.util import to_dashboard, to_dashboard_mobile
+from pandas import DataFrame, date_range
 
 
 def test_export_to_dashboard():

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -1,5 +1,6 @@
-import pytest
 import tempfile
+
+import pytest
 from openghg.util import load_surface_parser, read_header
 
 

--- a/tests/util/test_hashing.py
+++ b/tests/util/test_hashing.py
@@ -1,10 +1,10 @@
-import pandas as pd
-import numpy as np
 import datetime
-import pytest
 
-from openghg.util import hash_string, hash_retrieved_data, hash_bytes
+import numpy as np
+import pandas as pd
+import pytest
 from helpers import get_datapath
+from openghg.util import hash_bytes, hash_retrieved_data, hash_string
 
 
 def test_hash_string():

--- a/tests/util/test_lifetime.py
+++ b/tests/util/test_lifetime.py
@@ -1,5 +1,6 @@
 import pytest
-from openghg.util import species_lifetime, check_lifetime_monthly
+from openghg.util import check_lifetime_monthly, species_lifetime
+
 
 @pytest.mark.parametrize("species,expected_lifetime",
                          [("ch4", None),

--- a/tests/util/test_time.py
+++ b/tests/util/test_time.py
@@ -1,30 +1,31 @@
 from multiprocessing.sharedctypes import Value
-import pytest
+
 import numpy as np
-from pandas import Timestamp, DateOffset, Timedelta
 import pandas as pd
-from xarray import Dataset
+import pytest
 from openghg.util import (
+    check_date,
+    check_nan,
+    closest_daterange,
+    combine_dateranges,
     create_daterange,
+    create_daterange_str,
+    create_frequency_str,
+    daterange_contains,
     daterange_from_str,
     daterange_overlap,
-    create_daterange_str,
-    closest_daterange,
     find_daterange_gaps,
-    timestamp_tzaware,
-    combine_dateranges,
-    split_daterange_str,
-    trim_daterange,
-    split_encompassed_daterange,
-    daterange_contains,
-    check_nan,
-    check_date,
     find_duplicate_timestamps,
     parse_period,
-    create_frequency_str,
     relative_time_offset,
+    split_daterange_str,
+    split_encompassed_daterange,
     time_offset,
+    timestamp_tzaware,
+    trim_daterange,
 )
+from pandas import DateOffset, Timedelta, Timestamp
+from xarray import Dataset
 
 
 def test_create_daterange():

--- a/tests/util/test_tutorial.py
+++ b/tests/util/test_tutorial.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-from openghg.util import bilsdale_datapaths, retrieve_example_data
+
 from helpers import get_datapath
+from openghg.util import bilsdale_datapaths, retrieve_example_data
 
 
 def test_bilsdale_data():


### PR DESCRIPTION
There was a bug in the serverless function shortcut routing code I added. This resulted in a recursion error.
As we'll only (well should) call the serverless functions from the OpenGHG Hub the `call_function` function now only checks if it's running on hub. If it's not (so local or within a serverless function call) it just routes the call to the local function instead.

This also updates the way ICOS and CEDA files are retrieved by adding a couple of simple functions to the `functions` repo.