### PR TITLE
Removing use of environment variable for test store

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,36 +1,24 @@
 import os
 import sys
-import tempfile
-
 import pytest
+import shutil
+from helpers import temporary_store_path
+from typing import Iterator
+from unittest.mock import patch
 
 # Added for import of openghg from testing directory
 sys.path.insert(0, os.path.abspath("."))
 
-temporary_store = tempfile.TemporaryDirectory()
-temporary_store_path = temporary_store.name
-
-
-# @pytest.fixture(autouse=True)
-# def mock_auth_fixture(monkeypatch):
-#     def return_mock():
-#         return {
-#             "object_store": {"local_store": str(temporary_store_path)},
-#             "user_id": "test-id-123",
-#         }
-
-#     monkeypatch.setattr("openghg.util.read_local_config", return_mock)
-
-from typing import Iterator
-from unittest.mock import patch
+tmp_store_path = temporary_store_path()
 
 
 @pytest.fixture(scope="session", autouse=True)
 def default_session_fixture() -> Iterator[None]:
     mock_config = {
-        "object_store": {"local_store": str(temporary_store_path)},
+        "object_store": {"local_store": str(tmp_store_path)},
         "user_id": "test-id-123",
     }
+
     with patch("openghg.util.read_local_config", return_value=mock_config):
         yield
 
@@ -39,15 +27,15 @@ def pytest_sessionstart(session):
     """Set the required environment variables for OpenGHG
     at the start of the test session.
     """
-    os.environ["OPENGHG_TEST"] = temporary_store_path
+    shutil.rmtree(tmp_store_path, ignore_errors=True)
 
 
 def pytest_sessionfinish(session, exitstatus):
     """Called after whole test run finished, right before
     returning the exit status to the system.
     """
-    print(f"\n\nCleaning up testing store at {temporary_store.name}")
-    temporary_store.cleanup()
+    print(f"\n\nCleaning up testing store at {tmp_store_path}")
+    shutil.rmtree(tmp_store_path)
 
 
 def pytest_addoption(parser):

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -14,6 +14,7 @@ from .helpers import (
     glob_files,
     key_to_local_filepath,
     all_datasource_keys,
+    temporary_store_path,
 )
 from .meta import (
     attributes_checker_get_obs,

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -1,8 +1,8 @@
 """ Some helper functions for things we do in tests frequently
 """
-import os
 import shutil
 from pathlib import Path
+import tempfile
 from typing import Dict, List, Union
 
 __all__ = [
@@ -16,14 +16,14 @@ __all__ = [
 ]
 
 
+def temporary_store_path():
+    return Path(tempfile.gettempdir(), "openghg_testing_store")
+
+
 def clear_test_store():
     # Clears the testing object store
-    path = os.getenv("OPENGHG_TEST")
-    if path is not None:
-        try:
-            shutil.rmtree(path)
-        except FileNotFoundError:
-            pass
+    tmp_store = temporary_store_path()
+    shutil.rmtree(path=tmp_store, ignore_errors=True)
 
 
 def get_surface_datapath(filename: str, source_format: str) -> Path:

--- a/tests/objectstore/test_local_object_store.py
+++ b/tests/objectstore/test_local_object_store.py
@@ -1,8 +1,8 @@
 # from pathlib import Path
 
-# import pytest
-# from openghg.objectstore import get_local_objectstore_path, get_tutorial_store_path, get_bucket
-
+import pytest
+from openghg.objectstore import get_local_objectstore_path, get_tutorial_store_path, get_bucket
+import tempfile
 
 # @pytest.fixture(scope="session")
 # def setup_config():
@@ -31,3 +31,9 @@
 #     data = query_store()
 
 # print(data)
+
+
+def test_get_bucket():
+    tmpdir = tempfile.gettempdir()
+    b = get_bucket()
+    assert tmpdir in b


### PR DESCRIPTION
This removes the use of the environment variable setup in `conftest.py` and replaces it with the mock for the object store path.