### PR TITLE
Updating ObsData.plot_timeseries() method to use openghg.plotting.plot_timeseries() function

### DIFF
--- a/openghg/dataobjects/_obsdata.py
+++ b/openghg/dataobjects/_obsdata.py
@@ -84,46 +84,18 @@ class ObsData(_BaseData, abc.Mapping):
         xlabel: Optional[str] = None,
         ylabel: Optional[str] = None,
         units: Optional[str] = None,
+        logo: Optional[bool] = True,
     ) -> go.Figure:
         """Plot a timeseries"""
+        import openghg.plotting
 
-        species = self.metadata["species"]
-        site = self.metadata["site"]
-        inlet = self.metadata["inlet"]
-
-        if title is None:
-            title = f"{species.upper()} at {site.upper()} - {inlet}"
-
-        if xlabel is None:
-            xlabel = "Date"
-
-        if ylabel is None:
-            ylabel = "Concentration"
-
-        if units is not None:
-            ylabel += f"  ({units})"
-
-        data = self.data
-        x_data = data.time
-
-        try:
-            y_data = data[species]
-        except KeyError:
-            y_data = data["mf"]
-
-        font = {"size": 14}
-
-        title_layout = {"text": title, "y": 0.9, "x": 0.5, "xanchor": "center", "yanchor": "top"}
-
-        layout = go.Layout(
-            title=title_layout,
-            xaxis=dict(title=xlabel),
-            yaxis=dict(title=ylabel),
-            font=font,
+        fig = openghg.plotting.plot_timeseries(
+            self,
+            title = title,
+            xlabel = xlabel,
+            ylabel = ylabel,
+            units = units,
+            logo = logo,
         )
-
-        # Create traces
-        fig = go.Figure(layout=layout)
-        fig.add_trace(go.Scatter(x=x_data, y=y_data, mode="lines", name=species.upper()))
 
         return fig

--- a/openghg/dataobjects/_obsdata.py
+++ b/openghg/dataobjects/_obsdata.py
@@ -87,9 +87,9 @@ class ObsData(_BaseData, abc.Mapping):
         logo: Optional[bool] = True,
     ) -> go.Figure:
         """Plot a timeseries"""
-        import openghg.plotting
+        from openghg.plotting import plot_timeseries as general_plot_timeseries
 
-        fig = openghg.plotting.plot_timeseries(
+        fig = general_plot_timeseries(
             self,
             title = title,
             xlabel = xlabel,

--- a/openghg/plotting/_timeseries.py
+++ b/openghg/plotting/_timeseries.py
@@ -131,6 +131,7 @@ def plot_timeseries(
     data: Union[ObsData, List[ObsData]],
     xvar: Optional[str] = None,
     yvar: Optional[str] = None,
+    title: Optional[str] = None,
     xlabel: Optional[str] = None,
     ylabel: Optional[str] = None,
     units: Optional[str] = None,
@@ -142,6 +143,7 @@ def plot_timeseries(
         data: ObsData object or list of objects
         xvar: x axis variable, defaults to time
         yvar: y axis variable, defaults to species
+        title: Title for figure
         xlabel: Label for x axis
         ylabel: Label for y axis
         units: Units for y axis


### PR DESCRIPTION
Updating the relevant method on ObsData to use the plot_timeseries() function directly. This is to ensure optimisation and changes don't have to be made twice.

See comments on PR #614 