### PR TITLE
Iss679 config path

### DIFF
--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -33,9 +33,10 @@ def get_default_objectstore_path() -> Path:
 
 # @lru_cache
 def get_user_config_path() -> Path:
-    """Checks if a config file has already been create for
-    OpenGHG to use. This file is created in the user's home directory
-    in  ~/.config/openghg/user.conf on Linux / macOS or
+    """ Returns path to user config file.
+
+    This file is created in the user's home directory
+    in  ~/.ghgconfig/openghg/user.conf on Linux / macOS or
     in LOCALAPPDATA/openghg/openghg.conf on Windows.
 
     Returns:
@@ -52,7 +53,7 @@ def get_user_config_path() -> Path:
 
         config_path = Path(appdata_path).joinpath("openghg", openghg_config_filename)
     elif user_platform in ("Linux", "Darwin"):
-        config_path = Path.home().joinpath(".config", "openghg", openghg_config_filename)
+        config_path = Path.home().joinpath(".ghgconfig", "openghg", openghg_config_filename)
     else:
         raise ValueError(f"Unknown platform: {user_platform}")
 

--- a/tests/util/test_user.py
+++ b/tests/util/test_user.py
@@ -38,7 +38,7 @@ def test_create_config(monkeypatch, mocker, tmpdir):
 
 
 def test_create_config_migrate(mocker, monkeypatch, tmp_path, caplog):
-    monkeypatch.setitem(os.environ, 'HOME', str(tmp_path))
+    monkeypatch.setitem(os.environ, "HOME", str(tmp_path))
 
     # make config file at tmp_path/.config/openghg/openghg.conf
     mock_old_config_path = tmp_path / ".config" / "openghg" / "openghg.conf"
@@ -52,7 +52,8 @@ def test_create_config_migrate(mocker, monkeypatch, tmp_path, caplog):
     create_config()
 
     assert f"create_config moved configuration file to {str(mock_new_config_path)}" in caplog.text
-    assert  mock_new_config_path.read_text() == mock_config_content
+    assert mock_new_config_path.read_text() == mock_config_content
+
 
 def test_check_config(mock_config, mocker, caplog):
     with pytest.raises(ValueError):
@@ -69,7 +70,7 @@ def test_check_config(mock_config, mocker, caplog):
 
 
 def test_migrate_config_success(mocker, monkeypatch, tmp_path):
-    monkeypatch.setitem(os.environ, 'HOME', str(tmp_path))
+    monkeypatch.setitem(os.environ, "HOME", str(tmp_path))
 
     # make config file at tmp_path/.config/openghg/openghg.conf
     mock_old_config_path = tmp_path / ".config" / "openghg" / "openghg.conf"
@@ -83,14 +84,14 @@ def test_migrate_config_success(mocker, monkeypatch, tmp_path):
     migrate_config()
 
     assert not mock_old_config_path.exists()
-    assert not mock_old_config_path.parent.exists() # openghg dir deleted
-    assert mock_old_config_path.parent.parent.exists() # don't delete .config
+    assert not mock_old_config_path.parent.exists()  # openghg dir deleted
+    assert mock_old_config_path.parent.parent.exists()  # don't delete .config
     assert mock_new_config_path.exists()
     assert mock_new_config_path.read_text() == mock_config_content
 
 
 def test_migrate_config_fail(monkeypatch, tmp_path):
-    monkeypatch.setitem(os.environ, 'HOME', str(tmp_path))
+    monkeypatch.setitem(os.environ, "HOME", str(tmp_path))
 
     with pytest.raises(FileNotFoundError):
         migrate_config()


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The main change is to make the user config path ~/.ghgconfig/openghg/openghg.conf instead of ~/.config/openghg/openghg.conf. This is a one line change to 'get_user_config_path'.

If a user were to pull this branch without moving their config, 'read_local_config' would break, so I created a function 'migrate_config' which looks for a config file in ~/.config/openghg; if a config file is found there, it to ~/.ghgconfig/opengh, removes the openghg directory from ~/.config, and writes a log message saying that the config has moved; otherwise, it raises a FileNotFoundError.

'read_local_config' will try 'migrate_config' if nothing exists at the path returned by 'get_user_config_path'. If 'migrate_config' raises an error, this will be re-raised by 'read_local_config', giving the same behavior as before. If 'migrate_config' is successful, then 'read_local_config' continues as normal.

I modified 'create_config' to try 'migrate_config' if nothing exists at the path returned by 'get_user_config_path'. I modified the logic of the function slightly, but if 'migrate_config' raises a FileNotFoundError, then a new config file is created as before, and if a config file is found in .ghgconfig, then the user is asked if they want to modify it (as before).

I added tests for 'migrate_config' and an extra test for 'create_config' to check this behavior.

* **Please check if the PR fulfills these requirements**

- [x] Closes #679 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
