### PR TITLE
Fix for bucket being saved to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to OpenGHG will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/openghg/openghg/compare/0.6.1...HEAD)
+## [Unreleased](https://github.com/openghg/openghg/compare/0.6.2...HEAD)
+
+## [0.6.2] - 2023-08-07
+
+### Fixed
+
+- Bug where the object store path being written to JSON led to an invalid path being given to some users - [PR #741](https://github.com/openghg/openghg/pull/741)
 
 ## [0.6.1] - 2023-08-04
 

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -32,14 +32,15 @@ class BaseStore:
         # Hashes of previously stored data from other data platforms
         self._retrieved_hashes: Dict[str, Dict] = {}
         # Where we'll store this object
-        self._bucket = bucket
         self._metakey = ""
-        self._metastore = load_metastore(bucket=bucket, key=self.metakey())
 
         if exists(bucket=bucket, key=self.key()):
             data = get_object_from_json(bucket=bucket, key=self.key())
             # Update myself
             self.__dict__.update(data)
+
+        self._metastore = load_metastore(bucket=bucket, key=self.metakey())
+        self._bucket = bucket
 
     @classmethod
     def metakey(cls) -> str:
@@ -56,7 +57,7 @@ class BaseStore:
     def to_data(self) -> Dict:
         # We don't need to store the metadata store, it has its own location
         # QUESTION - Is this cleaner than the previous specifying
-        DO_NOT_STORE = ["_metastore"]
+        DO_NOT_STORE = ["_metastore", "_bucket"]
         return {k: v for k, v in self.__dict__.items() if k not in DO_NOT_STORE}
 
     def assign_data(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def default_session_fixture() -> Iterator[None]:
         "object_store": {
             "user": {"path": str(tmp_store_paths["user"]), "permissions": "rw"},
             "group": {"path": str(tmp_store_paths["group"]), "permissions": "rw"},
-            "shared": {"path": str(tmp_store_paths["group"]), "permissions": "r"},
+            "shared": {"path": str(tmp_store_paths["shared"]), "permissions": "r"},
         },
         "user_id": "test-id-123",
         "config_version": "2",

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -1,16 +1,19 @@
+import os
 import json
 import pytest
 import xarray as xr
 from helpers import attributes_checker_obssurface, get_surface_datapath, clear_test_stores
+from pathlib import Path
 from openghg.objectstore import (
     exists,
     get_bucket,
     get_writable_bucket,
-    get_object_from_json,
     set_object_from_json,
+    get_object_from_json,
 )
 from openghg.store import ObsSurface
 from openghg.store.base import Datasource
+from openghg.retrieve import search_surface
 from openghg.util import create_daterange_str
 from pandas import Timestamp
 
@@ -910,23 +913,23 @@ def test_gcwerks_fp_not_a_tuple_raises():
             obs.read_file(filepath=filepath, source_format="gc", site="cgo", network="agage")
 
 
-def test_get_store_path():
-    bucket = get_bucket()
-    print(bucket)
-
-
-def test_object_loads_if_invalid_objectstore_path_in_json():
+def test_object_loads_if_invalid_objectstore_path_in_json(tmpdir):
     bucket = get_writable_bucket(name="group")
-
-    with ObsSurface(bucket=bucket) as obs:
-        key = obs.key()
-
-    stored_obj = get_object_from_json(bucket=bucket, key=key)
-    stored_obj.update({"_bucket": "/tmp/nonexistent/path/123"})
-
-    set_object_from_json(bucket=bucket, key=key, data=stored_obj)
 
     filepath = get_surface_datapath(filename="bsd.picarro.1minute.248m.min.dat", source_format="CRDS")
 
     with ObsSurface(bucket=bucket) as obs:
         obs.read_file(filepath=filepath, source_format="CRDS", site="bsd", network="DECC")
+        key = obs.key()
+
+    no_permissions = Path(tmpdir).joinpath("invalid_path")
+    no_permissions.mkdir()
+    os.chmod(no_permissions, 0o444)
+
+    # Someone else comes along and changes the value
+    stored_obj = get_object_from_json(bucket=bucket, key=key)
+    stored_obj.update({"_bucket": str(no_permissions)})
+    set_object_from_json(bucket=bucket, key=key, data=stored_obj)
+
+    # Now we search for the object, in versions before 0.6.2 this would cause a PermissionError
+    search_surface(site="bsd", species="ch4")

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -914,6 +914,12 @@ def test_gcwerks_fp_not_a_tuple_raises():
 
 
 def test_object_loads_if_invalid_objectstore_path_in_json(tmpdir):
+    """This was added due to an issue found where in versions of OpenGHG < 0.6.2
+    the _bucket variable was written to JSON. If this _bucket variable was updated to
+    a path that another user couldn't access (such a symlink in a user's home directory
+    the group object store) then subsequent instances of the class would fail due to that bucket
+    path being invalid. See https://github.com/openghg/openghg/issues/740
+    """
     bucket = get_writable_bucket(name="group")
 
     filepath = get_surface_datapath(filename="bsd.picarro.1minute.248m.min.dat", source_format="CRDS")


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This stops the saving of the bucket path to the object JSON and updates the base store constructor so the class variable is assigned to after the JSON data is loaded in. This should allow this update to fix the issue without any intervention from the user.

* **Please check if the PR fulfills these requirements**

- [x] Closes #740 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
