### PR TITLE
Iss701 - Fix lowercasing of metadata causing object store lookup issues

### DIFF
--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -130,8 +130,13 @@ class BaseStore:
             else:
                 datasource = Datasource.load(bucket=self._bucket, uuid=uuid)
 
+            # TODO - remove this when the lowercasing of metadata gets removed
+            # We currently lowercase all the metadata and some keys we don't want to change, such as paths to the object store
+            skip_keys = ["object_store"]
             # Add the dataframe to the datasource
-            datasource.add_data(metadata=meta_copy, data=_data, overwrite=overwrite, data_type=data_type)
+            datasource.add_data(
+                metadata=meta_copy, data=_data, overwrite=overwrite, data_type=data_type, skip_keys=skip_keys
+            )
             # Save Datasource to object store
             datasource.save(bucket=self._bucket)
 

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -91,6 +91,9 @@ class BaseStore:
         uuids = {}
 
         lookup_results = self.datasource_lookup(data=data, required_keys=required_keys, min_keys=min_keys)
+        # TODO - remove this when the lowercasing of metadata gets removed
+        # We currently lowercase all the metadata and some keys we don't want to change, such as paths to the object store
+        skip_keys = ["object_store"]
 
         for key, parsed_data in data.items():
             metadata = parsed_data["metadata"]
@@ -123,16 +126,13 @@ class BaseStore:
 
                 # Make sure all the metadata is lowercase for easier searching later
                 # TODO - do we want to do this or should be just perform lowercase comparisons?
-                meta_copy = to_lowercase(d=meta_copy)
+                meta_copy = to_lowercase(d=meta_copy, skip_keys=skip_keys)
                 # TODO - 2023-05-25 - Remove the need for this key, this should just be a set
                 # so we can have rapid
                 self._datasource_uuids[uid] = key
             else:
                 datasource = Datasource.load(bucket=self._bucket, uuid=uuid)
 
-            # TODO - remove this when the lowercasing of metadata gets removed
-            # We currently lowercase all the metadata and some keys we don't want to change, such as paths to the object store
-            skip_keys = ["object_store"]
             # Add the dataframe to the datasource
             datasource.add_data(
                 metadata=meta_copy, data=_data, overwrite=overwrite, data_type=data_type, skip_keys=skip_keys

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -84,6 +84,7 @@ class Datasource:
         metadata: Dict,
         data: Dataset,
         data_type: str,
+        skip_keys: Optional[List] = None,
         overwrite: Optional[bool] = False,
     ) -> None:
         """Add data to this Datasource and segment the data by size.
@@ -103,7 +104,7 @@ class Datasource:
         if data_type not in expected_data_types:
             raise TypeError(f"Incorrect data type selected. Please select from one of {expected_data_types}")
 
-        self.add_metadata(metadata=metadata)
+        self.add_metadata(metadata=metadata, skip_keys=skip_keys)
 
         if "time" in data.coords:
             return self.add_timed_data(data=data, data_type=data_type)
@@ -248,7 +249,7 @@ class Datasource:
         for key in set(keys):
             delete_object(bucket=bucket, key=key)
 
-    def add_metadata(self, metadata: Dict) -> None:
+    def add_metadata(self, metadata: Dict, skip_keys: Optional[List] = None) -> None:
         """Add all metadata in the dictionary to this Datasource
 
         Args:
@@ -258,7 +259,7 @@ class Datasource:
         """
         from openghg.util import to_lowercase
 
-        lowercased: Dict = to_lowercase(metadata)
+        lowercased: Dict = to_lowercase(metadata, skip_keys=skip_keys)
         self._metadata.update(lowercased)
 
     def get_dataframe_daterange(self, dataframe: DataFrame) -> Tuple[Timestamp, Timestamp]:

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -7,8 +7,10 @@ from typing import Dict, List, Union
 
 
 def temporary_store_paths() -> Dict[str, Path]:
+    # Add some uppercasing and numbers here to enusure paths work
+    # with other characters - see https://github.com/openghg/openghg/issues/701
     return {
-        "user": Path(tempfile.gettempdir(), "openghg_testing_store"),
+        "user": Path(tempfile.gettempdir(), "openghg_testing-STORE_123"),
         "group": Path(tempfile.gettempdir(), "openghg_testing_group_store"),
         "shared": Path(tempfile.gettempdir(), "openghg_testing_shared_store"),
     }


### PR DESCRIPTION
* **Summary of changes**
This fixes the issue with the object store path being lowercased in the metadata resulting in
paths with uppercase letters being invalid on case-sensitive systems. It does this by allowing the passing in
of a `skip_keys` value in the `BaseStore.assign_data` function which is passed down to `Datasource.add_metadata`.

* **Please check if the PR fulfills these requirements**

- [x] Closes #701 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
