### PR TITLE
Fix bug in sampling period checking

### DIFF
--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -255,8 +255,9 @@ def _read_data(
 
     if sampling_period is not None:
         # Compare input to definition within json file
-        file_sampling_period = pd_Timedelta(seconds=extracted_sampling_period)
-        comparison_seconds = abs(sampling_period - file_sampling_period).total_seconds()
+        file_sampling_period_td = pd_Timedelta(seconds=float(extracted_sampling_period))
+        sampling_period_td = pd_Timedelta(seconds=float(sampling_period))
+        comparison_seconds = abs(sampling_period_td - file_sampling_period_td).total_seconds()
         tolerance_seconds = 1
 
         if comparison_seconds > tolerance_seconds:

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -3,10 +3,11 @@ from pathlib import Path
 from typing import DefaultDict, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
+from pandas import Timedelta
+from xarray import Dataset
 from openghg.store import DataSchema
 from openghg.store.base import BaseStore
 from openghg.types import multiPathType, pathType, resultsType, optionalPathType
-from xarray import Dataset
 
 __all__ = ["ObsSurface"]
 
@@ -110,7 +111,7 @@ class ObsSurface(BaseStore):
         inlet: Optional[str] = None,
         height: Optional[str] = None,
         instrument: Optional[str] = None,
-        sampling_period: Optional[str] = None,
+        sampling_period: Optional[Union[Timedelta, str]] = None,
         calibration_scale: Optional[str] = None,
         measurement_type: str = "insitu",
         overwrite: bool = False,
@@ -150,7 +151,6 @@ class ObsSurface(BaseStore):
         from openghg.store import assign_data, datasource_lookup, load_metastore
         from openghg.types import SurfaceTypes
         from openghg.util import clean_string, format_inlet, hash_file, load_surface_parser, verify_site
-        from pandas import Timedelta
         from tqdm import tqdm
 
         if not isinstance(filepath, list):
@@ -167,7 +167,6 @@ class ObsSurface(BaseStore):
         site = verify_site(site=site) if verify_site_code else clean_string(site)
         network = clean_string(network)
         instrument = clean_string(instrument)
-        # sampling_period = clean_string(sampling_period)
 
         # Check if alias `height` is included instead of `inlet`
         if inlet is None and height is not None:
@@ -180,12 +179,35 @@ class ObsSurface(BaseStore):
         sampling_period_seconds: Union[str, None] = None
         # If we have a sampling period passed we want the number of seconds
         if sampling_period is not None:
-            sampling_period_seconds = str(float(Timedelta(sampling_period).total_seconds()))
+            # Check value passed is not just a number with no units
+            try:
+                float(sampling_period)
+            except (ValueError, TypeError):
+                # If this cannot be evaluated to a float assume this is correct form.
+                pass
+            else:
+                raise ValueError(
+                    f"Invalid sampling period: '{sampling_period}'. Must be specified as a string with unit (e.g. 1m for 1 minute)."
+                )
 
+            # Check string passed can be evaluated as a Timedelta object
+            # and extract this in seconds.
+            try:
+                sampling_period_td = Timedelta(sampling_period)
+            except ValueError:
+                raise ValueError(
+                    f"Could not evaluate sampling period: '{sampling_period}'. Must be specified as a string with valid unit (e.g. 1m for 1 minute)."
+                )
+
+            sampling_period_seconds = str(float(sampling_period_td.total_seconds()))
+
+            # Check if sampling period has resolved to 0 seconds.
             if sampling_period_seconds == "0.0":
                 raise ValueError(
-                    "Invalid sampling period result, please pass a valid pandas time such as 1m for 1 minute."
+                    f"Sampling period resolves to <= 0.0 seconds. Please check input: '{sampling_period}'"
                 )
+            
+            # TODO: May want to add check for NaT or NaN
 
         # Load the data retrieve object
         parser_fn = load_surface_parser(source_format=source_format)

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -206,7 +206,7 @@ class ObsSurface(BaseStore):
                 raise ValueError(
                     f"Sampling period resolves to <= 0.0 seconds. Please check input: '{sampling_period}'"
                 )
-            
+
             # TODO: May want to add check for NaT or NaN
 
         # Load the data retrieve object

--- a/tests/standardise/surface/test_gcwerks.py
+++ b/tests/standardise/surface/test_gcwerks.py
@@ -74,6 +74,7 @@ def test_read_file_thd():
         site="thd",
         network="agage",
         instrument="gcmd",
+        sampling_period="75",  # Checking this can be compared successfully
     )
 
     parsed_surface_metachecker(data=gas_data)

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -97,25 +97,17 @@ def test_read_data(mocker):
         _ = ObsSurface.read_data(binary_data=binary_bsd, metadata=metadata, file_metadata=file_metadata)
 
 
-def test_read_CRDS_incorrent_sampling_period_raises():
+@pytest.mark.parametrize("sampling_period", ["60", 60, "60000000000", "twelve-thousand"])
+def test_read_CRDS_incorrect_sampling_period_raises(sampling_period):
     clear_test_store()
 
     filepath = get_surface_datapath(filename="bsd.picarro.1minute.248m.min.dat", source_format="CRDS")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exec_info:
         ObsSurface.read_file(
-            filepath=filepath, source_format="CRDS", site="bsd", network="DECC", sampling_period="60"
+            filepath=filepath, source_format="CRDS", site="bsd", network="DECC", sampling_period=sampling_period
         )
-        ObsSurface.read_file(
-            filepath=filepath, source_format="CRDS", site="bsd", network="DECC", sampling_period=60
-        )
-        ObsSurface.read_file(
-            filepath=filepath,
-            source_format="CRDS",
-            site="bsd",
-            network="DECC",
-            sampling_period="twelve-thousand",
-        )
+        assert "Invalid sampling period" in exec_info or "Could not evaluate sampling period" in exec_info
 
 
 def test_read_CRDS():


### PR DESCRIPTION
Updating a few bugs in sampling period checking:
 - updating checks within `ObsSurface.read_file()` on whether this has been specified incorrectly (based on current documentation i.e. doesn't contain a unit). Updated to explicitly check whether this can be evaluated to just a number and raising a ValueError.
 - updating logic within `parse_gcwerks()` - converting sampling period to a Timedelta was raising a ValueError as this was a string when a float was expected by the function.

Closes #583 