### PR TITLE
removed pinned mypy version and update to 1.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         exclude: doc
         exclude: tests
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
       - id: mypy
         # Copied from setup.cfg

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         exclude: doc
         exclude: tests
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.3.0
     hooks:
       - id: mypy
         # Copied from setup.cfg

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-cov
 pytest-mock
 requests-mock
 # For mypy
-mypy==0.991
+mypy
 types-paramiko
 types-PyYAML
 types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-cov
 pytest-mock
 requests-mock
 # For mypy
-mypy
+mypy==1.3.0
 types-paramiko
 types-PyYAML
 types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-cov
 pytest-mock
 requests-mock
 # For mypy
-mypy==1.3.0
+mypy==1.4.0
 types-paramiko
 types-PyYAML
 types-requests


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
* Type-UPDATE
* The earlier pinned version of mypy is now updated to the latest released version 1.4.0. inside requirements-dev.txt and pre-commit-config.yaml too.


* **Please check if the PR fulfills these requirements**

- [x] Closes #674 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
