### PR TITLE
Fix for string being interpreted as list on key delete in DataManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to OpenGHG will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/openghg/openghg/compare/0.6.0...HEAD)
+## [Unreleased](https://github.com/openghg/openghg/compare/0.6.1...HEAD)
+
+## [0.6.1] - 2023-07-xx
+
+### Fixed
+
+- Bug in `DataManager` where a string was interpreted as a list when processing metadata keys to be deleted - [PR #713](https://github.com/openghg/openghg/pull/713)
 
 ## [0.6.0] - 2023-07-18
 

--- a/openghg/dataobjects/_datamanager.py
+++ b/openghg/dataobjects/_datamanager.py
@@ -163,6 +163,9 @@ class DataManager:
 
                 # Do a quick check to make sure we're not being asked to delete all the metadata
                 if to_delete is not None:
+                    if not isinstance(to_delete, list):
+                        to_delete = [to_delete]
+
                     if "uuid" in to_delete:
                         raise ValueError("Cannot delete the UUID key.")
 

--- a/tests/dataobjects/test_datamanager.py
+++ b/tests/dataobjects/test_datamanager.py
@@ -214,7 +214,8 @@ def test_delete_metadata_keys():
 
     assert res.metadata["test-uuid-100"].items() >= expected.items()
 
-    res.update_metadata(uuid="test-uuid-100", to_delete=["species"])
+    # Delete a key giving it a string
+    res.update_metadata(uuid="test-uuid-100", to_delete="species")
 
     res = data_manager(data_type="surface", site="tac", inlet="100m", store="user")
 
@@ -223,6 +224,16 @@ def test_delete_metadata_keys():
     res = data_manager(data_type="surface", site="tac", species="ch4", inlet="100m", store="user")
 
     assert not res
+
+    res = data_manager(data_type="surface", site="tac", inlet="100m", store="user")
+
+    # Delete keys passing in a list
+    res.update_metadata(uuid="test-uuid-100", to_delete=["site", "inlet"])
+
+    res.refresh()
+
+    assert "site" not in res.metadata["test-uuid-100"]
+    assert "inlet" not in res.metadata["test-uuid-100"]
 
 
 def test_delete_and_modify_keys():


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Fixes a bug where a string was interpreted as a list when deleting metadata keys in `DataManager`

* **Please check if the PR fulfills these requirements**

- [x] Closes #712 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
