### PR TITLE
Fix conda install instructions

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -6,9 +6,8 @@ dependencies:
   - addict
   - dask
   - h5netcdf
-  - icoscp
   - matplotlib
-  - msgpack
+  - msgpack-python
   - numexpr
   - numpy
   - nc-time-axis

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python >= 3.8
   - addict
   - dask
   - h5netcdf
@@ -24,3 +25,5 @@ dependencies:
   - urllib3 >= 1.26.3
   - pip
   - xesmf
+  - pip:
+    - icoscp


### PR DESCRIPTION
Moved `icoscp` to pip section of environment.yaml and corrected `msgpack` package name to `msgpack-python`.

Need to do some additional checks to make sure this works correctly so a draft for now.