### PR TITLE
Harmonising get functions to produce same errors

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -51,10 +51,9 @@ from openghg.retrieve import (
     get_bc,
     get_flux,
     get_footprint,
-    search,
     search_surface,
     search_bc,
-    search_emissions,
+    search_emissions,  # TODO: Update to search_flux when available
     search_footprints,
 )
 from openghg.util import synonyms

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -57,7 +57,7 @@ from openghg.retrieve import (
     search_footprints,
 )
 from openghg.util import synonyms
-from openghg.exceptions import SearchError
+from openghg.types import SearchError
 from pandas import Timestamp
 from xarray import DataArray, Dataset
 

--- a/openghg/exceptions/__init__.py
+++ b/openghg/exceptions/__init__.py
@@ -1,8 +1,0 @@
-
-
-class OpenGHGError(Exception):
-    pass
-
-
-class SearchError(OpenGHGError):
-    pass

--- a/openghg/exceptions/__init__.py
+++ b/openghg/exceptions/__init__.py
@@ -1,0 +1,6 @@
+
+class OpenGHGError(Exception):
+    pass
+
+class SearchError(OpenGHGError):
+    pass

--- a/openghg/exceptions/__init__.py
+++ b/openghg/exceptions/__init__.py
@@ -1,6 +1,8 @@
 
+
 class OpenGHGError(Exception):
     pass
+
 
 class SearchError(OpenGHGError):
     pass

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -2,7 +2,7 @@ import json
 import logging
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Union, cast
-from openghg.exceptions import SearchError
+from openghg.types import SearchError
 
 from openghg.dataobjects import (
     BoundaryConditionsData,

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -2,6 +2,7 @@ import json
 import logging
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Union, cast
+from openghg.exceptions import SearchError
 
 from openghg.dataobjects import (
     BoundaryConditionsData,
@@ -16,6 +17,66 @@ from xarray import Dataset, load_dataset
 
 logger = logging.getLogger("openghg.retrieve")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
+
+DataTypes = Union[BoundaryConditionsData, FluxData, FootprintData, ObsColumnData, ObsData]
+multDataTypes = Union[List[BoundaryConditionsData], List[FluxData], List[FootprintData], List[ObsColumnData], List[ObsData]]
+
+
+def _get_generic(
+    sort: bool = True,
+    elevate_inlets: bool = False,
+    ambig_check_params: Optional[list] = None,
+    **kwargs: Any,
+) -> Any:
+    """Perform a search and create a dataclass object with the results if any are found.
+
+    Args:
+        data_class: Type of dataobject to create
+        sort: Sort Dataset during recombination
+        elevate_inlets: Elevate the inlet attribute to be a variable within the Dataset
+        ambig_check_params: Parameters to check and print if result is ambiguous.
+        kwargs: Search terms
+    Returns:
+        dataclass
+    """
+    from openghg.retrieve import search
+    from openghg.store.spec import define_data_type_classes
+
+    results = search(**kwargs)
+
+    keyword_string = _create_keyword_string(**kwargs)
+    if not results:
+        err_msg = f"Unable to find results for {keyword_string}"
+        logger.exception(err_msg)
+        raise SearchError(err_msg)
+
+    # TODO: UPDATE THIS - just use retrieve when retrieve_all is removed.
+    retrieved_data: Any = results.retrieve_all(sort=sort, elevate_inlet=elevate_inlets)
+
+    if retrieved_data is None:
+        err_msg = f"Unable to retrieve results for {keyword_string}"
+        logger.exception(err_msg)
+        raise SearchError(err_msg)
+    elif isinstance(retrieved_data, list) and len(retrieved_data) > 1:
+        param_diff_formatted = _metadata_difference_formatted(data=retrieved_data, params=ambig_check_params)
+        err_msg = f"""
+        Multiple entries found for input parameters for {keyword_string}.
+        Parameter differences:
+        {param_diff_formatted}
+        Please supply additional parameters or set ranking.
+        """
+        logger.exception(err_msg)
+        raise SearchError(err_msg)
+    elif isinstance(retrieved_data, list):
+        retrieved_data = retrieved_data[0]
+
+    # TODO: Included output of this as Any for now because we there are many
+    # options for types returned but can update this
+
+    # We can only get a single data object back here but mypy doesn't understand that
+    # retrieved_data = cast(ObsData, retrieved_data)
+
+    return retrieved_data
 
 
 def get_obs_surface(
@@ -163,38 +224,30 @@ def get_obs_surface_local(
             "This function cannot be used on the OpenGHG Hub. Please use openghg.retrieve.get_obs_surface instead."
         )
 
+    data_type = "surface"
+
     site_info = load_json(filename="acrg_site_info.json")
     site = site.upper()
 
+    # TODO: Evaluate this constraint - how do we want to handle and incorporate new sites?
     if site not in site_info:
         raise ValueError(f"No site called {site}, please enter a valid site name.")
 
-    # Get the observation data
-    obs_results = search_surface(
-        site=site,
-        species=species,
-        inlet=inlet,
-        start_date=start_date,
-        network=network,
-        end_date=end_date,
-        instrument=instrument,
-        # find_all=True,
-        # skip_ranking=skip_ranking,
-    )
+    surface_keywords = {
+        "site":site,
+        "species":species,
+        "inlet":inlet,
+        "start_date":start_date,
+        "end_date":end_date,
+        "network":network,
+        "instrument":instrument,
+        "data_type":data_type,
+    }
 
-    if not obs_results:
-        raise ValueError(f"Unable to find results for {species} at {site}")
-
-    retrieved_data: Union[ObsData, List[ObsData]] = obs_results.retrieve_all()
-
-    if retrieved_data is None:
-        print("No data returned.")
-        return None
-    elif isinstance(retrieved_data, list):
-        print(f"Multiple entries found for current input parameters - site: '{site}', species: '{species}'")
-        print("Please supply additional parameters or set ranking.")
-        metadata_difference(data=retrieved_data, params=["inlet", "network", "instrument"])
-        return None
+    # # Get the observation data
+    # obs_results = search_surface(**surface_keywords)
+    retrieved_data = _get_generic(ambig_check_params=["inlet", "network", "instrument"],
+                                  **surface_keywords)  # type:ignore
 
     data = retrieved_data.data
 
@@ -419,7 +472,7 @@ def get_flux(
     Returns:
         FluxData: FluxData object
     """
-    obs_data = _get_generic(
+    em_data = _get_generic(
         sort=False,
         species=species,
         source=source,
@@ -430,7 +483,7 @@ def get_flux(
         data_type="emissions",
     )
 
-    em_ds = obs_data.data
+    em_ds = em_data.data
     # Check for level coordinate. If one level, assume surface and drop
     if "lev" in em_ds.coords:
         if len(em_ds.lev) > 1:
@@ -438,7 +491,7 @@ def get_flux(
 
         em_ds = em_ds.drop_vars(names="lev")
 
-    return FluxData(data=obs_data.data, metadata=obs_data.metadata)
+    return FluxData(data=em_data.data, metadata=em_data.metadata)
 
 
 def get_bc(
@@ -462,7 +515,7 @@ def get_bc(
     Returns:
         BoundaryConditionsData: BoundaryConditionsData object
     """
-    obs_data = _get_generic(
+    bc_data = _get_generic(
         sort=False,
         species=species,
         bc_input=bc_input,
@@ -472,39 +525,7 @@ def get_bc(
         data_type="boundary_conditions",
     )
 
-    return BoundaryConditionsData(data=obs_data.data, metadata=obs_data.metadata)
-
-
-def _get_generic(
-    sort: bool = True,
-    elevate_inlets: bool = False,
-    **kwargs: Any,
-) -> ObsData:
-    """Perform a search and create a dataclass object with the results if any are found.
-
-    Args:
-        data_class: Type of dataobject to create
-        sort: Sort Dataset during recombination
-        elevate_inlets: Elevate the inlet attribute to be a variable within the Dataset
-        kwargs: Search terms
-    Returns:
-        dataclass
-    """
-    from openghg.retrieve import search
-
-    results = search(**kwargs)
-
-    if not results:
-        raise ValueError(f"Unable to find data. Please try other parameters.")
-
-    if len(results) > 1:
-        raise ValueError("Found more than one result, please narrow your search terms.")
-
-    obs_data = results.retrieve_all(sort=sort, elevate_inlet=elevate_inlets)
-    # We can only get a single ObsData back here but mypy doesn't understand that
-    obs_data = cast(ObsData, obs_data)
-
-    return obs_data
+    return BoundaryConditionsData(data=bc_data.data, metadata=bc_data.metadata)
 
 
 def get_footprint(
@@ -615,14 +636,24 @@ def _scale_convert(data: Dataset, species: str, to_scale: str) -> Dataset:
     return data
 
 
-multDataTypes = Union[List[ObsData], List[FootprintData], List[FluxData]]
-
-
-def metadata_difference(
-    data: multDataTypes, params: Optional[list] = None, print_output: bool = True
-) -> list:
+def _create_keyword_string(**kwargs: Any) -> str:
     """
-    Check differences between metadata for returned data objects.
+    Create a formatted string for supplied keyword values. This will ignore
+    keywords where the value is None.
+    This is used for printing details of keywords passed to the search functions.
+    """
+    used_keywords = {key: value for key, value in kwargs.items() if value is not None}
+    keyword_string = ', '.join([f"{key}='{value}'" for key, value in used_keywords.items()])
+
+    return keyword_string
+
+
+def _metadata_difference(
+    data: multDataTypes, params: Optional[list] = None, print_output: bool = True
+) -> Dict[str, list]:
+    """
+    Check differences between metadata for returned data objects. Note this will
+    only look at differences between values which are strings (not lists, floats etc.)
 
     Args:
         data : Multiple data objects e.g. multiple ObsData as a list
@@ -630,8 +661,9 @@ def metadata_difference(
         print_output : Summarise and print output to screen.
 
     Returns:
-        list : Keys from the metadata with differences
+        Dict[str, list] : Keys and lists of values from the metadata with differences.
     """
+    # Extract metadata dictionaries from each data object in list
     metadata = [d.metadata for d in data]
 
     if not metadata:
@@ -642,26 +674,69 @@ def metadata_difference(
     if params is not None:
         metadata = [{param: m[param] for param in params} for m in metadata]
 
+    ignore_params = ["uuid", "data_owner", "data_owner_email"]
+    if ignore_params is not None:
+        metadata = [{key: value for key, value in m.items() if key not in ignore_params} for m in metadata]
+
+    metadata = [{key: value for key, value in m.items() if isinstance(value, str)} for m in metadata]
+
     metadata0 = metadata[0]
     difference = []
     for metadata_compare in metadata[1:]:
-        metadata_diff = set(metadata0.items()) - set(metadata_compare.items())
-        difference.extend(list(metadata_diff))
+        try:
+            metadata_diff = set(metadata0.items()) - set(metadata_compare.items())
+        except TypeError:
+            logger.warning("Unable to compare metadata between ambiguous results")
+            return {}
+        else:
+            difference.extend(list(metadata_diff))
     param_difference = list(set([d[0] for d in difference]))
 
-    ignore_params = ["data_owner", "data_owner_email"]
-    for iparam in ignore_params:
-        try:
-            param_difference.remove(iparam)
-        except ValueError:
-            continue
+    # ignore_params = ["data_owner", "data_owner_email"]
+    # for iparam in ignore_params:
+    #     try:
+    #         param_difference.remove(iparam)
+    #     except ValueError:
+    #         continue
 
-    if print_output:
-        print("Datasets contain:")
-        for param in param_difference:
+    summary_difference: Dict[str, list] = {}
+    for param in param_difference:
+        summary_difference[param] = []
+        if print_output:
             print(f" {param}: ", end="")
-            for m in metadata:
+        for m in metadata:
+            summary_difference[param].append(m[param])
+            if print_output:
                 print(f" '{m[param]}', ", end="")
+        if print_output:
             print()  # print new line
 
-    return param_difference
+    # if print_output:
+    #     print("Datasets contain:")
+    #     for param in param_difference:
+    #         print(f" {param}: ", end="")
+    #         for m in metadata:
+    #             print(f" '{m[param]}', ", end="")
+    #         print()  # print new line
+
+    return summary_difference
+
+
+def _metadata_difference_formatted(data: multDataTypes,
+                                   params: Optional[list] = None,
+                                   print_output: bool = True) -> str:
+    """
+    Create formatted string for the difference in metadata between input objects.
+
+    Args:
+        data : Multiple data objects e.g. multiple ObsData as a list
+        params : Specific metadata parameters to check. If None all parameters will be checked
+        print_output : Summarise and print output to screen.
+
+    Returns:
+        str : Formatted string summarising differences in keys and sets of values
+              from the metadata.
+    """
+    param_difference = _metadata_difference(data, params, print_output)
+    formatted = "\n".join([f" - {key}: {', '.join(values)}" for key, values in param_difference.items()])
+    return formatted

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -107,6 +107,8 @@ def search_bc(
     species: Optional[str] = None,
     bc_input: Optional[str] = None,
     domain: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     period: Optional[Union[str, tuple]] = None,
     continuous: Optional[bool] = None,
 ) -> SearchResults:
@@ -118,6 +120,8 @@ def search_bc(
             - a model name such as "MOZART" or "CAMS"
             - a description such as "UniformAGAGE" (uniform values based on AGAGE average)
         domain: Region for boundary conditions
+        start_date: Start date (inclusive) for boundary conditions
+        end_date: End date (exclusive) for boundary conditions
         period: Period of measurements. Only needed if this can not be inferred from the time coords
                 If specified, should be one of:
                     - "yearly", "monthly"
@@ -127,10 +131,18 @@ def search_bc(
     Returns:
         SearchResults: SearchResults object
     """
+
+    if start_date is not None:
+        start_date = str(start_date)
+    if end_date is not None:
+        end_date = str(end_date)
+
     return search(
         species=species,
         bc_input=bc_input,
         domain=domain,
+        start_date=start_date,
+        end_date=end_date,
         period=period,
         continuous=continuous,
         data_type="boundary_conditions",
@@ -153,6 +165,12 @@ def search_eulerian(
     Returns:
         SearchResults: SearchResults object
     """
+
+    if start_date is not None:
+        start_date = str(start_date)
+    if end_date is not None:
+        end_date = str(end_date)
+
     return search(
         model=model, species=species, start_date=start_date, end_date=end_date, data_type="eulerian_model"
     )
@@ -162,7 +180,9 @@ def search_emissions(
     species: Optional[str] = None,
     source: Optional[str] = None,
     domain: Optional[str] = None,
-    date: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    date: Optional[str] = None,  # May want to remove this?
     high_time_resolution: Optional[bool] = None,
     period: Optional[Union[str, tuple]] = None,
     continuous: Optional[bool] = None,
@@ -185,10 +205,18 @@ def search_emissions(
     Returns:
         SearchResults: SearchResults object
     """
+
+    if start_date is not None:
+        start_date = str(start_date)
+    if end_date is not None:
+        end_date = str(end_date)
+
     return search(
         species=species,
         source=source,
         domain=domain,
+        start_date=start_date,
+        end_date=end_date,
         date=date,
         high_time_resolution=high_time_resolution,
         period=period,
@@ -204,6 +232,8 @@ def search_footprints(
     model: Optional[str] = None,
     metmodel: Optional[str] = None,
     species: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     network: Optional[str] = None,
     period: Optional[Union[str, tuple]] = None,
     continuous: Optional[bool] = None,
@@ -232,6 +262,12 @@ def search_footprints(
     Returns:
         SearchResults: SearchResults object
     """
+
+    if start_date is not None:
+        start_date = str(start_date)
+    if end_date is not None:
+        end_date = str(end_date)
+
     return search(
         site=site,
         height=height,
@@ -240,6 +276,8 @@ def search_footprints(
         metmodel=metmodel,
         species=species,
         network=network,
+        start_date=start_date,
+        end_date=end_date,
         period=period,
         continuous=continuous,
         high_spatial_res=high_spatial_res,

--- a/openghg/types/__init__.py
+++ b/openghg/types/__init__.py
@@ -13,5 +13,6 @@ from ._errors import (
     InvalidSiteError,
     ObjectStoreError,
     UnknownDataError,
+    SearchError,
 )
 from ._types import multiPathType, pathType, resultsType

--- a/openghg/types/_errors.py
+++ b/openghg/types/_errors.py
@@ -1,20 +1,25 @@
-class InvalidSiteError(Exception):
+
+class OpenGHGError(Exception):
+    """Top level OpenGHG error"""
+
+
+class InvalidSiteError(OpenGHGError):
     """Raised if an invalid site is passed"""
 
 
-class UnknownDataError(Exception):
+class UnknownDataError(OpenGHGError):
     """Raised if an unknown data type is passed"""
 
 
-class FunctionError(Exception):
+class FunctionError(OpenGHGError):
     """Raised if a serverless function cannot be called correctly"""
 
 
-class ObjectStoreError(Exception):
+class ObjectStoreError(OpenGHGError):
     """Raised if an error accessing an object at a key in the object store occurs"""
 
 
-class DatasourceLookupError(Exception):
+class DatasourceLookupError(OpenGHGError):
     """Raised if Datasource lookup fails"""
 
 
@@ -22,9 +27,13 @@ class EncodingError(ObjectStoreError):
     pass
 
 
-class MutexTimeoutError(Exception):
+class MutexTimeoutError(OpenGHGError):
     pass
 
 
-class RequestBucketError(Exception):
+class RequestBucketError(OpenGHGError):
     pass
+
+
+class SearchError(OpenGHGError):
+    """Related to searching the object store"""

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -259,9 +259,6 @@ def test_scenario_too_few_inputs():
     # Explicitly not including inlet to test this can be inferred.
     model_scenario = ModelScenario(site=site)
 
-    # TODO: This may be updated to be include empty ObsData() class
-    # May need to include:
-    # assert model_scenario.obs.data is None
     assert model_scenario.obs is None
 
     # TODO: get_footprint() is not currently returning None - check this

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -14,7 +14,7 @@ from helpers import (
 from openghg.dataobjects import ObsData
 from openghg.retrieve import get_flux, get_footprint, get_obs_column, get_obs_surface, search
 from openghg.util import compress, compress_str, hash_bytes
-from openghg.exceptions import SearchError
+from openghg.types import SearchError
 from pandas import Timedelta, Timestamp
 
 # a = [

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -14,6 +14,7 @@ from helpers import (
 from openghg.dataobjects import ObsData
 from openghg.retrieve import get_flux, get_footprint, get_obs_column, get_obs_surface, search
 from openghg.util import compress, compress_str, hash_bytes
+from openghg.exceptions import SearchError
 from pandas import Timedelta, Timestamp
 
 # a = [
@@ -62,9 +63,30 @@ def test_get_obs_surface():
     assert not time.equals(averaged_time)
 
 
-# def test_no_inlet_no_ranked_data_raises():
-#     with pytest.raises(ValueError):
-#         get_obs_surface(site="bsd", species="co2")
+def test_ambiguous_no_ranked_data_raises():
+    """
+    Test sensible error message is raised when result is ambiguous for
+    get_obs_surface() function
+    """
+    with pytest.raises(SearchError) as excinfo:
+        get_obs_surface(site="bsd", species="co2")
+        assert "Multiple entries found for input parameters" in excinfo
+
+
+def test_no_data_raises():
+    """
+    Test sensible error message is raised when no data can be found
+    get_obs_surface() function
+    """
+    with pytest.raises(SearchError) as excinfo:
+        site = "bsd"
+        species = "cfc11"
+        get_obs_surface(site=site, species=species)
+
+        assert "Unable to find results for" in excinfo
+        assert f"site='{site}'" in excinfo
+        assert f"species='{species}'" in excinfo
+
 
 
 # def test_get_obs_surface_ranked_data_only():
@@ -282,8 +304,14 @@ def test_get_flux():
 
 
 def test_get_flux_no_result():
-    with pytest.raises(ValueError):
+    """Test sensible error message is being returned when no results are found 
+    with input keywords for get_flux function"""
+    with pytest.raises(SearchError) as execinfo:
         get_flux(species="co2", source="cinnamon", domain="antarctica")
+        assert "Unable to find results" in execinfo
+        assert "species='co2'" in execinfo
+        assert "source='cinnamon'" in execinfo
+        assert "domain='antarctica'" in execinfo
 
 
 def test_get_footprint():
@@ -303,5 +331,13 @@ def test_get_footprint():
 
 
 def test_get_footprint_no_result():
-    with pytest.raises(ValueError):
+    """Test sensible error message is being returned when no results are found 
+    with input keywords for get_footprint function"""
+    with pytest.raises(SearchError) as execinfo:
         get_footprint(site="seville", domain="spain", height="10m", model="test_model")
+        assert "Unable to find results" in execinfo
+        assert "site='seville'" in execinfo
+        assert "domain='spain'" in execinfo
+        assert "height='10m'" in execinfo
+        assert "model='test_model'" in execinfo
+


### PR DESCRIPTION
Ensuring behaviour for openghg.retrieve.get_* functions is consistent and adding custom `SearchError` function for openghg
 - If no results found returns a `SearchError` with helpful message (restates keys which were passed in)
 - If multiple results are found returns `SearchError` with helpful message (compares metadata and prints differences)
 - All functions (including get_obs_surface_local) are now fed through _get_generic function

`openghg.analyse._scenario` has also been updated to account for this behaviour (interface and output from ModelScenario class and methods should be the same).

Closes #297, #416