### PR TITLE
Adding inlet as keyword and allowing height as an alias for both footprints and obs_surface

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -287,8 +287,8 @@ class ModelScenario:
 
             if height is not None and inlet is None:
                 inlet = height
-            inlet = format_inlet(inlet)
             inlet = clean_string(inlet)
+            inlet = format_inlet(inlet)
 
             # search for obs based on suitable keywords - site, species, inlet
             obs_keywords = {
@@ -335,11 +335,11 @@ class ModelScenario:
                 inlet = self.obs.metadata["inlet"]
             elif inlet is None and height is not None:
                 inlet = height                        
-                inlet = format_inlet(inlet)
                 inlet = clean_string(inlet)
+                inlet = format_inlet(inlet)
             else:
-                inlet = format_inlet(inlet)
                 inlet = clean_string(inlet)
+                inlet = format_inlet(inlet)
 
             # TODO: Add case to deal with "multiple" inlets
             if inlet == "multiple":

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -3,7 +3,7 @@
 
 """
 import logging
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union
 
 from openghg.dataobjects import SearchResults
 from openghg.store import load_metastore
@@ -343,7 +343,7 @@ def search_surface(
     if inlet is None and height is not None:
         inlet = height
     if isinstance(inlet, list):
-        inlet = [cast(str, format_inlet(value)) for value in inlet]
+        inlet = [format_inlet(value) for value in inlet]
     else:
         inlet = format_inlet(inlet)
 

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -227,9 +227,10 @@ def search_emissions(
 
 def search_footprints(
     site: Optional[str] = None,
-    height: Optional[str] = None,
+    inlet: Optional[str] = None,
     domain: Optional[str] = None,
     model: Optional[str] = None,
+    height: Optional[str] = None,
     metmodel: Optional[str] = None,
     species: Optional[str] = None,
     start_date: Optional[str] = None,
@@ -245,9 +246,10 @@ def search_footprints(
 
     Args:
         site: Site name
-        height: Height above ground level in metres
+        inlet: Height above ground level in metres
         domain: Domain of footprints
         model: Model used to create footprint (e.g. NAME or FLEXPART)
+        height: Alias for inlet
         metmodel: Underlying meteorlogical model used (e.g. UKV)
         species: Species name. Only needed if footprint is for a specific species e.g. co2 (and not inert)
         network: Network name
@@ -262,14 +264,21 @@ def search_footprints(
     Returns:
         SearchResults: SearchResults object
     """
+    from openghg.util import format_inlet
 
     if start_date is not None:
         start_date = str(start_date)
     if end_date is not None:
         end_date = str(end_date)
 
+    # Allow inlet or height to be specified, both or either may be included
+    # within the metadata so could use either to search
+    inlet = format_inlet(inlet)
+    height = format_inlet(height)
+
     return search(
         site=site,
+        inlet=inlet,
         height=height,
         domain=domain,
         model=model,
@@ -291,6 +300,7 @@ def search_surface(
     species: Union[str, List[str], None] = None,
     site: Union[str, List[str], None] = None,
     inlet: Union[str, List[str], None] = None,
+    height: Union[str, List[str], None] = None,
     instrument: Union[str, List[str], None] = None,
     measurement_type: Union[str, List[str], None] = None,
     source_format: Union[str, List[str], None] = None,
@@ -306,7 +316,8 @@ def search_surface(
     Args:
         species: Species
         site: Three letter site code
-        inlet: Inlet height
+        inlet: Inlet height above ground level in metres
+        height: Alias for inlet
         instrument: Instrument name
         measurement_type: Measurement type
         data_type: Data type e.g. "surface", "column", "emissions"
@@ -320,10 +331,18 @@ def search_surface(
     Returns:
         SearchResults: SearchResults object
     """
+    from openghg.util import format_inlet
+
     if start_date is not None:
         start_date = str(start_date)
     if end_date is not None:
         end_date = str(end_date)
+
+    # Allow height to be an alias for inlet but we do not expect height
+    # to be within the metadata (for now)
+    if inlet is None and height is not None:
+        inlet = height
+    inlet = format_inlet(inlet)
 
     results = search(
         species=species,

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -3,7 +3,7 @@
 
 """
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
 from openghg.dataobjects import SearchResults
 from openghg.store import load_metastore
@@ -342,7 +342,10 @@ def search_surface(
     # to be within the metadata (for now)
     if inlet is None and height is not None:
         inlet = height
-    inlet = format_inlet(inlet)
+    if isinstance(inlet, list):
+        inlet = [cast(str, format_inlet(value)) for value in inlet]
+    else:
+        inlet = format_inlet(inlet)
 
     results = search(
         species=species,

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -186,9 +186,10 @@ class Footprints(BaseStore):
     def read_file(
         filepath: Union[str, Path],
         site: str,
-        height: str,
         domain: str,
         model: str,
+        inlet: Optional[str] = None,
+        height: Optional[str] = None,
         metmodel: Optional[str] = None,
         species: Optional[str] = None,
         network: Optional[str] = None,
@@ -208,9 +209,10 @@ class Footprints(BaseStore):
         Args:
             filepath: Path of file to load
             site: Site name
-            height: Height above ground level in metres
             domain: Domain of footprints
             model: Model used to create footprint (e.g. NAME or FLEXPART)
+            inlet: Height above ground level in metres. Format 'NUMUNIT' e.g. "10m"
+            height: Alias for inlet. One of height or inlet must be included.
             metmodel: Underlying meteorlogical model used (e.g. UKV)
             species: Species name. Only needed if footprint is for a specific species e.g. co2 (and not inert)
             network: Network name
@@ -229,14 +231,24 @@ class Footprints(BaseStore):
         # from xarray import load_dataset
         import xarray as xr
         from openghg.store import assign_data, datasource_lookup, infer_date_range, load_metastore
-        from openghg.util import clean_string, hash_file, species_lifetime, timestamp_now
+        from openghg.util import clean_string, format_inlet, hash_file, species_lifetime, timestamp_now
 
         filepath = Path(filepath)
 
         site = clean_string(site)
         network = clean_string(network)
-        height = clean_string(height)
         domain = clean_string(domain)
+
+        # Make sure `inlet` OR the alias `height` is included
+        # Note: from this point only `inlet` variable should be used.
+        if inlet is None and height is None:
+            raise ValueError("One of inlet (or height) must be specified as an input")
+        elif inlet is None:
+            inlet = height
+
+        # Try to ensure inlet is 'NUM''UNIT' e.g. "10m"
+        inlet = clean_string(inlet)
+        inlet = format_inlet(inlet)
 
         fp = Footprints.load()
 
@@ -285,9 +297,12 @@ class Footprints(BaseStore):
 
         metadata["data_type"] = "footprints"
         metadata["site"] = site
-        metadata["height"] = height
         metadata["domain"] = domain
         metadata["model"] = model
+
+        # Include both inlet and height keywords for backwards compatability
+        metadata["inlet"] = inlet
+        metadata["height"] = inlet
 
         if species is not None:
             metadata["species"] = clean_string(species)
@@ -343,7 +358,7 @@ class Footprints(BaseStore):
 
         # This might seem longwinded now but will help when we want to read
         # more than one footprints at a time
-        key = "_".join((site, domain, model, height))
+        key = "_".join((site, domain, model, inlet))
 
         footprint_data: DefaultDict[str, Dict[str, Union[Dict, Dataset]]] = defaultdict(dict)
         footprint_data[key]["data"] = fp_data
@@ -352,7 +367,7 @@ class Footprints(BaseStore):
         # These are the keys we will take from the metadata to search the
         # metadata store for a Datasource, they should provide as much detail as possible
         # to uniquely identify a Datasource
-        required = ("site", "model", "height", "domain")
+        required = ("site", "model", "inlet", "domain")
         lookup_results = datasource_lookup(metastore=metastore, data=footprint_data, required_keys=required)
 
         data_type = "footprints"

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import DefaultDict, Dict, Literal, List, Optional, Tuple, Union
+from typing import DefaultDict, Dict, Literal, List, Optional, Tuple, Union, cast
 
 import numpy as np
 from openghg.store import DataSchema
@@ -249,6 +249,7 @@ class Footprints(BaseStore):
         # Try to ensure inlet is 'NUM''UNIT' e.g. "10m"
         inlet = clean_string(inlet)
         inlet = format_inlet(inlet)
+        inlet = cast(str, inlet)
 
         fp = Footprints.load()
 

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -102,6 +102,7 @@ class ObsSurface(BaseStore):
         network: str,
         site: str,
         inlet: Optional[str] = None,
+        height: Optional[str] = None,
         instrument: Optional[str] = None,
         sampling_period: Optional[str] = None,
         calibration_scale: Optional[str] = None,
@@ -118,7 +119,10 @@ class ObsSurface(BaseStore):
             source_format: Data format, for example CRDS, GCWERKS
             site: Site code/name
             network: Network name
-            inlet: Inlet height. If retrieve multiple files pass None, OpenGHG will attempt to
+            inlet: Inlet height. Format 'NUMUNIT' e.g. "10m".
+                If retrieve multiple files pass None, OpenGHG will attempt to
+                extract this from the file.
+            height: Alias for inlet.
             read inlets from data.
             instrument: Instrument name
             sampling_period: Sampling period in pandas style (e.g. 2H for 2 hour period, 2m for 2 minute period).
@@ -136,7 +140,7 @@ class ObsSurface(BaseStore):
 
         from openghg.store import assign_data, datasource_lookup, load_metastore
         from openghg.types import SurfaceTypes
-        from openghg.util import clean_string, hash_file, load_surface_parser, verify_site
+        from openghg.util import clean_string, format_inlet, hash_file, load_surface_parser, verify_site
         from pandas import Timedelta
         from tqdm import tqdm
 
@@ -153,9 +157,16 @@ class ObsSurface(BaseStore):
         # Clean the strings
         site = verify_site(site=site) if verify_site_code else clean_string(site)
         network = clean_string(network)
-        inlet = clean_string(inlet)
         instrument = clean_string(instrument)
         # sampling_period = clean_string(sampling_period)
+
+        # Check if alias `height` is included instead of `inlet`
+        if inlet is None and height is not None:
+            inlet = height        
+
+        # Try to ensure inlet is 'NUM''UNIT' e.g. "10m"
+        inlet = clean_string(inlet)
+        inlet = format_inlet(inlet)
 
         sampling_period_seconds: Union[str, None] = None
         # If we have a sampling period passed we want the number of seconds

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -23,6 +23,7 @@ from ._file import (
     read_header,
 )
 from ._hashing import hash_bytes, hash_file, hash_retrieved_data, hash_string
+from ._inlet import format_inlet
 from ._species import check_lifetime_monthly, molar_mass, species_lifetime, synonyms
 from ._strings import clean_string, is_number, remove_punctuation, to_lowercase
 from ._time import (

--- a/openghg/util/_inlet.py
+++ b/openghg/util/_inlet.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+
+def format_inlet(inlet: Optional[str],
+                 special_keywords: Optional[list] = None) -> Optional[str]:
+    """
+    Make sure inlet name conforms to standard of number followed by unit
+    (or is one of the special keywords).
+    If the string just contains numbers, it is assumed this is in metres and
+    units of "m" will be added.
+
+    e.g. "10m" not "10" or "10magl"
+
+    Args:
+        inlet: Height above ground level
+        special_keywords: Specify special keywords inlet could be set to
+            If so do not apply any formatting.
+            If this is not set a special keyword of "multiple" and "column" will still be allowed.
+
+    Returns:
+        str: formatted inlet string / None
+    """
+
+    if inlet is None:
+        return None
+
+    # By default the special keyword is "multiple" for data containing multiple inlets.
+    # This will be included if data is a combined object from the object store.
+    if special_keywords is None:
+        special_keywords = ["multiple", "column"]
+
+    # Check if inlet is set to a special keyword
+    if inlet in special_keywords:
+        return inlet
+
+    # Check if input inlet just contains numbers and no unit
+    # If so assume the units are metres and add this to the end of the string
+    try:
+        float(inlet)
+    except ValueError:
+        pass
+    else:
+        inlet = inlet + "m"
+
+    # Check if inlet ends with "magl" rather than just "m"
+    # If so remove the end "agl" to just include the "m" value
+    if inlet.endswith("magl"):
+        inlet = inlet.rstrip("lga")
+
+    return inlet

--- a/openghg/util/_inlet.py
+++ b/openghg/util/_inlet.py
@@ -1,10 +1,18 @@
-from typing import Optional
+from typing import Optional, overload
 
 
-def format_inlet(inlet: Optional[str],
-                 special_keywords: Optional[list] = None) -> Optional[str]:
-    """
-    Make sure inlet name conforms to standard of number followed by unit
+@overload
+def format_inlet(inlet: str, special_keywords: Optional[list] = None) -> str:
+    ...
+
+
+@overload
+def format_inlet(inlet: None, special_keywords: Optional[list] = None) -> None:
+    ...
+
+
+def format_inlet(inlet: Optional[str], special_keywords: Optional[list] = None) -> Optional[str]:
+    """Make sure inlet name conforms to standard of number followed by unit
     (or is one of the special keywords).
     If the string just contains numbers, it is assumed this is in metres and
     units of "m" will be added.
@@ -16,11 +24,9 @@ def format_inlet(inlet: Optional[str],
         special_keywords: Specify special keywords inlet could be set to
             If so do not apply any formatting.
             If this is not set a special keyword of "multiple" and "column" will still be allowed.
-
     Returns:
         str: formatted inlet string / None
     """
-
     if inlet is None:
         return None
 
@@ -47,4 +53,4 @@ def format_inlet(inlet: Optional[str],
     if inlet.endswith("magl"):
         inlet = inlet.rstrip("lga")
 
-    return inlet
+    return str(inlet)

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -41,8 +41,21 @@ from pandas import Timedelta, Timestamp
 # ]
 
 
-def test_get_obs_surface():
-    obsdata = get_obs_surface(site="bsd", species="co2", inlet="248m")
+@pytest.mark.parametrize(
+    "inlet_keyword,inlet_value",
+    [
+        ("inlet", "248m"),
+        ("height", "248m"),
+        ("inlet", "248magl"),
+        ("inlet", "248"),
+    ],
+)
+def test_get_obs_surface(inlet_keyword, inlet_value):
+
+    if inlet_keyword == "inlet":
+        obsdata = get_obs_surface(site="bsd", species="co2", inlet=inlet_value)
+    elif inlet_keyword == "height":
+        obsdata = get_obs_surface(site="bsd", species="co2", height=inlet_value)
     co2_data = obsdata.data
 
     assert co2_data.time[0] == Timestamp("2014-01-30T11:12:30")
@@ -313,9 +326,20 @@ def test_get_flux_no_result():
         assert "source='cinnamon'" in execinfo
         assert "domain='antarctica'" in execinfo
 
-
-def test_get_footprint():
-    fp_result = get_footprint(site="tmb", domain="europe", height="10m", model="test_model")
+@pytest.mark.parametrize(
+    "inlet_keyword,inlet_value",
+    [
+        ("inlet", "10m"),
+        ("height", "10m"),
+        ("inlet", "10magl"),
+        ("inlet", "10"),
+    ],
+)
+def test_get_footprint(inlet_keyword,inlet_value):
+    if inlet_keyword == "inlet":
+        fp_result = get_footprint(site="tmb", domain="europe", inlet=inlet_value, model="test_model")
+    elif inlet_keyword == "height":
+        fp_result = get_footprint(site="tmb", domain="europe", height=inlet_value, model="test_model")
 
     footprint = fp_result.data
     metadata = fp_result.metadata
@@ -340,4 +364,3 @@ def test_get_footprint_no_result():
         assert "domain='spain'" in execinfo
         assert "height='10m'" in execinfo
         assert "model='test_model'" in execinfo
-

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -1,3 +1,4 @@
+import pytest
 from openghg.retrieve import (
     search,
     search_bc,
@@ -9,12 +10,24 @@ from openghg.retrieve import (
 )
 
 
-def test_search_surface():
+@pytest.mark.parametrize(
+    "inlet_keyword,inlet_value",
+    [
+        ("inlet", "50m"),
+        ("height", "50m"),
+        ("inlet", "50magl"),
+        ("inlet", "50"),
+    ],
+)
+def test_search_surface(inlet_keyword, inlet_value):
     res = search_surface(site="hfd")
 
     assert len(res.metadata) == 6
 
-    res = search_surface(site="hfd", inlet="50m", species="co2")
+    if inlet_keyword == "inlet":
+        res = search_surface(site="hfd", inlet=inlet_value, species="co2")
+    elif inlet_keyword == "height":
+        res = search_surface(site="hfd", height=inlet_value, species="co2")
 
     key = next(iter(res.metadata))
 
@@ -151,15 +164,27 @@ def test_nonsense_terms():
 
     assert not res
 
+@pytest.mark.parametrize(
+    "inlet_keyword,inlet_value",
+    [
+        ("inlet", "10m"),
+        ("height", "10m"),
+        ("inlet", "10magl"),
+        ("inlet", "10"),
+    ],
+)
+def test_search_footprints(inlet_keyword,inlet_value):
 
-def test_search_footprints():
-    res = search_footprints(site="TMB", network="LGHG", height="10m", domain="EUROPE", model="test_model")
+    if inlet_keyword == "inlet":
+        res = search_footprints(site="TMB", network="LGHG", inlet=inlet_value, domain="EUROPE", model="test_model")
+    elif inlet_keyword == "height":
+        res = search_footprints(site="TMB", network="LGHG", height=inlet_value, domain="EUROPE", model="test_model")
 
     key = next(iter(res.metadata))
     partial_metadata = {
         "data_type": "footprints",
         "site": "tmb",
-        "height": "10m",
+        "inlet": "10m",
         "domain": "europe",
         "model": "test_model",
         "network": "lghg",

--- a/tests/util/test_inlet.py
+++ b/tests/util/test_inlet.py
@@ -1,0 +1,35 @@
+import pytest
+from openghg.util import format_inlet
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("10m", "10m"),
+        ("12.2m", "12.2m"),
+        ("123", "123m"),
+        ("123.45", "123.45m"),
+        ("10magl", "10m"),
+        ("13.3magl", "13.3m"),
+        ("multiple", "multiple"),
+        ("column", "column"),
+        (None, None),
+    ],
+)
+def test_format_inlet(test_input, expected):
+    """
+    Test format_inlet formats inlet names in the right way including expected
+    special keywords ("multiple") and None.
+    """
+    output = format_inlet(test_input)
+    assert output == expected
+
+
+def test_format_inlet_special():
+    """
+    Test new special keywords can be specified
+    """
+    special_keyword = "special"
+
+    output = format_inlet(special_keyword, special_keywords=[special_keyword])
+    assert output == special_keyword


### PR DESCRIPTION
At the moment, we have an input of `inlet` for ObsSurface data and `height` for Footprint data when they should represent the same property (and most of the time will be equivalent). 

This update makes the following changes:
 - Adds "inlet" as an additional input and metadata keyword within the `Footprint.read_file()` method
     -  This still retains "height" for backwards compatability but this should always be the same as the `inlet` value
     - Adds "inlet" to both `search_footprints` and `get_footprint` functions. Either inlet or height can be used to search.
 - Also allows "height" as an alias input for "inlet" within `ObsSurface.read_file`
     -  "height" is not added to the metadata here as this is not needed for backwards compatability
     - Adds "height" to both `search_surface` and `get_obs_surface` functions. Either "inlet" or "height" can be used to search (both will link to inlet metadata keyword)
 - Added new util function around inlets to try and apply additional formatting rules to this - should be 'NUM''UNIT' e.g. "20m" not "20magl" or "20". Incorporated into relevant functions mentioned above.

Additional tests added to check this.

Closes #466 