### PR TITLE
Add openghg conda channel

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -131,6 +131,7 @@ jobs:
         run: |
           micromamba create -n openghg_build anaconda-client boa -c conda-forge
           micromamba activate openghg_build
+          conda config --append channels openghg
           mkdir ${{ github.workspace }}/build
           conda mambabuild --croot ${{ github.workspace }}/build recipes -c conda-forge
           BUILD_DIR=${GITHUB_WORKSPACE}/build


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This adds the OpenGHG conda channel. It's done this way using `conda config --append ...` to avoid issues with conda thinking the local openghg folder is a channel and erroring.

* **Please check if the PR fulfills these requirements**

- [x] Closes #739 
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
