### PR TITLE
Allowing ICOS internal attributes and data derived from site_info to be compared

### DIFF
--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -323,7 +323,7 @@ def _retrieve_remote(
         # This is the metadata, dobj.info and dobj.meta are equal
         dobj_info = dobj.meta
 
-        metadata = {}
+        attributes = {}
 
         specific_info = dobj_info["specificInfo"]
         col_data = specific_info["columns"]
@@ -338,30 +338,30 @@ def _retrieve_remote(
 
         species_info = next(item for item in col_data if str(item["label"]).lower() == the_species.lower())
 
-        metadata["species"] = the_species
+        attributes["species"] = the_species
         acq_data = specific_info["acquisition"]
         station_data = acq_data["station"]
 
         to_store: Dict[str, Any] = {}
         try:
-            instrument_metadata = acq_data["instrument"]
+            instrument_attributes = acq_data["instrument"]
         except KeyError:
             to_store["instrument"] = "NA"
             to_store["instrument_data"] = "NA"
         else:
-            # Do some tidying of the instrument metadata
+            # Do some tidying of the instrument attributes
             instruments = set()
-            cleaned_instrument_metadata = []
+            cleaned_instrument_attributes = []
 
-            if not isinstance(instrument_metadata, list):
-                instrument_metadata = [instrument_metadata]
+            if not isinstance(instrument_attributes, list):
+                instrument_attributes = [instrument_attributes]
 
-            for inst in instrument_metadata:
+            for inst in instrument_attributes:
                 instrument_name = inst["label"]
                 instruments.add(instrument_name)
                 uri = inst["uri"]
 
-                cleaned_instrument_metadata.extend([instrument_name, uri])
+                cleaned_instrument_attributes.extend([instrument_name, uri])
 
             if len(instruments) == 1:
                 instrument = instruments.pop()
@@ -369,51 +369,66 @@ def _retrieve_remote(
                 instrument = "multiple"
 
             to_store["instrument"] = instrument
-            to_store["instrument_data"] = cleaned_instrument_metadata
+            to_store["instrument_data"] = cleaned_instrument_attributes
 
-        metadata.update(to_store)
+        attributes.update(to_store)
 
-        metadata["site"] = station_data["id"]
-        metadata["measurement_type"] = measurement_type
-        metadata["units"] = units
+        attributes["site"] = station_data["id"]
+        attributes["measurement_type"] = measurement_type
+        attributes["units"] = units
 
         _sampling_height = acq_data["samplingHeight"]
-        metadata["sampling_height"] = format_inlet(_sampling_height, key_name="sampling_height")
-        metadata["sampling_height_units"] = "metres"
-        metadata["inlet"] = format_inlet(_sampling_height, key_name="inlet")
-        metadata["inlet_height_magl"] = format_inlet(_sampling_height, key_name="inlet_height_magl")
+        attributes["sampling_height"] = format_inlet(_sampling_height, key_name="sampling_height")
+        attributes["sampling_height_units"] = "metres"
+        attributes["inlet"] = format_inlet(_sampling_height, key_name="inlet")
+        attributes["inlet_height_magl"] = format_inlet(_sampling_height, key_name="inlet_height_magl")
 
         loc_data = station_data["location"]
 
+        attributes["station_long_name"] = loc_data["label"]
+        attributes["station_latitude"] = str(loc_data["lat"])
+        attributes["station_longitude"] = str(loc_data["lon"])
+
+        # 03/05/2023: Updated attributes to include altitude for "station_height_masl" explicitly.
+        # attributes["station_altitude"] = format_inlet(loc_data["alt"], key_name="station_altitude")
+        # attributes["station_height_masl"] = format_inlet(str(stat.eas), key_name="station_height_masl")
+        attributes["station_height_masl"] = format_inlet(loc_data["alt"], key_name="station_height_masl")
+
+        attributes["data_owner"] = f"{stat.firstName} {stat.lastName}"
+        attributes["data_owner_email"] = str(stat.email)
+
+        attributes["citation_string"] = dobj_info["references"]["citationString"]
+        attributes["licence_name"] = dobj_info["references"]["licence"]["name"]
+        attributes["licence_info"] = dobj_info["references"]["licence"]["url"]
+
+        metadata = {}
+
+        network = "ICOS"
+
         try:
-            station_long_name = openghg_site_metadata[site.upper()]["ICOS"]["long_name"]
+            site_info = openghg_site_metadata[site.upper()][network]
         except KeyError:
-            station_long_name = loc_data["label"]
+            pass
+        else:
+            metadata["station_long_name"] = site_info["long_name"]
+            metadata["station_latitude"] = site_info["latitude"]
+            metadata["station_longitude"] = site_info["longitude"]
 
-        metadata["station_long_name"] = station_long_name
-        metadata["station_latitude"] = str(loc_data["lat"])
-        metadata["station_longitude"] = str(loc_data["lon"])
-
-        # 03/05/2023: Updated metadata to include altitude for "station_height_masl" explicitly.
-        # metadata["station_altitude"] = format_inlet(loc_data["alt"], key_name="station_altitude")
-        # metadata["station_height_masl"] = format_inlet(str(stat.eas), key_name="station_height_masl")
-        metadata["station_height_masl"] = format_inlet(loc_data["alt"], key_name="station_height_masl")
-
-        metadata["data_owner"] = f"{stat.firstName} {stat.lastName}"
-        metadata["data_owner_email"] = str(stat.email)
-
-        metadata["citation_string"] = dobj_info["references"]["citationString"]
-        metadata["licence_name"] = dobj_info["references"]["licence"]["name"]
-        metadata["licence_info"] = dobj_info["references"]["licence"]["url"]
+        # Add some values directly for attributes (for now)
+        metadata["species"] = attributes["species"]
 
         # Add ICOS in directly here for now
-        metadata["network"] = "ICOS"
-        metadata["data_type"] = "surface"
-        metadata["data_source"] = "icoscp"
-        metadata["source_format"] = "icos"
-        metadata["icos_data_level"] = str(data_level)
+        additional_data = {}
+        additional_data["network"] = network
+        additional_data["data_type"] = "surface"
+        additional_data["data_source"] = "icoscp"
+        additional_data["source_format"] = "icos"
+        additional_data["icos_data_level"] = str(data_level)
+        additional_data["dataset_source"] = dobj_dataset_source
+        additional_data["site"] = site
 
-        metadata["dataset_source"] = dobj_dataset_source
+        attributes.update(additional_data)
+        metadata.update(additional_data)
 
         dataframe.columns = [x.lower() for x in dataframe.columns]
         dataframe = dataframe.dropna(axis="index")
@@ -421,7 +436,7 @@ def _retrieve_remote(
         if not dataframe.index.is_monotonic_increasing:
             dataframe = dataframe.sort_index()
 
-        spec = metadata["species"]
+        spec = attributes["species"]
 
         rename_cols = {
             "stdev": spec + " variability",
@@ -444,7 +459,7 @@ def _retrieve_remote(
         dataframe.index = to_datetime(dataframe.index, format="%Y-%m-%d %H:%M:%S")
 
         dataset = dataframe.to_xarray()
-        dataset.attrs.update(metadata)
+        dataset.attrs.update(attributes)
 
         # So there isn't an easy way of getting a hash of a Dataset, can we do something
         # simple here we can compare data that's being added? Then we'll be able to make sure
@@ -454,7 +469,7 @@ def _retrieve_remote(
         standardised_data[data_key] = {
             "metadata": metadata,
             "data": dataset,
-            "attributes": metadata,
+            "attributes": attributes,
         }
 
     standardised_data = assign_attributes(

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -182,6 +182,7 @@ def local_retrieve(
         site=site,
         species=species,
         inlet=inlet,
+        sampling_height=sampling_height,
         network="ICOS",
         data_source="icoscp",
         start_date=start_date,
@@ -200,6 +201,7 @@ def local_retrieve(
             data_level=data_level,
             dataset_source=dataset_source,
             inlet=inlet,
+            sampling_height=sampling_height,
             update_mismatch=update_mismatch,
         )
 

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -182,7 +182,6 @@ def local_retrieve(
         site=site,
         species=species,
         inlet=inlet,
-        sampling_height=sampling_height,
         network="ICOS",
         data_source="icoscp",
         start_date=start_date,

--- a/tests/retrieve/icos/test_retrieve_icos.py
+++ b/tests/retrieve/icos/test_retrieve_icos.py
@@ -102,10 +102,8 @@ def test_icos_retrieve_skips_obspack_globalview(mocker, caplog):
     )
 
     # 05/01/2023: Added update_mismatch to account for WAO difference
-    #  - 04/05/2023: Took out for now but may need to add back if/when ICOS
-    #    metadata / attribute alignment is updated.
     data_first_retrieval = retrieve_atmospheric(
-        site="WAO", species="co2", sampling_height="10m", # update_mismatch=True
+        site="WAO", species="co2", sampling_height="10m", update_mismatch=True
     )
 
     meta1 = data_first_retrieval[0].metadata
@@ -114,38 +112,31 @@ def test_icos_retrieve_skips_obspack_globalview(mocker, caplog):
         "species": "co2",
         "instrument": "ftir",
         "site": "wao",
-        "measurement_type": "co2 mixing ratio (dry mole fraction)",
-        "units": "µmol mol-1",
-        "sampling_height": "10m",
-        "sampling_height_units": "metres",
+        # REMOVED sampling_height from metadata --> included inlet
+        # - This was to better align with metadata within the obs_surface data_type
+        # "sampling_height": "10m",
+        # "sampling_height_units": "metres",
         "inlet": "10m",
         "inlet_height_magl": "10",
-        "station_long_name": "weybourne observatory, uk",
-        "station_latitude": "52.95",
-        "station_longitude": "1.121",
+        # TODO: Will need to be updated once metadata / attributes checking
+        # "station_long_name": "weybourne observatory, uk",
+        "station_long_name": "wao",
+        "station_latitude": 52.95042,
+        "station_longitude": 1.12194,
         # TODO: Will need to be updated once metadata / attributes checking
         # is better aligned for ICOS.
         # "station_altitude": "31m",
         # "station_height_masl": 10.0,
-        "station_height_masl": "31",
-        "licence_name": "icos ccby4 data licence",
-        "licence_info": "http://meta.icos-cp.eu/ontologies/cpmeta/icoslicence",
+        "station_height_masl": 31.0,
         "network": "icos",
         "data_type": "surface",
         "data_source": "icoscp",
         "source_format": "icos",
         "icos_data_level": "2",
-        "conditions_of_use": "ensure that you contact the data owner at the outset of your project.",
-        "source": "in situ measurements of air",
-        "conventions": "cf-1.8",
-        "processed_by": "openghg_cloud",
         "calibration_scale": "unknown",
         "sampling_period": "not_set",
-        "sampling_period_unit": "s",
-        "instrument_data": ["FTIR", "http://meta.icos-cp.eu/resources/instruments/ATC_505"],
-        "citation_string": "Forster, G., Manning, A. (2022). ICOS ATC CO2 Release, Weybourne (10.0 m), 2021-10-21–2022-02-28, ICOS RI, https://hdl.handle.net/11676/NR9p9jxC7B7M46MdGuCOrzD3",
         "dataset_source": "ICOS",
-        "Conventions": "CF-1.8",
+
     }
 
     assert meta1_expected.items() <= meta1.items()
@@ -159,11 +150,28 @@ def test_icos_retrieve_skips_obspack_globalview(mocker, caplog):
     assert retrieve_all.call_count == 0
     assert get_mock.call_count == 2
 
+    # Check attributes within stored Dataset contain extra keys
+    attr1_expected_additional = {
+        "measurement_type": "co2 mixing ratio (dry mole fraction)",
+        "sampling_height": "10m",
+        "sampling_height_units": "metres",
+        "licence_name": "ICOS CCBY4 Data Licence",
+        "licence_info": "http://meta.icos-cp.eu/ontologies/cpmeta/icosLicence",
+        "conditions_of_use": "Ensure that you contact the data owner at the outset of your project.",
+        "source": "In situ measurements of air",
+        "sampling_period_unit": "s",
+        "instrument_data": ["FTIR", "http://meta.icos-cp.eu/resources/instruments/ATC_505"],
+        "citation_string": "Forster, G., Manning, A. (2022). ICOS ATC CO2 Release, Weybourne (10.0 m), 2021-10-21–2022-02-28, ICOS RI, https://hdl.handle.net/11676/NR9p9jxC7B7M46MdGuCOrzD3",
+        "Conventions": "CF-1.8",
+    }
+
+    data1_attrs = data1.attrs
+
+    assert attr1_expected_additional.items() <= data1_attrs.items()
+
     # 05/01/2023: Added update_mismatch to account for WAO difference
-    #  - 04/05/2023: Took out for now but may need to add back if/when ICOS
-    #    metadata / attribute alignment is updated.
     data_second_retrieval = retrieve_atmospheric(
-        site="WAO", species="co2", sampling_height="10m", # update_mismatch=True
+        site="WAO", species="co2", sampling_height="10m", update_mismatch=True
     )
 
     data2 = data_second_retrieval[0].data
@@ -180,10 +188,8 @@ def test_icos_retrieve_skips_obspack_globalview(mocker, caplog):
     )
 
     # 05/01/2023: Added update_mismatch to account for WAO difference
-    #  - 04/05/2023: Took out for now but may need to add back if/when ICOS
-    #    metadata / attribute alignment is updated.
     retrieve_atmospheric(
-        site="WAO", species="co2", sampling_height="10m", force_retrieval=True, # update_mismatch=True, 
+        site="WAO", species="co2", sampling_height="10m", force_retrieval=True, update_mismatch=True, 
     )
 
     assert "There is no new data to process." in caplog.text


### PR DESCRIPTION
At the moment the `retrieve_atmospheric` function uses internal attributes to directly create the metadata. This update is to allow these internal values to checked against the site_info data and spot mismatches (these can be allowed to be updated if needed).

This also reduces the expected metadata keys for the ICOS data and adds `inlet` in preference to `sampling_height` to align with other source_formats for the `obs_surface` data type.

Closes #656