### PR TITLE
Fixes for parsing surface NetCDFs using `parse_openghg`

### DIFF
--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -13,6 +13,7 @@ def standardise_surface(
     inlet: Optional[str] = None,
     instrument: Optional[str] = None,
     sampling_period: Optional[str] = None,
+    calibration_scale: Optional[str] = None,
     overwrite: bool = False,
 ) -> Optional[Dict]:
     """Standardise surface measurements and store the data in the object store.

--- a/openghg/standardise/surface/_icos.py
+++ b/openghg/standardise/surface/_icos.py
@@ -190,8 +190,14 @@ def _read_data_large_header(
 
     df = df.rename(columns=rename_dict)
 
+    print(df.dtypes)
+
     # Convert to xarray Dataset
     data = df.to_xarray()
+
+    data["flag"] = data["flag"].astype(str)
+
+    print(data.dtypes)
 
     if file_sampling_period == "1minute":
         file_sampling_period = "60.0"

--- a/openghg/standardise/surface/_openghg.py
+++ b/openghg/standardise/surface/_openghg.py
@@ -43,16 +43,11 @@ def parse_openghg(
         data_owner: Name of data owner.
         data_owner_email: Email address for data owner.
         kwargs: Any additional attributes to be associated with the data.
-
     Returns:
-        Dict : Dictionary of source_name : data, metadata, attributes
+        Dict: Dictionary of source_name : data, metadata, attributes
     """
     from openghg.util import clean_string, load_json
-    from openghg.standardise.meta import (
-        metadata_default_keys,
-        define_species_label,
-        assign_attributes
-    )
+    from openghg.standardise.meta import metadata_default_keys, define_species_label, assign_attributes
 
     data_filepath = Path(data_filepath)
 
@@ -79,11 +74,14 @@ def parse_openghg(
 
     # TODO: Decide if to allow any of these to be missed.
 
+    # Run some checks on the
+    data_attrs = {k.lower().replace(" ", "_"): v for k, v in data.attrs.items()}
+
     # Populate metadata with values from attributes if inputs have not been passed
     for key, value in metadata_initial.items():
         if value is None:
             try:
-                metadata_initial[key] = attributes[key]
+                metadata_initial[key] = data_attrs[key]
             except KeyError:
                 raise ValueError(f"Input '{key}' must be specified if not included in data attributes.")
         else:

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -104,6 +104,7 @@ class ObsSurface(BaseStore):
         inlet: Optional[str] = None,
         instrument: Optional[str] = None,
         sampling_period: Optional[str] = None,
+        calibration_scale: Optional[str] = None,
         measurement_type: str = "insitu",
         overwrite: bool = False,
         verify_site_code: bool = True,
@@ -220,6 +221,7 @@ class ObsSurface(BaseStore):
                         instrument=instrument,
                         sampling_period=sampling_period_seconds,
                         measurement_type=measurement_type,
+                        calibration_scale=calibration_scale,
                     )
 
                 # Current workflow: if any species fails, whole filepath fails


### PR DESCRIPTION
This adds being ablet to pass in `calibration_scale` and adds case insensitive / space removing checking of attribute keys.