### PR TITLE
Iss749 add compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.6.2...HEAD)
 
+## Added
+
+- Added compression to `Datasource.save` and modified `Datasource.load` to take advantage of
+  lazy loading via `xarray.open_dataset` - [PR #755](https://github.com/openghg/openghg/pull/755)
+
 ## [0.6.2] - 2023-08-07
 
 ### Fixed

--- a/openghg/objectstore/__init__.py
+++ b/openghg/objectstore/__init__.py
@@ -26,6 +26,7 @@ else:
         get_all_object_names,
         get_bucket,
         get_object,
+        get_object_data_path,
         get_object_from_json,
         get_object_names,
         get_objectstore_info,

--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -20,6 +20,7 @@ __all__ = [
     "get_all_object_names",
     "get_object_names",
     "get_object",
+    "get_object_data_path",
     "set_object",
     "set_object_from_json",
     "set_object_from_file",
@@ -221,6 +222,23 @@ def get_object(bucket: str, key: str) -> bytes:
             return filepath.read_bytes()
         else:
             raise ObjectStoreError(f"No object at key '{key}'")
+
+
+def get_object_data_path(bucket: str, key: str) -> Path:
+    """Get path to object data at key in passed bucket.
+
+    Args:
+        bucket: Bucket containing data
+        key: Key for data in bucket
+    Returns:
+        Path to data
+    """
+    filepath = Path(f"{bucket}/{key}._data")
+
+    if filepath.exists():
+        return filepath
+    else:
+        raise ObjectStoreError(f"No object at key '{key}'")
 
 
 def set_object(bucket: str, key: str, data: bytes) -> None:

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -615,10 +615,12 @@ class Datasource:
                             encoding[var] = enc
 
                     try:
+#                        breakpoint()
                         data.to_netcdf(filepath, engine="netcdf4", encoding=encoding)
                     except RuntimeError:
+                        raise
                         logger.warning(
-                            "Storing footprint for date range {daterange} without compression due to netCDF4 RuntimeError."
+                            f"Storing footprint for date range {daterange} without compression due to netCDF4 RuntimeError."
                         )
                         data.to_netcdf(filepath, engine="netcdf4")
                     except ValueError as e:

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -615,7 +615,6 @@ class Datasource:
                             encoding[var] = enc
 
                     try:
-#                        breakpoint()
                         data.to_netcdf(filepath, engine="netcdf4", encoding=encoding)
                     except RuntimeError:
                         logger.warning(

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -543,7 +543,7 @@ class Datasource:
 
         return d
 
-    def save(self, bucket: str, compression: bool=True) -> None:
+    def save(self, bucket: str, compression: bool = True) -> None:
         """Save this Datasource object as JSON to the object store
 
         Args:

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -1,4 +1,5 @@
 from pandas import DataFrame, Timestamp, Timedelta
+import xarray as xr
 from xarray import Dataset
 from collections import defaultdict
 import re
@@ -488,11 +489,14 @@ class Datasource:
     def load_dataset(bucket: str, key: str) -> Dataset:
         """Loads a xarray Dataset from the passed key for creation of a Datasource object
 
-        Currently this function gets binary data back from the object store, writes it
-        to a temporary file and then gets xarray to read from this file.
+        Data is lazy-loaded because we use `xarray.open_dataset`. This means that the
+        file handler for the data file remains open until the data is actually required.
 
-        This is done in a long winded way due to xarray not being able to create a Dataset
-        from binary data at the moment.
+        This improves performance, since we often only update one or two chunks of the dataset
+        at a time.
+
+        This may cause problems with thread safety if another thread tries to write to the
+        datasource at the same time.
 
         Args:
             bucket: Bucket containing data
@@ -500,14 +504,10 @@ class Datasource:
         Returns:
             xarray.Dataset: Dataset from NetCDF file
         """
-        import io
-        from pathlib import Path
-        from openghg.objectstore import get_object
-        from xarray import load_dataset, open_dataset
+        from openghg.objectstore import get_object_data_path
 
-        return load_dataset(io.BytesIO(get_object(bucket=bucket, key=key)))
-        # file_path = Path(f"{bucket}/{key}._data")
-        # return open_dataset(file_path)
+        file_path = get_object_data_path(bucket, key)
+        return xr.open_dataset(file_path)
 
     @classmethod
     def from_data(cls: Type[T], bucket: str, data: Dict, shallow: bool) -> T:
@@ -598,9 +598,18 @@ class Datasource:
                     # setting compression levels for data vars in data
                     comp = dict(zlib=True, complevel=5)
 
-                    valid_encoding_keys = ['zlib', 'fletcher32', 'dtype', 'complevel',
-                                           'chunksizes', 'compression', 'shuffle',
-                                           'contiguous', 'least_significant_digit', '_FillValue']
+                    valid_encoding_keys = [
+                        "zlib",
+                        "fletcher32",
+                        "dtype",
+                        "complevel",
+                        "chunksizes",
+                        "compression",
+                        "shuffle",
+                        "contiguous",
+                        "least_significant_digit",
+                        "_FillValue",
+                    ]
                     encoding = {}
                     for var in data.data_vars:
                         if var not in do_not_compress:
@@ -611,14 +620,16 @@ class Datasource:
                     try:
                         data.to_netcdf(filepath, engine="netcdf4", encoding=encoding)
                     except RuntimeError:
-                        #logger.warning("Storing footprint for date range {daterange} without compression due to netCDF4 RuntimeError.")
+                        logger.warning(
+                            "Storing footprint for date range {daterange} without compression due to netCDF4 RuntimeError."
+                        )
                         data.to_netcdf(filepath, engine="netcdf4")
                     except ValueError as e:
                         # chunksize might be set if the data was read from a netCDF file
                         # and sometimes this causes errors.
                         if "chunksize" in e.args[0].lstrip().split():
                             for k in encoding:
-                                encoding[k]['chunksizes'] = None
+                                encoding[k]["chunksizes"] = None
                             data.to_netcdf(filepath, engine="netcdf4", encoding=encoding)
                         else:
                             raise e

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -495,9 +495,6 @@ class Datasource:
         This improves performance, since we often only update one or two chunks of the dataset
         at a time.
 
-        This may cause problems with thread safety if another thread tries to write to the
-        datasource at the same time.
-
         Args:
             bucket: Bucket containing data
             key: Key for data
@@ -546,7 +543,7 @@ class Datasource:
 
         return d
 
-    def save(self, bucket: str, compression=True) -> None:
+    def save(self, bucket: str, compression: bool=True) -> None:
         """Save this Datasource object as JSON to the object store
 
         Args:

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -607,7 +607,7 @@ class Datasource:
                             enc = {k: v for k, v in data[var].encoding.items() if k in valid_encoding_keys}
                             enc.update(comp)
                             encoding[var] = enc
-                    print("encoding:", encoding)
+
                     try:
                         data.to_netcdf(filepath, engine="netcdf4", encoding=encoding)
                     except RuntimeError:

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -618,7 +618,6 @@ class Datasource:
 #                        breakpoint()
                         data.to_netcdf(filepath, engine="netcdf4", encoding=encoding)
                     except RuntimeError:
-                        raise
                         logger.warning(
                             f"Storing footprint for date range {daterange} without compression due to netCDF4 RuntimeError."
                         )

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -822,7 +822,7 @@ def test_store_icos_carbonportal_data(mocker):
     # First we need to jump through some hoops to get the correct data dict
     # I feel like there must be a simpler way of doing this but xarray.to_json
     # doesn't convert datetimes correctly
-    fake_uuids = ["test-uuid-1", "test-uuid-2", "test-uuid-3"]
+    fake_uuids = [f"test-uuid-{i}" for i in range(1, 101)]
     mocker.patch("uuid.uuid4", side_effect=fake_uuids)
 
     test_data_nc = get_surface_datapath(filename="test_toh_co2_147m.nc", source_format="ICOS")


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

1. Compression level for saving Datasources is increased from 4 to 5.
(Compression level 4 seems to be the default.) I added a test to show
that increasing compression does actually result in small files on disk.

2. `Datasource.load_dataset` now uses `xarray.open_dataset` instead
of `xarray.load_dataset`, which should lazy-load data. This gives a 
33% decrease in the time taken to run all of the tests on my machine.

I couldn't make a useful test to demonstrate that data is lazy-loaded,
but the xarray docs state that this is the case:

https://docs.xarray.dev/en/latest/user-guide/io.html#reading-encoded-data

(They say data is "always lazy loaded from netcdf", although the docs for
`load_dataset` say the opposite.)

*If* `load_dataset` is putting all data in memory, and `open_dataset` is
lazy-loading data, this should drastically reduce the amount of memory needed
to add footprints to the object store.


* **Please check if the PR fulfills these requirements**

- [x] Closes #749 (partially... I suggested using a script to compress anything already in the object store, but maybe it won't matter too much)
- [x] Closes #454 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
