### PR TITLE
Temporarily pinning pandas to < 2.0

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
   - numexpr
   - numpy
   - nc-time-axis
-  - pandas
+  - pandas < 2.0
   - plotly
   - pyvis
   - rapidfuzz

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ nbformat
 numexpr
 numpy
 nc-time-axis
-pandas
+pandas < 2.0
 plotly
 pyvis
 rapidfuzz


### PR DESCRIPTION
The upgrade to pandas 2.0 seems to have caused a set of tests to fail. Suggest pinning this to 2.0 to allow development to continue until we can address these issues.

Relates to #618 