### PR TITLE
Fixed logic for specifying default objectstore path in config file

### DIFF
--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -108,12 +108,12 @@ def create_config(silent: bool = False) -> None:
     else:
         updated = True
         default_objstore_path = get_default_objectstore_path()
-
-        if silent:
-            obj_store_path = default_objstore_path
-        else:
+        
+        obj_store_path = default_objstore_path
+        if not silent:
             obj_store_input = input(f"Enter path for object store (default {default_objstore_path}): ")
-            obj_store_path = Path(obj_store_input).expanduser().resolve()
+            if obj_store_input:
+                obj_store_path = Path(obj_store_input).expanduser().resolve()
 
         user_config_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -108,7 +108,7 @@ def create_config(silent: bool = False) -> None:
     else:
         updated = True
         default_objstore_path = get_default_objectstore_path()
-        
+
         obj_store_path = default_objstore_path
         if not silent:
             obj_store_input = input(f"Enter path for object store (default {default_objstore_path}): ")


### PR DESCRIPTION
Previously, if a user didn't enter path when promoted during create_config, the default path was being overwritten.

For me, the tests for these functions don't work. It could be to do with the mocking. I get errors when the tests try to clean up the testing store, like:

No such file or directory: '/var/folders/ck/vrz4wwp115qb8jbc7y_wk1r00000gq/T/openghg_testing_store