### PR TITLE
Added fixes for warnings related to _scenario.py

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -250,17 +250,15 @@ class ModelScenario:
                 num = i + 1
                 if num == num_checks:
                     print(f"Unable to add {data_type} data based on keywords supplied.")
-                    print(" Inputs - \n")
+                    print(" Inputs -")
                     for key, value in keyword_set.items():
-                        print(f" {key}: {value}\n")
+                        print(f" {key}: {value}")
                     if search_fn is not None:
                         data_search = search_fn(**keyword_set)  # type:ignore
                         print("---- Search results ---")
                         print(f"Number of results returned: {len(data_search)}")
-                        print(data_search)
-                        # TODO: If we can determine how many results are returned from search
-                        # we can use this to give better information about why no data has
-                        # been found for these inputs.
+                        print(data_search.results)
+                    print("\n")
                 data = None
             else:
                 print(f"Adding {data_type} to model scenario")
@@ -1178,7 +1176,7 @@ class ModelScenario:
 
         # Create times for matching to the flux
         full_dates = date_range(
-            date_start_back.values, date_end.values, freq=highest_resolution, closed="left"
+            date_start_back.values, date_end.values, freq=highest_resolution, inclusive="left"
         ).to_numpy()
 
         # Create low frequency flux data (monthly)

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -273,14 +273,24 @@ def get_obs_surface_local(
         retrieved_data.metadata["inlet"] = "multiple"
 
     if start_date is not None and end_date is not None:
-        start_date_tzaware = timestamp_tzaware(start_date)
-        end_date_tzaware = timestamp_tzaware(end_date)
-        end_date_tzaware_exclusive = end_date_tzaware - Timedelta(
-            1, unit="nanosecond"
-        )  # Deduct 1 ns to make the end day (date) exclusive.
+        
+        # Check if underlying data is timezone aware.
+        data_time_index = data.indexes["time"]
+        tzinfo = data_time_index.tzinfo
+
+        if tzinfo:
+            start_date_filter = timestamp_tzaware(start_date)
+            end_date_filter = timestamp_tzaware(end_date)
+        else:
+            start_date_filter = Timestamp(start_date)
+            end_date_filter = Timestamp(end_date)
+
+        end_date_filter_exclusive = end_date_filter - Timedelta(
+                1, unit="nanosecond"
+            )  # Deduct 1 ns to make the end day (date) exclusive.
 
         # Slice the data to only cover the dates we're interested in
-        data = data.sel(time=slice(start_date_tzaware, end_date_tzaware_exclusive))
+        data = data.sel(time=slice(start_date_filter, end_date_filter_exclusive))
 
     try:
         start_date_data = timestamp_tzaware(data.time[0].values)

--- a/openghg/standardise/meta/_attributes.py
+++ b/openghg/standardise/meta/_attributes.py
@@ -112,6 +112,7 @@ def get_attributes(
     # Is this better?
     variable_names = cast(Dict[str, Any], ds.variables)
     to_underscores = {var: var.lower().replace(" ", "_") for var in variable_names}
+    to_underscores.pop("time")  # Added to remove warning around resetting time index.
     ds = ds.rename(to_underscores)  # type: ignore
 
     species_lower = species.lower()

--- a/openghg/standardise/surface/_crds.py
+++ b/openghg/standardise/surface/_crds.py
@@ -182,11 +182,11 @@ def _read_data(
         ]
 
         # Name columns
-        gas_data = gas_data.set_axis(column_labels, axis="columns", inplace=False)
+        gas_data = gas_data.set_axis(column_labels, axis="columns")
 
         header_rows = 2
         # Drop the first two rows now we have the name
-        gas_data = gas_data.drop(index=gas_data.head(header_rows).index, inplace=False)
+        gas_data = gas_data.drop(index=gas_data.head(header_rows).index)
         gas_data.index = to_datetime(gas_data.index, format="%y%m%d %H%M%S")
         # Cast data to float64 / double
         gas_data = gas_data.astype("float64")

--- a/openghg/store/_infer_time.py
+++ b/openghg/store/_infer_time.py
@@ -107,7 +107,7 @@ def infer_date_range(
                 time_value, time_unit = inferred_freq
 
         # Check input period against inferred period
-        if inferred_freq != freq:
+        if inferred_freq != freq and period is not None:
             print(
                 f"Warning: Input period of {period} did not map to frequency inferred from filename: {inferred_freq} (date extracted: {date_match})"
             )


### PR DESCRIPTION
Running:
```
$ pytest -v tests/analyse/test_scenario.py
```

Among others, the following warning was being returned:
```
xarray/core/indexes.py:97: FutureWarning:

Indexing a timezone-naive DatetimeIndex with a timezone-aware datetime 
is deprecated and will raise KeyError in a future version.  Use a timezone-naive object instead.
```

Added a fix for this and for a few small additional warnings.

*Note: used the warnings module to pinpoint the origin of the warning.*
```
$ PYTHONWARNINGS=error::FutureWarning pytest -v tests/analyse/test_scenario.py
```

Closes #353
Closes #433 
Closes #434 