### PR TITLE
Adding ability to use alternative site_filename and adding mock to use static version in tests

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install --upgrade pytest
-        pytest -vs --run-cfchecks --cov=./ --cov-report=xml
+        pytest --run-cfchecks --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       run: |
         curl -s https://codecov.io/bash > codecov;

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install --upgrade pytest
-        pytest --run-cfchecks --cov=./ --cov-report=xml
+        pytest -vs --run-cfchecks --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       run: |
         curl -s https://codecov.io/bash > codecov;

--- a/doc/source/api/api_tutorial.rst
+++ b/doc/source/api/api_tutorial.rst
@@ -28,8 +28,6 @@ Functions used in our OpenGHG tutorial notebooks and documentation.
 
 .. autofunction:: openghg.tutorial.example_extract_path
 
-.. autofunction:: openghg.tutorial.bilsdale_datapaths
-
 .. autofunction:: openghg.tutorial.use_tutorial_store
 
 .. autofunction:: openghg.tutorial.unpack_example_archive

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 
 from openghg.cloud import create_file_package, create_post_dict
 from openghg.util import running_on_hub
+from openghg.types import optionalPathType
 
 
 def standardise_surface(
@@ -14,6 +15,7 @@ def standardise_surface(
     instrument: Optional[str] = None,
     sampling_period: Optional[str] = None,
     calibration_scale: Optional[str] = None,
+    site_filename: optionalPathType = None,
     overwrite: bool = False,
 ) -> Optional[Dict]:
     """Standardise surface measurements and store the data in the object store.
@@ -26,6 +28,8 @@ def standardise_surface(
         inlet: Inlet height in metres
         instrument: Instrument name
         sampling_period: Sampling period as pandas time code, e.g. 1m for 1 minute, 1h for 1 hour
+        site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+            Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
         overwrite: Overwrite data currently present in the object store
     Returns:
         dict: Dictionary containing confirmation of standardisation process.
@@ -36,6 +40,8 @@ def standardise_surface(
         filepaths = [filepaths]
 
     if running_on_hub():
+        # TODO: Use input for site_filename here? How to include this?
+
         # To convert bytes to megabytes
         MB = 1e6
         # The largest file we'll just directly POST to the standardisation
@@ -118,6 +124,7 @@ def standardise_surface(
             instrument=instrument,
             sampling_period=sampling_period,
             inlet=inlet,
+            site_filename=site_filename,
             overwrite=overwrite,
         )
 

--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
-
 from pandas import DataFrame
+
+from openghg.types import optionalPathType
 
 
 def find_files(
@@ -60,6 +61,7 @@ def parse_gcwerks(
     instrument: Optional[str] = None,
     sampling_period: Optional[str] = None,
     measurement_type: Optional[str] = None,
+    site_filename: optionalPathType = None,
 ) -> Dict:
     """Reads a GC data file by creating a GC object and associated datasources
 
@@ -69,6 +71,8 @@ def parse_gcwerks(
         site: Three letter code or name for site
         instrument: Instrument name
         network: Network name
+        site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+            Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
     Returns:
         dict: Dictionary of source_name : UUIDs
     """
@@ -124,7 +128,7 @@ def parse_gcwerks(
     )
 
     # Assign attributes to the data for CF compliant NetCDFs
-    gas_data = assign_attributes(data=gas_data, site=site)
+    gas_data = assign_attributes(data=gas_data, site=site, site_filename=site_filename)
 
     return gas_data
 

--- a/openghg/standardise/surface/_icos.py
+++ b/openghg/standardise/surface/_icos.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 import logging
 
+from openghg.types import optionalPathType
+
 logger = logging.getLogger("openghg.standardise.surface")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
@@ -15,6 +17,7 @@ def parse_icos(
     sampling_period: Optional[str] = None,
     measurement_type: Optional[str] = None,
     header_type: str = "large",
+    site_filename: optionalPathType = None,
     **kwargs: Dict,
 ) -> Dict:
     """Parses an ICOS data file and creates a dictionary containing the Dataset and metadata
@@ -29,6 +32,8 @@ def parse_icos(
         measurement_type: Measurement type e.g. insitu, flask
         header_type: ICOS data file with large (40 line) header or shorter single line header
             Options: large, small
+        site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+            Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
     Returns:
         dict: Dictionary of gas data
     """
@@ -71,7 +76,10 @@ def parse_icos(
         )
 
     # Ensure the data is CF compliant
-    gas_data = assign_attributes(data=gas_data, site=site, sampling_period=sampling_period)
+    gas_data = assign_attributes(data=gas_data,
+                                 site=site,
+                                 sampling_period=sampling_period,
+                                 site_filename=site_filename)
 
     return gas_data
 

--- a/openghg/standardise/surface/_noaa.py
+++ b/openghg/standardise/surface/_noaa.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Hashable, Optional, Union, cast
 import logging
 import xarray as xr
 
+from openghg.types import optionalPathType
+
 logger = logging.getLogger("openghg.standardise.surface")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
@@ -15,6 +17,7 @@ def parse_noaa(
     network: str = "NOAA",
     instrument: Optional[str] = None,
     sampling_period: Optional[str] = None,
+    site_filename: optionalPathType = None,    
     **kwarg: Dict,
 ) -> Dict:
     """Read NOAA data from raw text file or ObsPack NetCDF
@@ -27,6 +30,8 @@ def parse_noaa(
         network: Network, defaults to NOAA
         instrument: Instrument name
         sampling_period: Sampling period
+        site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+            Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
     Returns:
         dict: Dictionary of data and metadata
     """
@@ -45,6 +50,7 @@ def parse_noaa(
             measurement_type=measurement_type,
             instrument=instrument,
             sampling_period=sampling_period,
+            site_filename=site_filename,
         )
     else:
         return _read_raw_file(
@@ -54,6 +60,7 @@ def parse_noaa(
             measurement_type=measurement_type,
             instrument=instrument,
             sampling_period=sampling_period,
+            site_filename=site_filename,
         )
 
 
@@ -262,6 +269,7 @@ def _read_obspack(
     measurement_type: str,
     inlet: Optional[str] = None,
     instrument: Optional[str] = None,
+    site_filename: optionalPathType = None,
 ) -> Dict[str, Dict]:
     """Read NOAA ObsPack NetCDF files
 
@@ -272,7 +280,8 @@ def _read_obspack(
         measurement_type: One of flask, insitu or pfp
         inlet: Inlet height, if no height use measurement type e.g. flask
         instrument: Instrument name
-
+        site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+            Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
     Returns:
         dict: Dictionary of results
     """
@@ -378,7 +387,7 @@ def _read_obspack(
 
     gas_data = _split_inlets(processed_ds, attributes, metadata, inlet=inlet)
 
-    gas_data = assign_attributes(data=gas_data, site=site, network=network)
+    gas_data = assign_attributes(data=gas_data, site=site, network=network, site_filename=site_filename)
 
     return gas_data
 
@@ -390,6 +399,7 @@ def _read_raw_file(
     measurement_type: str,
     inlet: Optional[str] = None,
     instrument: Optional[str] = None,
+    site_filename: optionalPathType = None,
 ) -> Dict:
     """Reads NOAA data files and returns a dictionary of processed
     data and metadata.
@@ -401,6 +411,8 @@ def _read_raw_file(
         measurement_type: One of flask, insitu or pfp
         inlet: Inlet height, if no height use measurement type e.g. flask
         instrument: Instrument name
+        site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+            Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
 
     Returns:
         list: UUIDs of Datasources data has been assigned to
@@ -428,7 +440,7 @@ def _read_raw_file(
         sampling_period=sampling_period,
     )
 
-    gas_data = assign_attributes(data=gas_data, site=site, network="NOAA")
+    gas_data = assign_attributes(data=gas_data, site=site, network="NOAA", site_filename=site_filename)
 
     return gas_data
 

--- a/openghg/standardise/surface/_openghg.py
+++ b/openghg/standardise/surface/_openghg.py
@@ -3,6 +3,8 @@ from typing import Dict, Optional, Union, cast
 import logging
 import xarray as xr
 
+from openghg.types import optionalPathType
+
 logger = logging.getLogger("openghg.standardise.surface")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
@@ -18,6 +20,7 @@ def parse_openghg(
     calibration_scale: Optional[str] = None,
     data_owner: Optional[str] = None,
     data_owner_email: Optional[str] = None,
+    site_filename: optionalPathType = None,
     **kwargs: str,
 ) -> Dict:
     """
@@ -45,6 +48,8 @@ def parse_openghg(
             e.g. "WMOX2007"
         data_owner: Name of data owner.
         data_owner_email: Email address for data owner.
+        site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+            Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
         kwargs: Any additional attributes to be associated with the data.
     Returns:
         Dict: Dictionary of source_name : data, metadata, attributes
@@ -136,7 +141,7 @@ def parse_openghg(
     network_case_options = [network, network.upper(), network.lower()]
 
     # Extract centralised data for site (if present)
-    site_data = get_site_info()
+    site_data = get_site_info(site_filename=site_filename)
     for site_value in site_case_options:
         if site_value in site_data:
             site_info_all = site_data[site_value]
@@ -203,6 +208,6 @@ def parse_openghg(
 
     gas_data = {species: {"metadata": metadata, "data": data, "attributes": attributes}}
 
-    gas_data = assign_attributes(data=gas_data, site=site, network=network)
+    gas_data = assign_attributes(data=gas_data, site=site, network=network, site_filename=site_filename)
 
     return gas_data

--- a/openghg/standardise/surface/_thamesbarrier.py
+++ b/openghg/standardise/surface/_thamesbarrier.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Dict, Optional
 
-from openghg.types import pathType
+from openghg.types import pathType, optionalPathType
 
 
 def parse_tmb(
@@ -12,6 +12,7 @@ def parse_tmb(
     instrument: Optional[str] = None,
     sampling_period: Optional[str] = None,
     measurement_type: Optional[str] = None,
+    site_filename: optionalPathType = None,
     **kwargs: Dict,
 ) -> Dict:
     """Reads THAMESBARRIER data files and returns the UUIDS of the Datasources
@@ -25,6 +26,8 @@ def parse_tmb(
         instrument: Instrument name
         sampling_period: Sampling period
         measurement_type: Type of measurement taken e.g."flask", "insitu"
+        site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+            Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
     Returns:
         list: UUIDs of Datasources data has been assigned to
     """
@@ -122,6 +125,6 @@ def parse_tmb(
             "attributes": attributes,
         }
 
-    gas_data = assign_attributes(data=gas_data, site=site)
+    gas_data = assign_attributes(data=gas_data, site=site, site_filename=site_filename)
 
     return gas_data

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -5,7 +5,7 @@ from typing import DefaultDict, Dict, Optional, Sequence, Tuple, Union
 import numpy as np
 from openghg.store import DataSchema
 from openghg.store.base import BaseStore
-from openghg.types import multiPathType, pathType, resultsType
+from openghg.types import multiPathType, pathType, resultsType, optionalPathType
 from xarray import Dataset
 
 __all__ = ["ObsSurface"]
@@ -31,7 +31,11 @@ class ObsSurface(BaseStore):
 
     @staticmethod
     def read_data(
-        binary_data: bytes, metadata: Dict, file_metadata: Dict, precision_data: Optional[bytes] = None
+        binary_data: bytes,
+        metadata: Dict,
+        file_metadata: Dict,
+        precision_data: Optional[bytes] = None,
+        site_filename: optionalPathType = None,
     ) -> Dict:
         """Reads binary data passed in by serverless function.
         The data dictionary should contain sub-dictionaries that contain
@@ -45,6 +49,8 @@ class ObsSurface(BaseStore):
             metadata: Metadata
             file_metadata: File metadata such as original filename
             precision_data: GCWERKS precision data
+            site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+                Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
         Returns:
             dict: Dictionary of result
         """
@@ -91,7 +97,7 @@ class ObsSurface(BaseStore):
                 precision_filepath = tmpdir_path.joinpath("precision_data.C")
                 precision_filepath.write_bytes(precision_data)
                 # Create the expected GCWERKS tuple
-                result = ObsSurface.read_file(filepath=(filepath, precision_filepath), **meta_kwargs)
+                result = ObsSurface.read_file(filepath=(filepath, precision_filepath), site_filename=site_filename, **meta_kwargs)
 
         return result
 
@@ -109,6 +115,7 @@ class ObsSurface(BaseStore):
         measurement_type: str = "insitu",
         overwrite: bool = False,
         verify_site_code: bool = True,
+        site_filename: optionalPathType = None,
     ) -> Dict:
         """Process files and store in the object store. This function
             utilises the process functions of the other classes in this submodule
@@ -129,6 +136,8 @@ class ObsSurface(BaseStore):
             measurement_type: Type of measurement e.g. insitu, flask
             overwrite: Overwrite previously uploaded data
             verify_site_code: Verify the site code
+            site_filename: Alternative site info file (see openghg/supplementary_data repository for format).
+                Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
         Returns:
             dict: Dictionary of Datasource UUIDs
 
@@ -225,6 +234,7 @@ class ObsSurface(BaseStore):
                         instrument=instrument,
                         sampling_period=sampling_period_seconds,
                         measurement_type=measurement_type,
+                        site_filename=site_filename,
                     )
                 else:
                     data = parser_fn(
@@ -236,6 +246,7 @@ class ObsSurface(BaseStore):
                         sampling_period=sampling_period_seconds,
                         measurement_type=measurement_type,
                         calibration_scale=calibration_scale,
+                        site_filename=site_filename,
                     )
 
                 # Current workflow: if any species fails, whole filepath fails

--- a/openghg/tutorial/__init__.py
+++ b/openghg/tutorial/__init__.py
@@ -11,7 +11,6 @@ from ._tutorial import (
     retrieve_example_data,
     clear_example_cache,
     example_extract_path,
-    bilsdale_datapaths,
     use_tutorial_store,
     unpack_example_archive,
 )

--- a/openghg/tutorial/_tutorial.py
+++ b/openghg/tutorial/_tutorial.py
@@ -14,18 +14,7 @@ from openghg.standardise import standardise_footprint, standardise_flux, standar
 logger = logging.getLogger("openghg.tutorial")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
-__all__ = ["bilsdale_datapaths"]
 
-
-# def _suppress_output(func):
-#     def wrapper(*a, **ka):
-#         with warnings.catch_warnings():
-#             warnings.simplefilter("ignore")
-#             with open(os.devnull, "w") as devnull:
-#                 with contextlib.redirect_stdout(devnull):
-#                     return func(*a, **ka)
-
-#     return wrapper
 def populate_footprint_data() -> None:
     """Adds all footprint data to the tutorial object store
 
@@ -261,19 +250,6 @@ def populate_surface_data() -> None:
                 )
 
     logger.info("Done.")
-
-
-def bilsdale_datapaths() -> List:
-    """Return a list of paths to the Tacolneston data for use in the ranking
-    tutorial
-
-    Returns:
-        list: List of paths
-    """
-    crds_path = Path(__file__).resolve().parent.parent.parent.joinpath("tests/data/proc_test_data/CRDS")
-    print(crds_path)
-
-    return list(crds_path.glob("bsd.picarro.1minute.*.min.*"))
 
 
 def use_tutorial_store() -> None:

--- a/openghg/tutorial/_tutorial.py
+++ b/openghg/tutorial/_tutorial.py
@@ -271,6 +271,7 @@ def bilsdale_datapaths() -> List:
         list: List of paths
     """
     crds_path = Path(__file__).resolve().parent.parent.parent.joinpath("tests/data/proc_test_data/CRDS")
+    print(crds_path)
 
     return list(crds_path.glob("bsd.picarro.1minute.*.min.*"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import tempfile
 
 import pytest
 
+from helpers import get_info_datapath
+
+
 # Added for import of openghg from testing directory
 sys.path.insert(0, os.path.abspath("."))
 
@@ -33,6 +36,20 @@ def default_session_fixture() -> Iterator[None]:
     }
     with patch("openghg.util.read_local_config", return_value=mock_config):
         yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def site_info_mock(session_mocker):
+    """
+    Mock the external call to openghg_defs module for site_info_file
+    to replace this with a static version within the tests data directory.
+    """
+    import openghg_defs
+
+    site_info_file = get_info_datapath(filename="site_info.json")
+    session_mocker.patch.object(openghg_defs, 'site_info_file', new=site_info_file)
+
+    yield
 
 
 def pytest_sessionstart(session):

--- a/tests/data/info/site_info.json
+++ b/tests/data/info/site_info.json
@@ -1,4 +1,14 @@
 {
+  "BAO": {
+    "NOAA": {
+      "height": ["300m"],
+      "height_name": ["300magl"],
+      "height_station_masl": 1584.0,
+      "latitude": 40.05,
+      "long_name": "Boulder Atmospheric Observatory, Colorado, United States",
+      "longitude": -105.004
+    }
+  },
   "BIK": {
         "EUROCOM": {
           "height": ["300m"],
@@ -27,6 +37,23 @@
       "longitude": -1.15033
     }
   },
+  "BTT": {
+    "GAUGE": {
+      "height": ["185m"],
+      "height_name": ["185magl"],
+      "latitude": 51.5215,
+      "long_name": "BT Tower, UK",
+      "longitude": -0.1389
+    },
+    "LGHG": {
+      "height": ["185m"],
+      "height_name": ["185magl"],
+      "latitude": 51.5215,
+      "long_name": "BT Tower, UK",
+      "longitude": -0.1389,
+      "status": "current"
+    }
+  },
   "CGO": {
     "AGAGE": {
       "height": ["70m", "10m"],
@@ -41,6 +68,32 @@
       "latitude": -40.683,
       "long_name": "Cape Grim, Tasmania, Australia",
       "longitude": 144.69
+    }
+  },
+  "CMN": {
+    "AGAGE": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 2155.0,
+      "latitude": 44.193889,
+      "long_name": "Monte Cimone, Italy",
+      "longitude": 10.701389
+    },
+    "ICOS": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 2155.0,
+      "latitude": 44.193889,
+      "long_name": "Monte Cimone, Italy",
+      "longitude": 10.701389
+    },
+    "NOAA": {
+      "latitude": 44.1936,
+      "longitude": 10.6999,
+      "height_station_masl": 2165.0,
+      "long_name": "Mt. Cimone Station, Italy",
+      "height": ["7m"],
+      "height_name": ["7magl"]
     }
   },
   "ESP": {
@@ -59,6 +112,16 @@
       "longitude": -126.5441
     }
   },
+  "GSN": {
+    "AGAGE": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 72.0,
+      "latitude": 33.29244,
+      "long_name": "Gosan, Korea",
+      "longitude": 126.1618
+    }
+  },
   "HFD": {
     "DECC": {
       "height": ["100m", "50m"],
@@ -75,6 +138,32 @@
       "latitude": 50.97675,
       "long_name": "Heathfield, UK",
       "longitude": 0.23048
+    }
+  },
+  "JFJ": {
+    "AGAGE": {
+      "height": ["1000m", "10m"],
+      "height_name": ["1000magl", "10magl"],
+      "height_station_masl": 3570.0,
+      "latitude": 46.5475,
+      "long_name": "Jungfraujoch, Switzerland",
+      "longitude": 7.979167
+    },
+    "ICOS": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 3570.0,
+      "latitude": 46.5475,
+      "long_name": "Jungfraujoch, Switzerland",
+      "longitude": 7.979167
+    },
+    "NOAA": {
+      "latitude": 46.55,
+      "longitude": 7.987,
+      "height_station_masl": 3570.0,
+      "long_name": "Jungfraujoch, Switzerland",
+      "height": ["5m"],
+      "height_name": ["5magl"]
     }
   },
   "MHD": {
@@ -101,12 +190,130 @@
       "longitude": -9.899
     }
   },
+  "NPL": {
+    "LGHG": {
+      "height": ["NA"],
+      "height_name": ["NA"],
+      "height_station_masl": 0,
+      "latitude": 51.4241,
+      "long_name": "National Physical Laboratory",
+      "longitude": -0.3487,
+      "status": "current"
+    }
+  },
   "POCN25": {
     "NOAA": {
       "height_station_masl": 10.0,
       "latitude": 25.0,
       "long_name": "Pacific Ocean (25 N), N/A",
       "longitude": -139.0
+    }
+  },
+  "RGL": {
+    "DECC": {
+      "height": ["90m", "45m"],
+      "height_name": ["90magl", "45magl"],
+      "height_station_masl": 200.0,
+      "latitude": 51.997435,
+      "long_name": "Ridge Hill, UK",
+      "longitude": -2.5399
+    },
+    "ICOS": {
+      "height": ["90m", "45m"],
+      "height_name": ["90magl", "45magl"],
+      "height_station_masl": 200.0,
+      "latitude": 51.997435,
+      "long_name": "Ridge Hill, UK",
+      "longitude": -2.5399
+    },
+    "NOAA": {
+      "height": ["90m", "45m"],
+      "height_name": ["90magl", "45magl"],
+      "height_station_masl": 200.0,
+      "latitude": 51.997435,
+      "long_name": "Ridge Hill, UK",
+      "longitude": -2.5399
+    }
+  },
+  "RPB": {
+    "AGAGE": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 32.0,
+      "latitude": 13.16512,
+      "long_name": "Ragged Point, Barbados",
+      "longitude": -59.43208,
+      "w3w": "///munched.brimmed.elect"
+    },
+    "NOAA": {
+      "height_station_masl": 15.0,
+      "latitude": 13.165,
+      "long_name": "Ragged Point, Barbados",
+      "longitude": -59.432
+    }
+  },
+  "SCSN06": {
+    "NOAA": {
+      "height_station_masl": 15.0,
+      "latitude": 6.0,
+      "long_name": "South China Sea (6 N), N/A",
+      "longitude": 107.0
+    }
+  },
+  "SDZ": {
+    "AGAGE": {
+      "height": ["80m", "10m"],
+      "height_name": ["80magl", "10magl"],
+      "height_station_masl": 287.0,
+      "latitude": 40.65,
+      "long_name": "Shangdianzi, China",
+      "longitude": 117.12
+    },
+    "NOAA": {
+      "height_station_masl": 293.0,
+      "latitude": 40.65,
+      "long_name": "Shangdianzi, Peoples Republic of China",
+      "longitude": 117.117
+    }
+  },
+  "SIO": {
+    "AGAGE": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 10.0,
+      "latitude": 32.8328,
+      "long_name": "Scripps Institue of Oceanography, California",
+      "longitude": -117.2713
+    },
+    "NOAA": {
+      "height_station_masl": 14.0,
+      "latitude": 32.83,
+      "long_name": "La Jolla, California, United States",
+      "longitude": -117.27
+    }
+  },
+  "SMO": {
+    "AGAGE": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 82.0,
+      "latitude": -14.25,
+      "long_name": "Cape Matatula, American Samoa",
+      "longitude": -170.56
+    },
+    "NOAA": {
+      "height_station_masl": 42.0,
+      "latitude": -14.2474,
+      "long_name": "Tutuila, American Samoa",
+      "longitude": -170.5644
+    }
+  },
+  "SPF": {
+    "NOAA": {
+      "height_station_masl": 1623.0,
+      "latitude": -73.8658,
+      "long_name": "Antarctic Firn Air, Antarctica",
+      "longitude": 163.687
     }
   },
   "TAC": {
@@ -131,6 +338,32 @@
       "latitude": 52.5177,
       "long_name": "Tacolneston, United Kingdom",
       "longitude": 1.1386
+    }
+  },
+  "THD": {
+    "AGAGE": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 107.0,
+      "latitude": 41.0541,
+      "long_name": "Trinidad Head, California",
+      "longitude": -124.151
+    },
+    "NOAA": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 107.0,
+      "latitude": 41.0541,
+      "long_name": "Trinidad Head, California",
+      "longitude": -124.151
+    },
+    "SIOCC": {
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 107.0,
+      "latitude": 41.0541,
+      "long_name": "Trinidad Head, California",
+      "longitude": -124.151
     }
   },
   "TMB": {
@@ -168,6 +401,48 @@
       "latitude": 56.55511,
       "long_name": "Angus Tower, UK",
       "longitude": -2.98598
+    }
+  },
+  "WAO": {
+    "ICOS": {
+      "height": ["21m"],
+      "height_name": ["20magl"],
+      "height_station_masl": 10.0,
+      "latitude": 52.95042,
+      "long_name": "Weybourne Observatory, UK",
+      "longitude": 1.12194
+    },
+    "UCAM": {
+      "height": ["21m"],
+      "height_name": ["20magl"],
+      "height_station_masl": 10.0,
+      "latitude": 52.95042,
+      "long_name": "Weybourne Observatory, UK",
+      "longitude": 1.12194
+    },
+    "UEA": {
+      "height": ["21m"],
+      "height_name": ["20magl"],
+      "height_station_masl": 10.0,
+      "latitude": 52.95042,
+      "long_name": "Weybourne Observatory, UK",
+      "longitude": 1.12194
+    }
+  },
+  "ZEP": {
+    "AGAGE": {
+      "height": ["10m"],
+      "height_name": ["16magl"],
+      "height_station_masl": 474.0,
+      "latitude": 78.925,
+      "long_name": "Zeppelin, Ny Alesund, Norway",
+      "longitude": 11.92222
+    },
+    "NOAA": {
+      "height_station_masl": 474.0,
+      "latitude": 78.9067,
+      "long_name": "Ny-Alesund, Svalbard, Norway and Sweden",
+      "longitude": 11.8883
     }
   }
 }

--- a/tests/data/info/site_info.json
+++ b/tests/data/info/site_info.json
@@ -1,5 +1,5 @@
 {
-    "BIK": {
+  "BIK": {
         "EUROCOM": {
           "height": ["300m"],
           "height_name": ["300magl"],
@@ -9,16 +9,76 @@
           "longitude": 23.03
         }
       },
-    "MHD": {
-    "AGAGE": {
-      "height": ["10m"],
-      "height_name": ["10magl"],
-      "height_station_masl": 5.0,
-      "latitude": 53.32611,
-      "long_name": "Mace Head, Ireland",
-      "longitude": -9.90389
+  "BSD": {
+    "DECC": {
+      "height": ["248m", "108m", "42m"],
+      "height_name": ["248magl", "110magl", "50magl"],
+      "height_station_masl": 380.0,
+      "latitude": 54.35858,
+      "long_name": "Bilsdale, UK",
+      "longitude": -1.15033
     },
-    "EUROCOM": {
+    "NOAA": {
+      "height": ["108m", "42m", "248m"],
+      "height_name": ["110magl", "50magl", "248magl"],
+      "height_station_masl": 380.0,
+      "latitude": 54.35858,
+      "long_name": "Bilsdale, UK",
+      "longitude": -1.15033
+    }
+  },
+  "CGO": {
+    "AGAGE": {
+      "height": ["70m", "10m"],
+      "height_name": ["70magl", "10magl"],
+      "height_station_masl": 94.0,
+      "latitude": -40.683,
+      "long_name": "Cape Grim, Tasmania",
+      "longitude": 144.689
+    },
+    "NOAA": {
+      "height_station_masl": 94.0,
+      "latitude": -40.683,
+      "long_name": "Cape Grim, Tasmania, Australia",
+      "longitude": 144.69
+    }
+  },
+  "ESP": {
+    "EC": {
+      "height": ["40m"],
+      "height_name": ["40magl"],
+      "height_station_masl": 7.0,
+      "latitude": 49.382935,
+      "long_name": "Estevan Point, British Columbia, Canada",
+      "longitude": -126.544097
+    },
+    "NOAA": {
+      "height_station_masl": 7.0,
+      "latitude": 49.383,
+      "long_name": "Estevan Point,  British Columbia, Canada",
+      "longitude": -126.5441
+    }
+  },
+  "HFD": {
+    "DECC": {
+      "height": ["100m", "50m"],
+      "height_name": ["100magl", "50magl"],
+      "height_station_masl": 150.0,
+      "latitude": 50.97675,
+      "long_name": "Heathfield, UK",
+      "longitude": 0.23048
+    },
+    "GAUGE": {
+      "height": ["100m", "50m"],
+      "height_name": ["100magl", "50magl"],
+      "height_station_masl": 150.0,
+      "latitude": 50.97675,
+      "long_name": "Heathfield, UK",
+      "longitude": 0.23048
+    }
+  },
+  "MHD": {
+    "AGAGE": {
       "height": ["10m"],
       "height_name": ["10magl"],
       "height_station_masl": 5.0,
@@ -41,6 +101,14 @@
       "longitude": -9.899
     }
   },
+  "POCN25": {
+    "NOAA": {
+      "height_station_masl": 10.0,
+      "latitude": 25.0,
+      "long_name": "Pacific Ocean (25 N), N/A",
+      "longitude": -139.0
+    }
+  },
   "TAC": {
     "DECC": {
       "height": ["185m", "54m", "100m"],
@@ -50,7 +118,7 @@
       "long_name": "Tacolneston Tower, UK",
       "longitude": 1.13872
     },
-    "EUROCOM": {
+    "ICOS": {
       "height": ["100m", "54m", "185m"],
       "height_name": ["100magl", "50magl", "185magl"],
       "height_station_masl": 50.0,
@@ -63,6 +131,43 @@
       "latitude": 52.5177,
       "long_name": "Tacolneston, United Kingdom",
       "longitude": 1.1386
+    }
+  },
+  "TMB": {
+    "CRANFIELD": {
+      "height": ["5m"],
+      "height_name": ["5magl"],
+      "height_station_masl": 5.0,
+      "latitude": 51.496769,
+      "long_name": "Thames Barrier, UK",
+      "longitude": 0.036995
+    },
+    "LGHG": {
+      "height": ["5m"],
+      "height_name": ["5magl"],
+      "height_station_masl": 5.0,
+      "latitude": 51.496769,
+      "long_name": "Thames Barrier, UK",
+      "longitude": 0.036995,
+      "status": "current"
+    }
+  },
+  "TTA": {
+    "DECC": {
+      "height": ["222m"],
+      "height_name": ["222magl"],
+      "height_station_masl": 300.0,
+      "latitude": 56.55511,
+      "long_name": "Angus Tower, UK",
+      "longitude": -2.98598
+    },
+    "ICOS": {
+      "height": ["222m"],
+      "height_name": ["222magl"],
+      "height_station_masl": 300.0,
+      "latitude": 56.55511,
+      "long_name": "Angus Tower, UK",
+      "longitude": -2.98598
     }
   }
 }

--- a/tests/data/info/site_info.json
+++ b/tests/data/info/site_info.json
@@ -21,6 +21,17 @@
       },
   "BSD": {
     "DECC": {
+      "defaults": [
+        {
+          "gases": ["CO", "N2O"],
+          "inlet": ["248m", "248m"],
+          "instrument": ["GCECD", "picarro5310"],
+          "periods": [
+            ["1900-01-01", "2019-03-06"],
+            ["2019-03-06", "2100-01-01"]
+          ]
+        }
+      ],
       "height": ["248m", "108m", "42m"],
       "height_name": ["248magl", "110magl", "50magl"],
       "height_station_masl": 380.0,
@@ -28,7 +39,7 @@
       "long_name": "Bilsdale, UK",
       "longitude": -1.15033
     },
-    "NOAA": {
+      "NOAA": {
       "height": ["108m", "42m", "248m"],
       "height_name": ["110magl", "50magl", "248magl"],
       "height_station_masl": 380.0,

--- a/tests/tutorial/test_tutorial.py
+++ b/tests/tutorial/test_tutorial.py
@@ -1,20 +1,7 @@
 from pathlib import Path
 
 from helpers import get_surface_datapath
-from openghg.tutorial import bilsdale_datapaths, retrieve_example_data
-
-
-def test_bilsdale_data():
-    paths = bilsdale_datapaths()
-
-    names = [p.name for p in paths]
-    names.sort()
-
-    assert names == [
-        "bsd.picarro.1minute.108m.min.dat",
-        "bsd.picarro.1minute.248m.min.dat",
-        "bsd.picarro.1minute.42m.min.dat",
-    ]
+from openghg.tutorial import retrieve_example_data
 
 
 def test_retrieve_example_data(requests_mock, mocker):

--- a/tests/util/test_site.py
+++ b/tests/util/test_site.py
@@ -3,6 +3,25 @@ from pathlib import Path
 import pytest
 from helpers import get_info_datapath
 
+
+def test_site_info_file_mock():
+    """
+    Test site_info_file from openghg_defs is being successfully mocked.
+
+    Because site_info_file is an external file (which can be updated), we have 
+    added a mock for an internal version when site_info_file is imported
+    which is static.
+
+    This is mocked using an autouse fixture in tests/conftest.py/site_info_mock
+    """
+    from openghg_defs import site_info_file
+
+    # Check local filepath is being used when external module is called.
+    expected_location_end = Path("openghg/tests/data/info/site_info.json")
+
+    assert site_info_file.parts[-5:] == expected_location_end.parts
+
+
 @pytest.mark.parametrize(
     "network,expected_site",
     [


### PR DESCRIPTION
Two main changes within this PR:
 - Adding `site_filename` as an input for front-end functions. This allows a "site_info.json" file to be specified directly rather than using the "site_info.json" file available from the `openghg_defs` dependency. This includes:
    - `ObsSurface.read_file` method
    - `standardise_obs` function
    - `parse_*` functions (where appropriate) this includes:
         - `parse_crds`, `parse_gcwerks`, `parse_icos`, `parse_noaa`, `parse_openghg`, `parse_tmb`
         - NOT added for others as these often did not include link with direct/indirect calls to `get_site_info()` which is the function that calls `openghg_defs`
 - Mocking the call to `openghg_defs` within the tests to use a static version of "site_info.json" within tests data folder.

The second fix is to ensure the tests aren't influenced by external changes to the openghg/supplementary_data repository. This also fixes tests which started failing in relation to recent changes made.

Closes #571 