### PR TITLE
Fix for `long_name` KeyError on average.

### DIFF
--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -382,11 +382,12 @@ def get_obs_surface_local(
             f"{species}_variability"
         ].median()
 
+        print(data.attrs)
         # Create attributes for variability variable
-        if "long_name" in data.attrs:
+        if "long_name" in data[species].attrs:
             ds_resampled[f"{species}_variability"].attrs[
                 "long_name"
-            ] = f"{data.attrs['long_name']}_variability"
+            ] = f"{data[species].attrs['long_name']}_variability"
 
         if "units" in data[species].attrs:
             ds_resampled[f"{species}_variability"].attrs["units"] = data[species].attrs["units"]

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -234,14 +234,7 @@ def get_obs_surface_local(
     """
     import numpy as np
     from openghg.retrieve import search_surface
-    from openghg.util import (
-        clean_string,
-        format_inlet,
-        load_json,
-        synonyms,
-        timestamp_tzaware,
-        get_site_info
-    )
+    from openghg.util import clean_string, format_inlet, load_json, synonyms, timestamp_tzaware, get_site_info
     from pandas import Timedelta
 
     if running_on_hub():
@@ -390,9 +383,13 @@ def get_obs_surface_local(
         ].median()
 
         # Create attributes for variability variable
-        ds_resampled[f"{species}_variability"].attrs["long_name"] = f"{data.attrs['long_name']}_variability"
+        if "long_name" in data.attrs:
+            ds_resampled[f"{species}_variability"].attrs[
+                "long_name"
+            ] = f"{data.attrs['long_name']}_variability"
 
-        ds_resampled[f"{species}_variability"].attrs["units"] = data[species].attrs["units"]
+        if "units" in data[species].attrs:
+            ds_resampled[f"{species}_variability"].attrs["units"] = data[species].attrs["units"]
 
         # Resampling may introduce NaNs, so remove, if not keep_missing
         if keep_missing is False:

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -382,7 +382,6 @@ def get_obs_surface_local(
             f"{species}_variability"
         ].median()
 
-        print(data.attrs)
         # Create attributes for variability variable
         if "long_name" in data[species].attrs:
             ds_resampled[f"{species}_variability"].attrs[

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -44,8 +44,16 @@ from pandas import Timedelta, Timestamp
 def test_get_obs_surface_average_works_without_longname():
     # The stored dataset here doesn't have a long_name attribute so failed
     # Now works with checks
-    obsdata = get_obs_surface(site="mhd", species="ch4", inlet="10magl", average="4H")
+    obsdata = get_obs_surface(
+        site="mhd",
+        species="ch4",
+        inlet="10magl",
+        average="4H",
+        instrument="gcmd",
+    )
+
     assert obsdata.data.attrs["averaged_period_str"] == "4H"
+    assert obsdata.data.attrs["averaged_period"] == 14400
 
 
 @pytest.mark.parametrize(

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -41,6 +41,13 @@ from pandas import Timedelta, Timestamp
 # ]
 
 
+def test_get_obs_surface_average_works_without_longname():
+    # The stored dataset here doesn't have a long_name attribute so failed
+    # Now works with checks
+    obsdata = get_obs_surface(site="mhd", species="ch4", inlet="10magl", average="4H")
+    assert obsdata.data.attrs["averaged_period_str"] == "4H"
+
+
 @pytest.mark.parametrize(
     "inlet_keyword,inlet_value",
     [
@@ -100,7 +107,6 @@ def test_no_data_raises():
         assert "Unable to find results for" in excinfo
         assert f"site='{site}'" in excinfo
         assert f"species='{species}'" in excinfo
-
 
 
 # def test_get_obs_surface_ranked_data_only():
@@ -322,7 +328,7 @@ def test_get_flux():
 
 
 def test_get_flux_no_result():
-    """Test sensible error message is being returned when no results are found 
+    """Test sensible error message is being returned when no results are found
     with input keywords for get_flux function"""
     with pytest.raises(SearchError) as execinfo:
         get_flux(species="co2", source="cinnamon", domain="antarctica")
@@ -342,8 +348,7 @@ def test_get_bc():
     assert float(bc.lon.max()) == pytest.approx(39.38)
     assert float(bc.lon.min()) == pytest.approx(-97.9)
 
-    bc_variables = ['height', 'lat', 'lon', 'time',
-                    'vmr_e', 'vmr_n', 'vmr_s', 'vmr_w']
+    bc_variables = ["height", "lat", "lon", "time", "vmr_e", "vmr_n", "vmr_s", "vmr_w"]
     assert sorted(list(bc.variables)) == bc_variables
 
     time = bc["time"]
@@ -359,7 +364,7 @@ def test_get_bc():
         ("inlet", "10"),
     ],
 )
-def test_get_footprint(inlet_keyword,inlet_value):
+def test_get_footprint(inlet_keyword, inlet_value):
     if inlet_keyword == "inlet":
         fp_result = get_footprint(site="tmb", domain="europe", inlet=inlet_value, model="test_model")
     elif inlet_keyword == "height":
@@ -379,7 +384,7 @@ def test_get_footprint(inlet_keyword,inlet_value):
 
 
 def test_get_footprint_no_result():
-    """Test sensible error message is being returned when no results are found 
+    """Test sensible error message is being returned when no results are found
     with input keywords for get_footprint function"""
     with pytest.raises(SearchError) as execinfo:
         get_footprint(site="seville", domain="spain", height="10m", model="test_model")


### PR DESCRIPTION
This fixes the KeyError bug due to the `long_name` attribute being read from the site attributes rather than the species attributes during averaging in `get_obs_surface`. Closes #578 .