### PR TITLE
Fix for object_store not being present in Datasource metadata

### DIFF
--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -597,6 +597,9 @@ def _base_search(**kwargs: Any) -> SearchResults:
                     if res:
                         metastore_records.extend(res)
 
+        if not metastore_records:
+            continue
+
         # Add in a quick check to make sure we don't have dupes
         # TODO - remove this once a more thorough tests are added
         uuids = [s["uuid"] for s in metastore_records]
@@ -609,6 +612,9 @@ def _base_search(**kwargs: Any) -> SearchResults:
         # we'll create a pandas DataFrame out of this in the SearchResult object
         # for better printing / searching within a notebook
         metadata = {r["uuid"]: r for r in metastore_records}
+        # Add in the object store to the metadata the user sees
+        for m in metadata.values():
+            m.update({"object_store": bucket})
 
         # Narrow the search to a daterange if dates passed
         if start_date is not None or end_date is not None:

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -121,9 +121,6 @@ class BaseStore:
                 datasource = Datasource()
                 uid = datasource.uuid()
                 meta_copy["uuid"] = uid
-                # For retrieval later we'll need to know which bucket this is stored in
-                meta_copy["object_store"] = self._bucket
-
                 # Make sure all the metadata is lowercase for easier searching later
                 # TODO - do we want to do this or should be just perform lowercase comparisons?
                 meta_copy = to_lowercase(d=meta_copy, skip_keys=skip_keys)

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -259,6 +259,13 @@ class Datasource:
         """
         from openghg.util import to_lowercase
 
+        try:
+            del metadata["object_store"]
+        except KeyError:
+            pass
+        else:
+            logger.warning("object_store should not be added to the metadata, removing.")
+
         lowercased: Dict = to_lowercase(metadata, skip_keys=skip_keys)
         self._metadata.update(lowercased)
 

--- a/tests/dataobjects/test_datamanager.py
+++ b/tests/dataobjects/test_datamanager.py
@@ -317,7 +317,7 @@ def test_delete_data():
     with ObsSurface(bucket) as obs:
         assert uid not in obs._datasource_uuids
 
-
+@pytest.mark.xfail(reason="Failing due to the Datasource save bug - issue 724")
 def test_metadata_backup_restore():
     res_one = data_manager(data_type="surface", site="tac", inlet="100m", species="ch4", store="user")
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Removes the `object_store` key from the Datasource metadata to avoid issues when folders are moved etc.
The object store key is now added to the metadata presented to the user by the `SearchResults` object.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #709 
- [ ] Closes #723 
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
