### PR TITLE
Make ICOS retrieval function filter by sampling height correctly

### DIFF
--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -183,6 +183,7 @@ def local_retrieve(
         standardised_data = _retrieve_remote(
             site=site,
             species=species,
+            sampling_height=sampling_height,
             data_level=data_level,
             dataset_source=dataset_source,
             update_metadata_mismatch=update_metadata_mismatch,


### PR DESCRIPTION
This closes #599 . There was a missing sampling_height argument in the call to _retrieve_remote from local_retrieve within openghg.retrieve.icos. This meant that it wasn't possible to filter by sampling_height.