### PR TITLE
Iss686 logger update

### DIFF
--- a/openghg/__init__.py
+++ b/openghg/__init__.py
@@ -57,18 +57,7 @@ if cloud_env or hub_env:
 else:
     logfile_path = str(_Path.home().joinpath("openghg.log"))
 
-# Create file handler for log file - set to DEBUG (maximum detail)
-fileHandler = logging.FileHandler(logfile_path)  # May want to update this to user area
-fileFormatter = logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s")
-fileHandler.setFormatter(fileFormatter)
-fileHandler.setLevel(logging.DEBUG)
-logger.addHandler(fileHandler)
-
-# Create console handler - set to WARNING (lower level)
-consoleHandler = logging.StreamHandler()
-consoleFormatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
-consoleHandler.setFormatter(consoleFormatter)
-consoleHandler.setLevel(logging.INFO)
-logger.addHandler(consoleHandler)
+util.add_file_handler(logger, logfile_path)
+util.add_stream_handler(logger)
 
 del logfile_path, hub_env, cloud_env

--- a/openghg/standardise/meta/_metadata.py
+++ b/openghg/standardise/meta/_metadata.py
@@ -3,7 +3,7 @@ import math
 from copy import deepcopy
 from typing import Dict, List, Optional
 from openghg.types import AttrMismatchError
-from openghg.util import is_number
+from openghg.util import is_number, remove_stream_handler
 
 logger = logging.getLogger("openghg.standardise.metadata")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -79,6 +79,7 @@ def sync_surface_metadata(
     from rich.progress import Progress
 
     progress = Progress()
+    remove_stream_handler(logger)  # Stop console output when using progress bar
     meta_copy = deepcopy(metadata)
 
     attr_mismatches = {}
@@ -142,7 +143,9 @@ def sync_surface_metadata(
             try:
                 meta_copy[key] = attributes[key]
             except KeyError:
-                progress.log(Warning(f"{key} key not in attributes or metadata"))
+                message_key = f"Warning: {key} key not in attributes or metadata"
+                logger.info(message_key)  # Add to log file
+                progress.log(Warning(message_key))  # Include with progress bar
             else:
                 if key in keys_as_floats:
                     meta_copy[key] = float(meta_copy[key])

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -4,6 +4,7 @@ import numpy as np
 from openghg.store.spec import define_data_types
 from pandas import DataFrame, Timestamp, Timedelta
 from xarray import Dataset
+from openghg.util import remove_stream_handler, add_stream_handler
 
 logger = logging.getLogger("openghg.store.base")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -126,6 +127,7 @@ class Datasource:
         from rich.progress import Progress
 
         progress = Progress()
+        remove_stream_handler(logger)  # Stop console output when using progress bar
         # Extract period associated with data from metadata
         # TODO: May want to add period as a potential data variable so would need to extract from there if needed
         period = self.get_period()
@@ -163,7 +165,9 @@ class Datasource:
                     ex = self._data.pop(existing_daterange)
                     new = new_data.pop(new_daterange)
 
-                    progress.log("Combining overlapping data dateranges")
+                    message = "Combining overlapping data dateranges"
+                    logger.info(message)  # Add to log file
+                    progress.log(message)  # Include with progress bar
                     # Concatenate datasets along time dimension
                     try:
                         combined = xr_concat((ex, new), dim=time_coord)

--- a/openghg/tutorial/_tutorial.py
+++ b/openghg/tutorial/_tutorial.py
@@ -11,6 +11,8 @@ from typing import List, Union
 import logging
 from openghg.standardise import standardise_footprint, standardise_flux, standardise_bc
 
+# TODO: Decide whether we want any of the tutorial output to add to the log file?
+# - May be better to include a print statement instead in this case?
 logger = logging.getLogger("openghg.tutorial")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -32,6 +32,7 @@ from ._file import (
 )
 from ._hashing import hash_bytes, hash_file, hash_retrieved_data, hash_string
 from ._inlet import format_inlet, extract_height_name
+from ._logging import add_file_handler, add_stream_handler, remove_stream_handler
 from ._site import get_site_info, sites_in_network
 from ._species import get_species_info, check_lifetime_monthly, molar_mass, species_lifetime, synonyms
 from ._strings import clean_string, is_number, remove_punctuation, to_lowercase

--- a/openghg/util/_logging.py
+++ b/openghg/util/_logging.py
@@ -1,0 +1,83 @@
+from typing import Union, Optional
+from pathlib import Path
+import logging
+
+__all__ = ["add_file_handler", "add_stream_handler", "remove_stream_handler"]
+
+
+def add_file_handler(logger: logging.Logger, logfile_path: Union[Path, str]) -> None:
+    """
+    Add FileHandler to a logger object for writing to a log file.
+    Args:
+        logger: Python Logger object
+        logfile_path: Filepath for log file
+    Returns:
+        None
+    """
+
+    # Create file handler for log file - set to DEBUG (maximum detail)
+    fileHandler = logging.FileHandler(logfile_path)  # May want to update this to user area
+    fileFormatter = logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s")
+    fileHandler.setFormatter(fileFormatter)
+    fileHandler.setLevel(logging.DEBUG)
+    logger.addHandler(fileHandler)
+
+
+def add_stream_handler(logger: logging.Logger, check_exists: bool = False) -> None:
+    """
+    Add StreamHandler to a logger object to use for writing to the console.
+    Args:
+        logger: Python Logger object
+    Returns:
+        None
+    """
+    # Create console handler - set to WARNING (lower level)
+    consoleHandler = logging.StreamHandler()
+    consoleFormatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+    consoleHandler.setFormatter(consoleFormatter)
+    consoleHandler.setLevel(logging.WARNING)
+
+    add_handler = True
+    if check_exists:
+        if _find_stream_handler(logger) is not None:
+            add_handler = False
+
+    if add_handler:
+        logger.addHandler(consoleHandler)
+    else:
+        print("StreamHandler already exists on logger object.")
+
+
+def _find_stream_handler(logger: logging.Logger) -> Optional[logging.StreamHandler]:
+    """
+    If present, find the (first) StreamHandler attached to a logger object.
+    Args:
+        logger: Python Logger object
+    Returns:
+        StreamHandler: if present
+        None: if no StreamHandler is present
+    """
+
+    handlers = logger.handlers
+    for handler in handlers:
+        if type(handler) is logging.StreamHandler:
+            return handler
+
+    return None
+
+
+def remove_stream_handler(logger: logging.Logger) -> None:
+    """
+    Remove existing StreamHandler attached to a Logger object.
+    Note: this will only remove the first instance found if multiple
+    are present.
+    Args:
+        logger: Python Logger object
+    Returns:
+        None
+    """
+    stream_handler = _find_stream_handler(logger)
+    if stream_handler is not None:
+        logger.removeHandler(stream_handler)
+    else:
+        print("No StreamHandler on logger object to remove")

--- a/openghg/util/_util.py
+++ b/openghg/util/_util.py
@@ -4,6 +4,7 @@
 from collections.abc import Iterable
 from typing import Any, Dict, Iterator, Optional, Tuple
 import logging
+from openghg.util import remove_stream_handler
 
 logger = logging.getLogger("openghg.util")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -198,6 +199,7 @@ def verify_site(site: str) -> Optional[str]:
     from openghg_defs import site_info_file
 
     progress = Progress()
+    remove_stream_handler(logger)  # Stop console output when using progress bar
     site_data = load_json(path=site_info_file)
 
     if site.upper() in site_data:
@@ -205,7 +207,10 @@ def verify_site(site: str) -> Optional[str]:
     else:
         site_code = site_code_finder(site_name=site)
         if site_code is None:
-            progress.log(Warning(f"Unable to find site code for {site}, please provide additional metadata."))
+            message = f"Warning: Unable to find site code for {site}, please provide additional metadata."
+            logger.info(message)
+            progress.log(message)
+
         return site_code
 
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This includes suggestions of how we could incorporate both the progress bar and the logging to output file. This builds on the rich tool kit added previously (branched off [Iss686_tqdm_to_rich_progress_bar](https://github.com/openghg/openghg/tree/Iss686_tqdm_to_rich_progress_bar)). At the moment, this basically just turns off the standard out from the logger when the progress bar is in use

* **Please check if the PR fulfills these requirements**

- [x] All tests pass (none added at present)
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
