### PR TITLE
Updated standardise module, applied to tests

### DIFF
--- a/openghg/standardise/__init__.py
+++ b/openghg/standardise/__init__.py
@@ -1,8 +1,12 @@
 from ._standardise import (
+    standardise,
     standardise_bc,
     standardise_flux,
     standardise_footprint,
     standardise_column,
     standardise_surface,
+    standardise_from_binary_data,
+    standardise_from_remote_source,
+    standardise_via_transform,
 )
 from ._summarise import summary_source_formats, summary_site_codes

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -1,18 +1,33 @@
 from pathlib import Path
-from typing import Dict, Literal, Optional, Union
+from typing import Dict, Literal, Optional, Union, cast
 from pandas import Timedelta
 
+from openghg.store.spec import define_data_type_classes
 from openghg.cloud import create_file_package, create_post_dict
 from openghg.objectstore import get_writable_bucket
 from openghg.util import running_on_hub
 from openghg.types import optionalPathType, multiPathType
 
 
+def standardise(
+    bucket: str, data_type: str, filepath: multiPathType, **kwargs
+) -> Optional[dict]:
+    try:
+        dclass = define_data_type_classes()[data_type]
+    except KeyError:
+        raise ValueError(f"No standarising function found for data type {data_type}.")
+    else:
+        with dclass(bucket) as dc:
+            result = dc.read_file(filepath=filepath, **kwargs)
+    return result
+
+
 def standardise_surface(
-    filepaths: multiPathType,
     source_format: str,
     network: str,
     site: str,
+    filepath: Optional[multiPathType] = None,
+    filepaths: Optional[multiPathType] = None,
     inlet: Optional[str] = None,
     height: Optional[str] = None,
     instrument: Optional[str] = None,
@@ -24,6 +39,7 @@ def standardise_surface(
     verify_site_code: bool = True,
     site_filepath: optionalPathType = None,
     store: Optional[str] = None,
+    bucket: Optional[str] = None,
 ) -> Optional[Dict]:
     """Standardise surface measurements and store the data in the object store.
 
@@ -52,14 +68,19 @@ def standardise_surface(
             Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
         store: Name of object store to write to, required if user has access to more than one
         writable store
+        bucket: object store bucket to use; this takes precendence over 'store'
     Returns:
         dict: Dictionary of result data
     """
     from openghg.cloud import call_function
-    from openghg.store import ObsSurface
 
-    if not isinstance(filepaths, list):
-        filepaths = [filepaths]
+    if filepath is None and filepaths is None:
+        raise ValueError("One of `filepath` and `filepaths` must be specified.")
+    elif filepath is None:
+        filepath = filepaths
+
+    if not isinstance(filepath, list):
+        filepath = [filepath]
 
     if running_on_hub():
         # TODO: Use input for site_filepath here? How to include this?
@@ -84,7 +105,7 @@ def standardise_surface(
             metadata["sampling_period"] = sampling_period
 
         responses = {}
-        for fpath in filepaths:
+        for fpath in filepath:
             gcwerks = False
             if source_format.lower() in ("gc", "gcwerks"):
                 metadata["source_format"] = "gcwerks"
@@ -136,27 +157,27 @@ def standardise_surface(
 
         return responses
     else:
-        bucket = get_writable_bucket(name=store)
+        if bucket is None:
+            bucket = get_writable_bucket(name=store)
 
-        with ObsSurface(bucket=bucket) as obs:
-            results = obs.read_file(
-                filepath=filepaths,
-                source_format=source_format,
-                network=network,
-                site=site,
-                inlet=inlet,
-                height=height,
-                instrument=instrument,
-                sampling_period=sampling_period,
-                calibration_scale=calibration_scale,
-                measurement_type=measurement_type,
-                overwrite=overwrite,
-                verify_site_code=verify_site_code,
-                site_filepath=site_filepath,
-                update_mismatch=update_mismatch,
-            )
-
-        return results
+        return standardise(
+            bucket=bucket,
+            data_type="surface",
+            filepath=filepath,
+            source_format=source_format,
+            network=network,
+            site=site,
+            inlet=inlet,
+            height=height,
+            instrument=instrument,
+            sampling_period=sampling_period,
+            calibration_scale=calibration_scale,
+            measurement_type=measurement_type,
+            overwrite=overwrite,
+            verify_site_code=verify_site_code,
+            site_filepath=site_filepath,
+            update_mismatch=update_mismatch,
+        )
 
 
 def standardise_column(
@@ -172,6 +193,7 @@ def standardise_column(
     source_format: str = "openghg",
     overwrite: bool = False,
     store: Optional[str] = None,
+    bucket: Optional[str] = None,
 ) -> Optional[Dict]:
     """Read column observation file
 
@@ -195,11 +217,11 @@ def standardise_column(
         source_format : Type of data being input e.g. openghg (internal format)
         overwrite: Should this data overwrite currently stored data.
         store: Name of store to write to
+        bucket: object store bucket to use; this takes precendence over 'store'
     Returns:
         dict: Dictionary containing confirmation of standardisation process.
     """
     from openghg.cloud import call_function
-    from openghg.store import ObsColumn
 
     filepath = Path(filepath)
 
@@ -230,24 +252,24 @@ def standardise_column(
         response_content: Dict = fn_response["content"]
         return response_content
     else:
-        bucket = get_writable_bucket(name=store)
+        if bucket is None:
+            bucket = get_writable_bucket(name=store)
 
-        with ObsColumn(bucket=bucket) as obs_col:
-            result = obs_col.read_file(
-                filepath=filepath,
-                satellite=satellite,
-                domain=domain,
-                selection=selection,
-                site=site,
-                species=species,
-                network=network,
-                instrument=instrument,
-                platform=platform,
-                source_format=source_format,
-                overwrite=overwrite,
-            )
-
-        return result
+        return standardise(
+            bucket=bucket,
+            data_type="column",
+            filepath=filepath,
+            satellite=satellite,
+            domain=domain,
+            selection=selection,
+            site=site,
+            species=species,
+            network=network,
+            instrument=instrument,
+            platform=platform,
+            source_format=source_format,
+            overwrite=overwrite,
+        )
 
 
 def standardise_bc(
@@ -259,6 +281,7 @@ def standardise_bc(
     continuous: bool = True,
     overwrite: bool = False,
     store: Optional[str] = None,
+    bucket: Optional[str] = None,
 ) -> Optional[Dict]:
     """Standardise boundary condition data and store it in the object store.
 
@@ -273,11 +296,11 @@ def standardise_bc(
         continuous: Whether time stamps have to be continuous.
         overwrite: Should this data overwrite currently stored data.
         store: Name of store to write to
+        bucket: object store bucket to use; this takes precendence over 'store'
     returns:
         dict: Dictionary containing confirmation of standardisation process.
     """
     from openghg.cloud import call_function
-    from openghg.store import BoundaryConditions
 
     filepath = Path(filepath)
 
@@ -303,19 +326,19 @@ def standardise_bc(
         response_content: Dict = fn_response["content"]
         return response_content
     else:
-        bucket = get_writable_bucket(name=store)
-        with BoundaryConditions(bucket=bucket) as bcs:
-            result = bcs.read_file(
-                filepath=filepath,
-                species=species,
-                bc_input=bc_input,
-                domain=domain,
-                period=period,
-                continuous=continuous,
-                overwrite=overwrite,
-            )
-
-        return result
+        if bucket is None:
+            bucket = get_writable_bucket(name=store)
+        return standardise(
+            bucket=bucket,
+            data_type="boundary_conditions",
+            filepath=filepath,
+            species=species,
+            bc_input=bc_input,
+            domain=domain,
+            period=period,
+            continuous=continuous,
+            overwrite=overwrite,
+        )
 
 
 def standardise_footprint(
@@ -336,6 +359,7 @@ def standardise_footprint(
     high_time_resolution: bool = False,
     overwrite: bool = False,
     store: Optional[str] = None,
+    bucket: Optional[str] = None,
 ) -> Optional[Dict]:
     """Reads footprint data files and returns the UUIDs of the Datasources
     the processed data has been assigned to
@@ -359,12 +383,12 @@ def standardise_footprint(
                         Note this will be set to True automatically for Carbon Dioxide data.
         overwrite: Overwrite any currently stored data
         store: Name of store to write to
+        bucket: object store bucket to use; this takes precendence over 'store'
     Returns:
         dict / None: Dictionary containing confirmation of standardisation process. None
         if file already processed.
     """
     from openghg.cloud import call_function
-    from openghg.store import Footprints
 
     filepath = Path(filepath)
 
@@ -399,28 +423,28 @@ def standardise_footprint(
         response_content: Dict = fn_response["content"]
         return response_content
     else:
-        bucket = get_writable_bucket(name=store)
-        with Footprints(bucket=bucket) as fps:
-            result = fps.read_file(
-                filepath=filepath,
-                site=site,
-                domain=domain,
-                model=model,
-                inlet=inlet,
-                height=height,
-                metmodel=metmodel,
-                species=species,
-                network=network,
-                period=period,
-                chunks=chunks,
-                continuous=continuous,
-                retrieve_met=retrieve_met,
-                high_spatial_resolution=high_spatial_resolution,
-                high_time_resolution=high_time_resolution,
-                overwrite=overwrite,
-            )
-
-        return result
+        if bucket is None:
+            bucket = get_writable_bucket(name=store)
+        return standardise(
+            bucket=bucket,
+            data_type="footprints",
+            filepath=filepath,
+            site=site,
+            domain=domain,
+            model=model,
+            inlet=inlet,
+            height=height,
+            metmodel=metmodel,
+            species=species,
+            network=network,
+            period=period,
+            chunks=chunks,
+            continuous=continuous,
+            retrieve_met=retrieve_met,
+            high_spatial_resolution=high_spatial_resolution,
+            high_time_resolution=high_time_resolution,
+            overwrite=overwrite,
+        )
 
 
 def standardise_flux(
@@ -437,6 +461,7 @@ def standardise_flux(
     continuous: bool = True,
     overwrite: bool = False,
     store: Optional[str] = None,
+    bucket: Optional[str] = None,
 ) -> Optional[Dict]:
     """Process flux data
 
@@ -452,11 +477,11 @@ def standardise_flux(
         continuous: Whether time stamps have to be continuous.
         overwrite: Should this data overwrite currently stored data.
         store: Name of store to write to
+        bucket: object store bucket to use; this takes precendence over 'store'
     returns:
         dict: Dictionary of Datasource UUIDs data assigned to
     """
     from openghg.cloud import call_function
-    from openghg.store import Emissions
 
     filepath = Path(filepath)
 
@@ -489,72 +514,62 @@ def standardise_flux(
         response_content: Dict = fn_response["content"]
         return response_content
     else:
-        bucket = get_writable_bucket(name=store)
-        with Emissions(bucket=bucket) as ems:
-            return ems.read_file(
-                filepath=filepath,
-                species=species,
-                source=source,
-                domain=domain,
-                database=database,
-                database_version=database_version,
-                model=model,
-                high_time_resolution=high_time_resolution,
-                period=period,
-                continuous=continuous,
-                chunks=chunks,
-                overwrite=overwrite,
-            )
+        if bucket is None:
+            bucket = get_writable_bucket(name=store)
+        return standardise(
+            data_type="emissions",
+            bucket=bucket,
+            filepath=filepath,
+            species=species,
+            source=source,
+            domain=domain,
+            database=database,
+            database_version=database_version,
+            model=model,
+            high_time_resolution=high_time_resolution,
+            period=period,
+            continuous=continuous,
+            chunks=chunks,
+            overwrite=overwrite,
+        )
 
 
-# def upload_to_par(filepath: Optional[Union[str, Path]] = None, data: Optional[bytes] = None) -> None:
-#     """Upload a file to the object store
+def standardise_from_binary_data(
+    bucket: str, data_type: str, binary_data, metadata, file_metadata
+) -> Optional[dict]:
+    try:
+        dclass = define_data_type_classes()[data_type]
+    except KeyError:
+        raise ValueError(f"No data class found for data type {data_type}.")
+    else:
+        with dclass(bucket) as dc:
+            result = dc.read_data(binary_data=binary_data, metadata=metadata, file_metadata=file_metadata)
+    return result
 
-#     Args:
-#         filepath: Path of file to upload
-#     Returns:
-#         None
-#     """
-#     from gzip import compress
-#     import tempfile
-#     from openghg.objectstore import PAR
-#     from openghg.client import get_function_url, get_auth_key
 
-#     auth_key = get_auth_key()
-#     fn_url = get_function_url(fn_name="get_par")
-#     # First we need to get a PAR to write the data
+def standardise_from_remote_source(bucket: str, data_type: str, data: dict, **kwargs) -> Optional[dict]:
+    try:
+        dclass = define_data_type_classes()[data_type]
+    except KeyError:
+        raise ValueError(f"No data class found for data type {data_type}.")
+    else:
+        with dclass(bucket) as dc:
+            result = dc.store_data(data=data, **kwargs)
+    return result
 
-#     response = _post(url=fn_url, auth_key=auth_key)
-#     par_json = response.content
 
-#     par = PAR.from_json(json_str=par_json)
-#     # Get the URL to upload data to
-#     par_url = par.uri
-
-#     if filepath is not None and data is None:
-#         filepath = Path(filepath)
-#         MB = 1e6
-#         file_size = Path("somefile.txt").stat().st_size / MB
-
-#         mem_limit = 50  # MiB
-#         if file_size < mem_limit:
-#             # Read the file, compress it and send the data
-#             file_data = filepath.read_bytes()
-#             compressed_data = compress(data=file_data)
-#         else:
-#             tmp_dir = tempfile.TemporaryDirectory()
-#             compressed_filepath = Path(tmp_dir.name).joinpath(f"{filepath.name}.tar.gz")
-#             # Compress in place and then upload
-#             with tarfile.open(compressed_filepath, mode="w:gz") as tar:
-#                 tar.add(filepath)
-
-#             compressed_data = compressed_filepath.read_bytes()
-#     elif data is not None and filepath is None:
-#         compressed_data = gzip.compress(data)
-#     else:
-#         raise ValueError("Either filepath or data must be passed.")
-
-#     # Write the data to the object store
-#     put_response = _put(url=par_url, data=compressed_data, auth_key=auth_key)
-
-#     print(str(put_response))
+def standardise_via_transform(
+    bucket: str, data_type: str, datapath: Union[str, Path], database: str, **kwargs
+) -> dict:
+    if data_type != "emissions":
+        raise NotImplementedError(
+            f"transform_data only define for emissions/flux, not data type {data_type}."
+        )
+    try:
+        dclass = define_data_type_classes()[data_type]
+    except KeyError:
+        raise ValueError(f"No data class found for data type {data_type}.")
+    else:
+        with dclass(bucket) as dc:
+            result = dc.transform_data(datapath=datapath, database=database, **kwargs)
+    return result

--- a/openghg/store/_populate.py
+++ b/openghg/store/_populate.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 import logging
 from openghg.objectstore import get_writable_bucket
-from openghg.store import ObsSurface
+from openghg.standardise import standardise
 
 logger = logging.getLogger("openghg.store")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -97,15 +97,16 @@ def add_noaa_obspack(
         if _project in projects_to_read:
             try:
                 # TODO - can we streamline this a bit to save repeated loads?
-                with ObsSurface(bucket=bucket) as obs:
-                    processed = obs.read_file(
-                        filepath,
-                        site=site,
-                        measurement_type=measurement_type,
-                        network="NOAA",
-                        source_format="NOAA",
-                        overwrite=overwrite,
-                    )
+                processed = standardise(
+                    bucket=bucket,
+                    data_type="surface",
+                    filepath=filepath,
+                    site=site,
+                    measurement_type=measurement_type,
+                    network="NOAA",
+                    source_format="NOAA",
+                    overwrite=overwrite,
+                )
             except Exception:
                 files_with_errors.append(filepath.name)
 

--- a/tests/analyse/conftest.py
+++ b/tests/analyse/conftest.py
@@ -6,7 +6,7 @@ from helpers import (
     get_surface_datapath,
 )
 from openghg.objectstore import get_bucket
-from openghg.store import BoundaryConditions, Emissions, Footprints, ObsSurface
+from openghg.standardise import standardise_surface, standardise_flux, standardise_bc, standardise_footprint
 from helpers import clear_test_stores
 
 @pytest.fixture(scope="module", autouse=True)
@@ -15,6 +15,8 @@ def data_read():
     Data set up for running tests for these sets of modules.
     """
     clear_test_stores()
+    bucket = get_bucket()
+
 
     # Files for creating forward model (mf_mod) for methane and carbon dioxide at TAC site
 
@@ -29,114 +31,99 @@ def data_read():
     tac_path2 = get_surface_datapath(filename="tac.picarro.1minute.100m.201407.dat", source_format="CRDS")
     tac_filepaths = [tac_path1, tac_path2]
 
-    bucket = get_bucket()
+    # WAO data for radon from 2021-12-04 (data level 1 (NRT product) from ICOS)
+    # - This has been standardised through openghg already from download.
+    # - This data was then output to a netcdf file we can read.
+    site2 = "wao"
+    network2 = "ICOS"
+    source_format2 = "OPENGHG"
 
-    with ObsSurface(bucket=bucket) as obs:
-        obs.read_file(filepath=tac_filepaths, source_format=source_format1, site=site1, network=network1)
+    wao_path = get_surface_datapath(filename="wao_rn_icos_standardised_2021-12-04.nc", source_format="OPENGHG")
 
-        # WAO data for radon from 2021-12-04 (data level 1 (NRT product) from ICOS)
-        # - This has been standardised through openghg already from download.
-        # - This data was then output to a netcdf file we can read.
-        site2 = "wao"
-        network2 = "ICOS"
-        source_format2 = "OPENGHG"
-
-        wao_path = get_surface_datapath(filename="wao_rn_icos_standardised_2021-12-04.nc", source_format="OPENGHG")
-        obs.read_file(filepath=wao_path,
-                            source_format=source_format2,
-                            site=site2,
-                            network=network2,
-                            inlet="10m")
+    standardise_surface(bucket=bucket, filepath=tac_filepaths, source_format=source_format1, site=site1, network=network1)
+    standardise_surface(bucket=bucket,
+                             filepath=wao_path,
+                             source_format=source_format2,
+                             site=site2,
+                             network=network2,
+                             inlet="10m")
 
     # Emissions data
     # Anthropogenic ch4 (methane) data from 2012 for EUROPE
     source1 = "anthro"
     domain = "EUROPE"
-
     emissions_datapath1 = get_emissions_datapath("ch4-anthro_EUROPE_2012.nc")
+    standardise_flux(bucket=bucket,
+                             filepath=emissions_datapath1,
+                             species="ch4",
+                             source=source1,
+                             domain=domain,
+                             high_time_resolution=False,
+                             )
 
-    with Emissions(bucket=bucket) as ems:
-        ems.read_file(
-            filepath=emissions_datapath1,
-            species="ch4",
-            source=source1,
-            domain=domain,
-            high_time_resolution=False,
-        )
-
-        # Waste data for CH4 (from UKGHG model)
-        source2 = "waste"
-
-        emissions_datapath2 = get_emissions_datapath("ch4-ukghg-waste_EUROPE_2012.nc")
-
-        ems.read_file(
-            filepath=emissions_datapath2,
-            species="ch4",
-            source=source2,
-            domain=domain,
-            high_time_resolution=False,
-        )
+    # Waste data for CH4 (from UKGHG model)
+    source2 = "waste"
+    emissions_datapath2 = get_emissions_datapath("ch4-ukghg-waste_EUROPE_2012.nc")
+    standardise_flux(bucket=bucket,
+                             filepath=emissions_datapath2,
+                             species="ch4",
+                             source=source2,
+                             domain=domain,
+                             high_time_resolution=False,
+                             )
 
         # Natural sources for CO2 (R-total from Cardamom)
         #  - 2 hourly (high resolution?)
-        source3 = "natural-rtot"
+    source3 = "natural-rtot"
+    emissions_datapath3 = get_emissions_datapath("co2-rtot-cardamom-2hr_TEST_2014.nc")
+    standardise_flux(bucket=bucket,
+                             filepath=emissions_datapath3,
+                             species="co2",
+                             source=source3,
+                             domain="TEST",
+                             high_time_resolution=True,
+                             )
 
-        emissions_datapath3 = get_emissions_datapath("co2-rtot-cardamom-2hr_TEST_2014.nc")
-
-        ems.read_file(
-            filepath=emissions_datapath3,
-            species="co2",
-            source=source3,
-            domain="TEST",
-            high_time_resolution=True,
-        )
-
-        # Ocean flux for CO2
-        #  - monthly (cut down data to 1 month)
-        source4 = "ocean"
-
-        emissions_datapath4a = get_emissions_datapath("co2-nemo-ocean-mth_TEST_2014.nc")
-        emissions_datapath4b = get_emissions_datapath("co2-nemo-ocean-mth_TEST_2013.nc")
-
-        ems.read_file(
-            filepath=emissions_datapath4a,
-            species="co2",
-            source=source4,
-            domain="TEST",
-            high_time_resolution=False,
-        )
-
-        ems.read_file(
-            filepath=emissions_datapath4b,
-            species="co2",
-            source=source4,
-            domain="TEST",
-            high_time_resolution=False,
-        )
+    # Ocean flux for CO2
+    #  - monthly (cut down data to 1 month)
+    source4 = "ocean"
+    emissions_datapath4a = get_emissions_datapath("co2-nemo-ocean-mth_TEST_2014.nc")
+    emissions_datapath4b = get_emissions_datapath("co2-nemo-ocean-mth_TEST_2013.nc")
+    standardise_flux(bucket=bucket,
+                             filepath=emissions_datapath4a,
+                             species="co2",
+                             source=source4,
+                             domain="TEST",
+                             high_time_resolution=False,
+                             )
+    standardise_flux(bucket=bucket,
+                             filepath=emissions_datapath4b,
+                             species="co2",
+                             source=source4,
+                             domain="TEST",
+                             high_time_resolution=False,
+                             )
 
     # Boundary conditions data
     # CH4
     bc_filepath1 = get_bc_datapath("ch4_EUROPE_201208.nc")
+    standardise_bc(bucket=bucket,
+                             filepath=bc_filepath1,
+                             species="ch4",
+                             domain="EUROPE",
+                             bc_input="MOZART",
+                             period="monthly",
+                             )
 
-    with BoundaryConditions(bucket=bucket) as bcs:
-        bcs.read_file(
-            filepath=bc_filepath1,
-            species="ch4",
-            domain="EUROPE",
-            bc_input="MOZART",
-            period="monthly",
-        )
-
-        # CO2
-        bc_filepath1 = get_bc_datapath("co2_TEST_201407.nc")
-
-        bcs.read_file(
-            filepath=bc_filepath1,
-            species="co2",
-            domain="TEST",
-            bc_input="MOZART",
-            period="monthly",
-        )
+    # CO2
+    bc_filepath1 = get_bc_datapath("co2_TEST_201407.nc")
+    standardise_bc(bucket=bucket,
+                             filepath=bc_filepath1,
+                             species="co2",
+                             domain="TEST",
+                             bc_input="MOZART",
+                             period="monthly",
+                             )
 
     # Footprint data
     # TAC footprint from 2012-08 - 2012-09 at 100m
@@ -144,32 +131,28 @@ def data_read():
     model1 = "NAME"
 
     fp_datapath1 = get_footprint_datapath("TAC-100magl_EUROPE_201208.nc")
+    standardise_footprint(bucket=bucket,
+                             filepath=fp_datapath1, site=site1, model=model1, network=network1,
+                             height=height1, domain=domain
+                             )
 
-    with Footprints(bucket=bucket) as fps:
-        fps.read_file(
-            filepath=fp_datapath1, site=site1, model=model1, network=network1,
-            height=height1, domain=domain
-        )
+    # TAC footprint from 2014-07 - 2014-09 at 100m for CO2 (high time resolution)
+    fp_datapath2 = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")
+    standardise_footprint(bucket=bucket,
+                             filepath=fp_datapath2, site=site1, model=model1, network=network1, metmodel="UKV",
+                             height=height1, domain="TEST", species="co2"
+                             )
 
-        # TAC footprint from 2014-07 - 2014-09 at 100m for CO2 (high time resolution)
-        fp_datapath2 = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")
+    # WAO radon footprint from 2021-12-04
+    # - cut down from full file to one day
+    # - cut down to only include TEST domain rather than full EUROPE
+    fp_height2 = "20m"
+    model2 = "NAME"
+    domain2 = "TEST"
+    species2 = "rn"  # Species-specific footprint for short-lived species.
 
-        fps.read_file(
-            filepath=fp_datapath2, site=site1, model=model1, network=network1, metmodel="UKV",
-            height=height1, domain="TEST", species="co2"
-        )
-
-        # WAO radon footprint from 2021-12-04
-        # - cut down from full file to one day
-        # - cut down to only include TEST domain rather than full EUROPE
-        fp_height2 = "20m"
-        model2 = "NAME"
-        domain2 = "TEST"
-        species2 = "rn"  # Species-specific footprint for short-lived species.
-
-        fp_datapath2 = get_footprint_datapath("WAO-20magl_UKV_rn_TEST_202112.nc")
-
-        fps.read_file(
-            filepath=fp_datapath2, site=site2, model=model2, network=network2,
-            height=fp_height2, domain=domain2, species=species2,
-        )
+    fp_datapath2 = get_footprint_datapath("WAO-20magl_UKV_rn_TEST_202112.nc")
+    standardise_footprint(bucket=bucket,
+                             filepath=fp_datapath2, site=site2, model=model2, network=network2,
+                             height=fp_height2, domain=domain2, species=species2,
+                             )

--- a/tests/retrieve/conftest.py
+++ b/tests/retrieve/conftest.py
@@ -8,22 +8,14 @@ from helpers import (
     get_surface_datapath,
     clear_test_stores,
 )
-
-from openghg.store import (
-    BoundaryConditions,
-    Emissions,
-    EulerianModel,
-    Footprints,
-    ObsColumn,
-    ObsSurface,
-)
-
 from openghg.objectstore import get_bucket
+from openghg.standardise import standardise_surface, standardise_footprint, standardise_flux, standardise_bc, standardise_column, standardise
 
 
 @pytest.fixture(scope="module", autouse=True)
 def data_read():
     clear_test_stores()
+    bucket = get_bucket()
 
     # DECC network sites
     network = "DECC"
@@ -33,37 +25,38 @@ def data_read():
 
     bsd_paths = [bsd_248_path, bsd_108_path, bsd_42_path]
 
-    bucket = get_bucket()
-    with ObsSurface(bucket=bucket) as obs:
-        bsd_results = obs.read_file(filepath=bsd_paths, source_format="CRDS", site="bsd", network=network)
+    standardise_surface(bucket=bucket, filepath=bsd_paths, source_format="CRDS", site="bsd", network=network)
 
-        hfd_100_path = get_surface_datapath(filename="hfd.picarro.1minute.100m.min.dat", source_format="CRDS")
-        hfd_50_path = get_surface_datapath(filename="hfd.picarro.1minute.50m.min.dat", source_format="CRDS")
-        hfd_paths = [hfd_100_path, hfd_50_path]
+    hfd_100_path = get_surface_datapath(filename="hfd.picarro.1minute.100m.min.dat", source_format="CRDS")
+    hfd_50_path = get_surface_datapath(filename="hfd.picarro.1minute.50m.min.dat", source_format="CRDS")
+    hfd_paths = [hfd_100_path, hfd_50_path]
 
-        obs.read_file(filepath=hfd_paths, source_format="CRDS", site="hfd", network=network)
+    standardise_surface(bucket=bucket, filepath=hfd_paths, source_format="CRDS", site="hfd", network=network)
 
-        tac_path = get_surface_datapath(filename="tac.picarro.1minute.100m.test.dat", source_format="CRDS")
-        obs.read_file(filepath=tac_path, source_format="CRDS", site="tac", network=network)
+    tac_path = get_surface_datapath(filename="tac.picarro.1minute.100m.test.dat", source_format="CRDS")
+    standardise_surface(bucket=bucket, filepath=tac_path, source_format="CRDS", site="tac", network=network)
 
-        # GCWERKS data (AGAGE network sites)
-        data_filepath = get_surface_datapath(filename="capegrim-medusa.18.C", source_format="GC")
-        prec_filepath = get_surface_datapath(filename="capegrim-medusa.18.precisions.C", source_format="GC")
+    # GCWERKS data (AGAGE network sites)
+    data_filepath = get_surface_datapath(filename="capegrim-medusa.18.C", source_format="GC")
+    prec_filepath = get_surface_datapath(filename="capegrim-medusa.18.precisions.C", source_format="GC")
 
-        obs.read_file(
-            filepath=(data_filepath, prec_filepath), site="CGO", source_format="GCWERKS", network="AGAGE"
-        )
+    standardise_surface(bucket=bucket,
+                             filepath=(data_filepath, prec_filepath),
+                             site="CGO",
+                             source_format="GCWERKS",
+                             network="AGAGE"
+                             )
 
-        mhd_data_filepath = get_surface_datapath(filename="macehead.12.C", source_format="GC")
-        mhd_prec_filepath = get_surface_datapath(filename="macehead.12.precisions.C", source_format="GC")
+    mhd_data_filepath = get_surface_datapath(filename="macehead.12.C", source_format="GC")
+    mhd_prec_filepath = get_surface_datapath(filename="macehead.12.precisions.C", source_format="GC")
 
-        obs.read_file(
-            filepath=(mhd_data_filepath, mhd_prec_filepath),
-            site="MHD",
-            source_format="GCWERKS",
-            network="AGAGE",
-            instrument="GCMD",
-        )
+    standardise_surface(bucket=bucket,
+                             filepath=(mhd_data_filepath, mhd_prec_filepath),
+                             site="MHD",
+                             source_format="GCWERKS",
+                             network="AGAGE",
+                             instrument="GCMD",
+                             )
 
     # with ObsSurface(bucket=bucket) as obs:
 
@@ -78,32 +71,30 @@ def data_read():
     #     uid_42 = bsd_results["processed"]["bsd.picarro.1minute.42m.min.dat"]["ch4"]["uuid"]
     #     obs.set_rank(uuid=uid_42, rank=1, date_range="2019-01-01_2021-01-01")
 
-    with ObsSurface(bucket=bucket) as obs:
     # Obs Surface - openghg pre-formatted data
     # - This shouldn't conflict with TAC data above as this is for 185m rather than 100m
-        openghg_path = get_surface_datapath(
-            filename="DECC-picarro_TAC_20130131_co2-185m-20220929_cut.nc", source_format="OPENGHG"
-        )
-        obs.read_file(
-            filepath=openghg_path,
-            source_format="OPENGHG",
-            site="tac",
-            network="DECC",
-            instrument="picarro",
-            sampling_period="1H",
-        )
+    openghg_path = get_surface_datapath(
+        filename="DECC-picarro_TAC_20130131_co2-185m-20220929_cut.nc", source_format="OPENGHG"
+    )
+    standardise_surface(bucket=bucket,
+                             filepath=openghg_path,
+                             source_format="OPENGHG",
+                             site="tac",
+                             network="DECC",
+                             instrument="picarro",
+                             sampling_period="1H",
+                             )
 
     # Obs Column data
     column_datapath = get_column_datapath("gosat-fts_gosat_20170318_ch4-column.nc")
 
-    with ObsColumn(bucket=bucket) as obscol:
-        obscol.read_file(
-            filepath=column_datapath,
-            source_format="OPENGHG",
-            satellite="GOSAT",
-            domain="BRAZIL",
-            species="methane",
-        )
+    standardise_column(bucket=bucket,
+                             filepath=column_datapath,
+                             source_format="OPENGHG",
+                             satellite="GOSAT",
+                             domain="BRAZIL",
+                             species="methane",
+                             )
 
     # Emissions data - added consecutive data for 2012-2013
     # This will be seen as "yearly" data and each file only contains one time point.
@@ -113,23 +104,20 @@ def data_read():
     species = "co2"
     source = "gpp-cardamom"
     domain = "europe"
-
-    with Emissions(bucket=bucket) as ems:
-        ems.read_file(
-            filepath=test_datapath1,
-            species=species,
-            source=source,
-            domain=domain,
-            high_time_resolution=False,
-        )
-
-        ems.read_file(
-            filepath=test_datapath2,
-            species=species,
-            source=source,
-            domain=domain,
-            high_time_resolution=False,
-        )
+    standardise_flux(bucket=bucket,
+                             filepath=test_datapath1,
+                             species=species,
+                             source=source,
+                             domain=domain,
+                             high_time_resolution=False,
+                             )
+    standardise_flux(bucket=bucket,
+                             filepath=test_datapath2,
+                             species=species,
+                             source=source,
+                             domain=domain,
+                             high_time_resolution=False,
+                             )
 
     # Footprint data
     datapath = get_footprint_datapath("footprint_test.nc")
@@ -140,16 +128,15 @@ def data_read():
     domain = "EUROPE"
     model = "test_model"
 
-    with Footprints(bucket=bucket) as fps:
-        fps.read_file(
-            filepath=datapath,
-            site=site,
-            model=model,
-            network=network,
-            height=height,
-            domain=domain,
-            high_spatial_resolution=True,
-        )
+    standardise_footprint(bucket=bucket,
+                             filepath=datapath,
+                             site=site,
+                             model=model,
+                             network=network,
+                             height=height,
+                             domain=domain,
+                             high_spatial_resolution=True,
+                             )
 
     # Add two footprints with the same inputs but covering different time periods
     fp_datapath2 = get_footprint_datapath("TAC-100magl_UKV_TEST_201607.nc")
@@ -162,41 +149,38 @@ def data_read():
     model = "NAME"
     metmodel = "UKV"
 
-    with Footprints(bucket=bucket) as fps:
-        fps.read_file(
-            filepath=fp_datapath2,
-            site=site,
-            model=model,
-            network=network,
-            height=height,
-            domain=domain,
-            metmodel=metmodel,
-        )
+    standardise_footprint(bucket=bucket,
+                             filepath=fp_datapath2,
+                             site=site,
+                             model=model,
+                             network=network,
+                             height=height,
+                             domain=domain,
+                             metmodel=metmodel,
+                             )
 
-    with Footprints(bucket=bucket) as fps:
-        fps.read_file(
-            filepath=fp_datapath3,
-            site=site,
-            model=model,
-            network=network,
-            height=height,
-            domain=domain,
-            metmodel=metmodel,
-        )
+    standardise_footprint(bucket=bucket,
+                             filepath=fp_datapath3,
+                             site=site,
+                             model=model,
+                             network=network,
+                             height=height,
+                             domain=domain,
+                             metmodel=metmodel,
+                             )
 
     # High time resolution footprints
     hitres_fp_datapath = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")
-    with Footprints(bucket=bucket) as fps:
-        fps.read_file(
-            filepath=hitres_fp_datapath,
-            site="TAC",
-            model="NAME",
-            network="DECC",
-            height="100m",
-            domain="TEST",
-            metmodel="UKV",
-            high_time_resolution=True,
-        )
+    standardise_footprint(bucket=bucket,
+                             filepath=hitres_fp_datapath,
+                             site="TAC",
+                             model="NAME",
+                             network="DECC",
+                             height="100m",
+                             domain="TEST",
+                             metmodel="UKV",
+                             high_time_resolution=True,
+                             )
 
     # Boundary conditions
     test_datapath = get_bc_datapath("n2o_EUROPE_2012.nc")
@@ -205,15 +189,13 @@ def data_read():
     bc_input = "MOZART"
     domain = "EUROPE"
 
-    with BoundaryConditions(bucket=bucket) as bcs:
-        bcs.read_file(
-            filepath=test_datapath,
-            species=species,
-            bc_input=bc_input,
-            domain=domain,
-        )
+    standardise_bc(bucket=bucket,
+                             filepath=test_datapath,
+                             species=species,
+                             bc_input=bc_input,
+                             domain=domain,
+                             )
 
     test_datapath = get_eulerian_datapath("GEOSChem.SpeciesConc.20150101_0000z_reduced.nc4")
 
-    with EulerianModel(bucket=bucket) as em:
-        em.read_file(filepath=test_datapath, model="GEOSChem", species="ch4")
+    standardise(bucket=bucket, data_type="eulerian_model", filepath=test_datapath, model="GEOSChem", species="ch4")

--- a/tests/store/test_emissions.py
+++ b/tests/store/test_emissions.py
@@ -1,8 +1,10 @@
 import pytest
+from functools import partial
 from helpers import get_emissions_datapath
 from openghg.retrieve import search, search_flux
 from openghg.objectstore import get_bucket
 from openghg.store import Emissions, load_metastore
+from openghg.standardise import standardise_flux, standardise_from_binary_data, standardise_via_transform
 from openghg.util import hash_bytes
 from openghg.types import DatasourceLookupError
 from xarray import open_dataset
@@ -11,43 +13,67 @@ from pandas import Timestamp
 from helpers import clear_test_stores
 
 
-def test_read_binary_data(mocker):
-    clear_test_stores()
-    fake_uuids = ["test-uuid-1", "test-uuid-2", "test-uuid-3"]
-    mocker.patch("uuid.uuid4", side_effect=fake_uuids)
-
-    test_datapath = get_emissions_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
-
-    binary_data = test_datapath.read_bytes()
-
-    metadata = {
-        "species": "co2",
-        "source": "gpp-cardamom",
-        "domain": "europe",
-        "high_time_resolution": False,
-    }
-
-    sha1_hash = hash_bytes(data=binary_data)
-    filename = test_datapath.name
-
-    file_metadata = {"filename": filename, "sha1_hash": sha1_hash, "compressed": False}
-
-    bucket = get_bucket()
-    with Emissions(bucket=bucket) as ems:
-        results = ems.read_data(binary_data=binary_data, metadata=metadata, file_metadata=file_metadata)
-
-    expected_results = {"co2_gpp-cardamom_europe": {"uuid": "test-uuid-2",
-                                                    "new": True}}
-
-    assert results == expected_results
+# fixtures
+@pytest.fixture
+def bucket():
+    return get_bucket()
 
 
-def test_read_file():
-    test_datapath = get_emissions_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
+@pytest.fixture
+def standardise(bucket):
+    """Use `standardise(**kwargs)` to standardise emissions data.
 
-    bucket = get_bucket()
-    with Emissions(bucket=bucket) as ems:
-        proc_results = ems.read_file(
+    We only deal with emissions data in this test module, and most
+    tests just use `bucket = get_bucket()`, so this works for
+    most tests in this module.
+    """
+    return partial(standardise_flux, bucket=bucket)
+
+
+class TestCardamom:
+    """Tests involving cardamom data.
+
+    First test: add binary data, check if it's added.
+    Second test: add same data from file, overwriting binary data; check new data as expected.
+    """
+    def test_read_binary_data(self, mocker, bucket):
+        clear_test_stores()
+        fake_uuids = ["test-uuid-1", "test-uuid-2", "test-uuid-3"]
+        mocker.patch("uuid.uuid4", side_effect=fake_uuids)
+
+        test_datapath = get_emissions_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
+
+        binary_data = test_datapath.read_bytes()
+
+        metadata = {
+            "species": "co2",
+            "source": "gpp-cardamom",
+            "domain": "europe",
+            "high_time_resolution": False,
+        }
+
+        sha1_hash = hash_bytes(data=binary_data)
+        filename = test_datapath.name
+
+        file_metadata = {"filename": filename, "sha1_hash": sha1_hash, "compressed": False}
+
+        results = standardise_from_binary_data(
+            bucket=bucket,
+            data_type="emissions",
+            binary_data=binary_data,
+            metadata=metadata,
+            file_metadata=file_metadata)
+
+        expected_results = {"co2_gpp-cardamom_europe": {"uuid": "test-uuid-2",
+                                                        "new": True}}
+
+        assert results == expected_results
+
+
+    def test_read_file(self, standardise):
+        test_datapath = get_emissions_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
+
+        proc_results = standardise(
             filepath=test_datapath,
             species="co2",
             source="gpp-cardamom",
@@ -56,385 +82,314 @@ def test_read_file():
             overwrite=True,
         )
 
-    assert "co2_gpp-cardamom_europe" in proc_results
+        assert "co2_gpp-cardamom_europe" in proc_results
 
-    search_results = search(
-        species="co2",
-        source="gpp-cardamom",
-        domain="europe",
-        data_type="emissions",
-        start_date="2012",
-        end_date="2013",
-    )
-
-    emissions_obs = search_results.retrieve_all()
-    emissions_data = emissions_obs.data
-    metadata = emissions_obs.metadata
-
-    orig_data = open_dataset(test_datapath)
-
-    assert orig_data.lat.equals(emissions_data.lat)
-    assert orig_data.lon.equals(emissions_data.lon)
-    assert orig_data.time.equals(emissions_data.time)
-    assert orig_data.flux.equals(emissions_data.flux)
-
-    expected_metadata = {
-        "title": "gross primary productivity co2",
-        "author": "openghg cloud",
-        "date_created": "2018-05-20 19:44:14.968710",
-        "number_of_prior_files_used": 1,
-        "prior_file_1": "cardamom gpp",
-        "prior_file_1_raw_resolution": "25x25km",
-        "prior_file_1_reference": "t.l. smallman, jgr biogeosciences, 2017",
-        "regridder_used": "acrg_grid.regrid.regrid_3d",
-        "comments": "fluxes copied from year 2013. december 2012 values copied from january 2013 values.",
-        "species": "co2",
-        "domain": "europe",
-        "source": "gpp-cardamom",
-        "start_date": "2012-01-01 00:00:00+00:00",
-        "end_date": "2012-12-31 23:59:59+00:00",
-        "max_longitude": 39.38,
-        "min_longitude": -97.9,
-        "max_latitude": 79.057,
-        "min_latitude": 10.729,
-        "time_resolution": "standard",
-        "data_type": "emissions",
-        "time_period": "1 year",
-    }
-
-    del metadata["processed"]
-    del metadata["prior_file_1_version"]
-
-    assert metadata.items() >= expected_metadata.items()
-
-
-# TODO: Add test for adding additional years data - 2013 gpp cardomom
-
-
-def test_read_file_additional_keys():
-    """
-    Test multiple files can be added using additional keywords
-    ('database' and 'database_version' tested below).
-    and still be stored and retrieved separately.
-
-    Data used:
-     - EDGAR - ch4, anthro, globaledgar domain, 2014, version v5.0 (v50)
-     - EDGAR - ch4, anthro, globaledgar domain, 2015, version v6.0 (v60)
-
-    Should produce 2 search results.
-    """
-    clear_test_stores()
-
-    test_datapath1 = get_emissions_datapath("ch4-anthro_globaledgar_v5-0_2014.nc")
-
-    bucket = get_bucket()
-    with Emissions(bucket=bucket) as ems:
-        proc_results1 = ems.read_file(
-            filepath=test_datapath1,
-            species="ch4",
-            source="anthro",
-            domain="globaledgar",
-            database="EDGAR",
-            database_version="v50",
+        search_results = search(
+            species="co2",
+            source="gpp-cardamom",
+            domain="europe",
+            data_type="emissions",
+            start_date="2012",
+            end_date="2013",
         )
 
-        assert "ch4_anthro_globaledgar" in proc_results1
+        emissions_obs = search_results.retrieve_all()
+        emissions_data = emissions_obs.data
+        metadata = emissions_obs.metadata
 
-        test_datapath2 = get_emissions_datapath("ch4-anthro_globaledgar_v6-0_2015.nc")
+        orig_data = open_dataset(test_datapath)
 
-        proc_results2 = ems.read_file(
-            filepath=test_datapath2,
-            species="ch4",
-            source="anthro",
-            domain="globaledgar",
-            database="EDGAR",
-            database_version="v60",
-        )
+        assert orig_data.lat.equals(emissions_data.lat)
+        assert orig_data.lon.equals(emissions_data.lon)
+        assert orig_data.time.equals(emissions_data.time)
+        assert orig_data.flux.equals(emissions_data.flux)
 
-    assert "ch4_anthro_globaledgar" in proc_results2
+        expected_metadata = {
+            "title": "gross primary productivity co2",
+            "author": "openghg cloud",
+            "date_created": "2018-05-20 19:44:14.968710",
+            "number_of_prior_files_used": 1,
+            "prior_file_1": "cardamom gpp",
+            "prior_file_1_raw_resolution": "25x25km",
+            "prior_file_1_reference": "t.l. smallman, jgr biogeosciences, 2017",
+            "regridder_used": "acrg_grid.regrid.regrid_3d",
+            "comments": "fluxes copied from year 2013. december 2012 values copied from january 2013 values.",
+            "species": "co2",
+            "domain": "europe",
+            "source": "gpp-cardamom",
+            "start_date": "2012-01-01 00:00:00+00:00",
+            "end_date": "2012-12-31 23:59:59+00:00",
+            "max_longitude": 39.38,
+            "min_longitude": -97.9,
+            "max_latitude": 79.057,
+            "min_latitude": 10.729,
+            "time_resolution": "standard",
+            "data_type": "emissions",
+            "time_period": "1 year",
+        }
 
-    search_results_all = search_flux(species="ch4", source="anthro", domain="globaledgar", database="EDGAR")
+        del metadata["processed"]
+        del metadata["prior_file_1_version"]
 
-    # Should still produce 2 search results - one for each added file (database_version)
-    assert len(search_results_all) == 2
-
-    # Check these can be distinguished by searching by database_version
-    search_results_1 = search_flux(
-        species="ch4", source="anthro", domain="globaledgar", database="EDGAR", database_version="v50"
-    )
-    search_results_2 = search_flux(
-        species="ch4", source="anthro", domain="globaledgar", database="EDGAR", database_version="v60"
-    )
-
-    assert len(search_results_1) == 1
-    assert len(search_results_2) == 1
-
-    assert search_results_1.results.iloc[0]["database_version"] == "v50"
-    assert search_results_1.results.iloc[0]["start_date"] == "2014-01-01 00:00:00+00:00"
-    assert search_results_2.results.iloc[0]["database_version"] == "v60"
-    assert search_results_2.results.iloc[0]["start_date"] == "2015-01-01 00:00:00+00:00"
-
-
-def test_read_file_align_correct_datasource():
-    """
-    Test datasources can be correctly aligned for additional keywords.
-    ('database' and 'database_version' tested below).
-
-    Data used:
-     - EDGAR v5.0 (v50)
-       - ch4, anthro, globaledgar domain, 2014
-       - ch4, anthro, globaledgar domain, 2015
-     - EDGAR v6.0 (v60)
-       - ch4, anthro, globaledgar domain, 2015
-
-    Should produce 2 search results.
-    """
-    clear_test_stores()
-
-    test_datapath1 = get_emissions_datapath("ch4-anthro_globaledgar_v5-0_2014.nc")
-
-    bucket = get_bucket()
-    with Emissions(bucket=bucket) as ems:
-        ems.read_file(
-            filepath=test_datapath1,
-            species="ch4",
-            source="anthro",
-            domain="globaledgar",
-            database="EDGAR",
-            database_version="v50",
-        )
-
-        test_datapath2 = get_emissions_datapath("ch4-anthro_globaledgar_v6-0_2015.nc")
-
-        ems.read_file(
-            filepath=test_datapath2,
-            species="ch4",
-            source="anthro",
-            domain="globaledgar",
-            database="EDGAR",
-            database_version="v60",
-        )
-
-        test_datapath3 = get_emissions_datapath("ch4-anthro_globaledgar_v5-0_2015.nc")
-
-        ems.read_file(
-            filepath=test_datapath3,
-            species="ch4",
-            source="anthro",
-            domain="globaledgar",
-            database="EDGAR",
-            database_version="v50",
-        )
-
-    search_results_all = search_flux(species="ch4", source="anthro", domain="globaledgar", database="EDGAR")
-
-    # Should still produce 2 search results as 2014, 2015 v5.0 should be associated in a data source.
-    assert len(search_results_all) == 2
-
-    # Check these can be distinguished by searching by database_version
-    search_results_1 = search_flux(
-        species="ch4", source="anthro", domain="globaledgar", database="EDGAR", database_version="v50"
-    )
-    search_results_2 = search_flux(
-        species="ch4", source="anthro", domain="globaledgar", database="EDGAR", database_version="v60"
-    )
-
-    assert len(search_results_1) == 1
-    assert len(search_results_2) == 1
-
-    # Check both time points are found within the retrieved data for v5.0
-    # and date range has been extended.
-    edgar_v5_retrieve = search_results_1.retrieve()
-    edgar_v5_data = edgar_v5_retrieve.data
-    edgar_v5_metadata = edgar_v5_retrieve.metadata
-
-    assert edgar_v5_data.dims["time"] == 2
-    assert edgar_v5_data["time"][0] == Timestamp("2014-01-01")
-    assert edgar_v5_data["time"][1] == Timestamp("2015-01-01")
-
-    assert edgar_v5_metadata["start_date"] == "2014-01-01 00:00:00+00:00"
-    assert edgar_v5_metadata["end_date"] == "2015-12-31 23:59:59+00:00"
+        assert metadata.items() >= expected_metadata.items()
 
 
-def test_read_file_fails_ambiguous():
-    """
-    Test helpful error message is raised if read_file is unable to disambiguiate
-    between multiple datasources based on provided keywords when using
-    additional keywords ('database' and 'database_version' tested).
+    # TODO: Add test for adding additional years data - 2013 gpp cardomom
 
-    Data used:
-     - same as test_read_file_align_correct_datasource() but doesn't pass
-     `database_version` keyword at all for final file.
-    """
-    clear_test_stores()
 
-    test_datapath1 = get_emissions_datapath("ch4-anthro_globaledgar_v5-0_2014.nc")
+class TestEDGAR:
+    @pytest.fixture(autouse=True)
+    def clear_store(self):
+        clear_test_stores()
 
-    bucket = get_bucket()
-    with Emissions(bucket=bucket) as ems:
-        ems.read_file(
-            filepath=test_datapath1,
-            species="ch4",
-            source="anthro",
-            domain="globaledgar",
-            database="EDGAR",
-            database_version="v50",
-        )
+    @pytest.fixture
+    def load_edgar(self, standardise):
+        def _load_edgar(version, year, database_version: bool = True):
+            """Load CH_4 globaledgar data for given version and year.
 
-        test_datapath2 = get_emissions_datapath("ch4-anthro_globaledgar_v6-0_2015.nc")
-
-        ems.read_file(
-            filepath=test_datapath2,
-            species="ch4",
-            source="anthro",
-            domain="globaledgar",
-            database="EDGAR",
-            database_version="v60",
-        )
-
-        test_datapath3 = get_emissions_datapath("ch4-anthro_globaledgar_v5-0_2015.nc")
-
-        # Doesn't include a database_version input which would be needed to distinguish
-        # between the 2 previous datasources added.
-        with pytest.raises(DatasourceLookupError) as exc_info:
-            ems.read_file(
-                filepath=test_datapath3,
+            Args:
+                version: can be 5 or 6,
+                year: can be 2014, 2015, 2016
+                database_version: if True, `database_version` argument passed to `read_file`
+            """
+            file_name = f"ch4-anthro_globaledgar_v{str(version)}-0_{str(year)}.nc"
+            datapath = get_emissions_datapath(file_name)
+            kwargs = dict(
+                filepath=datapath,
                 species="ch4",
                 source="anthro",
                 domain="globaledgar",
                 database="EDGAR",
             )
+            if database_version:
+                kwargs["database_version"] = "v" + str(version) + "0"
+            return standardise(**kwargs)
+        return _load_edgar
 
-    assert "More than once Datasource found for metadata" in exc_info.value.args[0]
+    def test_read_file_additional_keys(self, load_edgar):
+        """
+        Test multiple files can be added using additional keywords
+        ('database' and 'database_version' tested below).
+        and still be stored and retrieved separately.
 
+        Data used:
+         - EDGAR - ch4, anthro, globaledgar domain, 2014, version v5.0 (v50)
+         - EDGAR - ch4, anthro, globaledgar domain, 2015, version v6.0 (v60)
 
-def test_add_edgar_database():
-    """Test edgar can be added to object store (default domain)"""
-    clear_test_stores()
-    bucket = get_bucket()
+        Should produce 2 search results.
+        """
+        # load 2014, v5
+        proc_results1 = load_edgar(5, 2014)
+        assert "ch4_anthro_globaledgar" in proc_results1
 
-    folder = "v6.0_CH4"
-    test_datapath = get_emissions_datapath(f"EDGAR/yearly/{folder}")
+        # load 2015, v6
+        proc_results2 = load_edgar(6, 2015)
+        assert "ch4_anthro_globaledgar" in proc_results2
 
-    database = "EDGAR"
-    date = "2015"
+        search_results_all = search_flux(species="ch4", source="anthro", domain="globaledgar", database="EDGAR")
 
-    with Emissions(bucket=bucket) as em:
-        proc_results = em.transform_data(
-            datapath=test_datapath,
-            database=database,
-            date=date,
+        # Should still produce 2 search results - one for each added file (database_version)
+        assert len(search_results_all) == 2
+
+        # Check these can be distinguished by searching by database_version
+        search_results_1 = search_flux(
+            species="ch4", source="anthro", domain="globaledgar", database="EDGAR", database_version="v50"
+        )
+        search_results_2 = search_flux(
+            species="ch4", source="anthro", domain="globaledgar", database="EDGAR", database_version="v60"
         )
 
-    default_domain = "globaledgar"
+        assert len(search_results_1) == 1
+        assert len(search_results_2) == 1
 
-    version = "v6.0"
-    species = "ch4"
-    default_source = "anthro"
-
-    output_key = f"{species}_{default_source}_{default_domain}_{date}"
-    assert output_key in proc_results
-
-    search_results = search_flux(
-        species=species,
-        date=date,
-        database=database,  # would searching for lowercase not work?
-        database_version=version,
-    )
-
-    assert search_results
-
-    edgar_obs = search_results.retrieve_all()
-    metadata = edgar_obs.metadata
-
-    expected_metadata = {
-        "species": species,
-        "domain": default_domain,
-        "source": default_source,
-        "database": database.lower(),
-        "database_version": version.replace(".", ""),
-        "date": "2015",
-        "author": "OpenGHG Cloud".lower(),
-        "start_date": "2015-01-01 00:00:00+00:00",
-        "end_date": "2015-12-31 23:59:59+00:00",
-        # "min_longitude": -174.85857,
-        # "max_longitude": 180.0,
-        "min_longitude": -180.0,
-        "max_longitude": 174.85858,
-        "min_latitude": -89.95,
-        "max_latitude": 89.95,
-        "time_resolution": "standard",
-        "time_period": "1 year",
-    }
-
-    assert metadata.items() >= expected_metadata.items()
+        assert search_results_1.results.iloc[0]["database_version"] == "v50"
+        assert search_results_1.results.iloc[0]["start_date"] == "2014-01-01 00:00:00+00:00"
+        assert search_results_2.results.iloc[0]["database_version"] == "v60"
+        assert search_results_2.results.iloc[0]["start_date"] == "2015-01-01 00:00:00+00:00"
 
 
-def test_transform_and_add_edgar_database():
-    """
-    Test EDGAR database can be transformed (regridded) and added to the object store.
-    """
-    # Regridding to a new domain will use the xesmf importer - so skip this test
-    # if module is not present.
-    xesmf = pytest.importorskip("xesmf")
+    def test_read_file_align_correct_datasource(self, load_edgar):
+        """
+        Test datasources can be correctly aligned for additional keywords.
+        ('database' and 'database_version' tested below).
 
-    folder = "v6.0_CH4"
-    test_datapath = get_emissions_datapath(f"EDGAR/yearly/{folder}")
+        Data used:
+         - EDGAR v5.0 (v50)
+           - ch4, anthro, globaledgar domain, 2014
+           - ch4, anthro, globaledgar domain, 2015
+         - EDGAR v6.0 (v60)
+           - ch4, anthro, globaledgar domain, 2015
 
-    database = "EDGAR"
-    date = "2015"
-    domain = "EUROPE"
+        Should produce 2 search results.
+        """
+        load_edgar(5, 2014)
+        load_edgar(6, 2015)
+        load_edgar(5, 2015)
 
-    bucket = get_bucket()
-    with Emissions(bucket=bucket) as em:
-        proc_results = em.transform_data(
-            datapath=test_datapath,
-            database=database,
+        search_results_all = search_flux(species="ch4", source="anthro", domain="globaledgar", database="EDGAR")
+
+        # Should still produce 2 search results as 2014, 2015 v5.0 should be associated in a data source.
+        assert len(search_results_all) == 2
+
+        # Check these can be distinguished by searching by database_version
+        search_results_1 = search_flux(
+            species="ch4", source="anthro", domain="globaledgar", database="EDGAR", database_version="v50"
+        )
+        search_results_2 = search_flux(
+            species="ch4", source="anthro", domain="globaledgar", database="EDGAR", database_version="v60"
+        )
+
+        assert len(search_results_1) == 1
+        assert len(search_results_2) == 1
+
+        # Check both time points are found within the retrieved data for v5.0
+        # and date range has been extended.
+        edgar_v5_retrieve = search_results_1.retrieve()
+        edgar_v5_data = edgar_v5_retrieve.data
+        edgar_v5_metadata = edgar_v5_retrieve.metadata
+
+        assert edgar_v5_data.dims["time"] == 2
+        assert edgar_v5_data["time"][0] == Timestamp("2014-01-01")
+        assert edgar_v5_data["time"][1] == Timestamp("2015-01-01")
+
+        assert edgar_v5_metadata["start_date"] == "2014-01-01 00:00:00+00:00"
+        assert edgar_v5_metadata["end_date"] == "2015-12-31 23:59:59+00:00"
+
+
+    def test_read_file_fails_ambiguous(self, load_edgar):
+        """
+        Test helpful error message is raised if read_file is unable to disambiguiate
+        between multiple datasources based on provided keywords when using
+        additional keywords ('database' and 'database_version' tested).
+
+        Data used:
+         - same as test_read_file_align_correct_datasource() but doesn't pass
+         `database_version` keyword at all for final file.
+        """
+        load_edgar(5, 2014)
+        load_edgar(6, 2015)
+
+        try:
+            load_edgar(5, 2015, database_version=False)  # do not pass `database_version="v50"`
+        except Exception as e:
+            assert "More than once Datasource found for metadata" in e.args[0]
+        else:
+            raise AssertionError("This test should throw/catch a DatasourceLookupError with a useful message!")
+
+
+    def test_add_edgar_database(self, bucket):
+        """Test edgar can be added to object store (default domain)"""
+        folder = "v6.0_CH4"
+        test_datapath = get_emissions_datapath(f"EDGAR/yearly/{folder}")
+
+        database = "EDGAR"
+        date = "2015"
+
+        proc_results = standardise_via_transform(bucket=bucket, data_type="emissions", datapath=test_datapath, database=database, date=date)
+
+        default_domain = "globaledgar"
+
+        version = "v6.0"
+        species = "ch4"
+        default_source = "anthro"
+
+        output_key = f"{species}_{default_source}_{default_domain}_{date}"
+        assert output_key in proc_results
+
+        search_results = search_flux(
+            species=species,
+            date=date,
+            database=database,  # would searching for lowercase not work?
+            database_version=version,
+        )
+
+        assert search_results
+
+        edgar_obs = search_results.retrieve_all()
+        metadata = edgar_obs.metadata
+
+        expected_metadata = {
+            "species": species,
+            "domain": default_domain,
+            "source": default_source,
+            "database": database.lower(),
+            "database_version": version.replace(".", ""),
+            "date": "2015",
+            "author": "OpenGHG Cloud".lower(),
+            "start_date": "2015-01-01 00:00:00+00:00",
+            "end_date": "2015-12-31 23:59:59+00:00",
+            # "min_longitude": -174.85857,
+            # "max_longitude": 180.0,
+            "min_longitude": -180.0,
+            "max_longitude": 174.85858,
+            "min_latitude": -89.95,
+            "max_latitude": 89.95,
+            "time_resolution": "standard",
+            "time_period": "1 year",
+        }
+
+        assert metadata.items() >= expected_metadata.items()
+
+
+    def test_transform_and_add_edgar_database(self):
+        """
+        Test EDGAR database can be transformed (regridded) and added to the object store.
+        """
+        # Regridding to a new domain will use the xesmf importer - so skip this test
+        # if module is not present.
+        xesmf = pytest.importorskip("xesmf")
+
+        folder = "v6.0_CH4"
+        test_datapath = get_emissions_datapath(f"EDGAR/yearly/{folder}")
+
+        database = "EDGAR"
+        date = "2015"
+        domain = "EUROPE"
+
+        bucket = get_bucket()
+        proc_results = standardise_via_transform(bucket=bucket, data_type="emissions", datapath=test_datapath, database=database, date=date, domain=domain)
+
+        version = "v6.0"
+        species = "ch4"
+        default_source = "anthro"
+
+        output_key = f"{species}_{default_source}_{domain}_{date}"
+        assert output_key in proc_results
+
+        search_results = search(
+            species=species,
             date=date,
             domain=domain,
+            database=database,  # would searching for lowercase not work?
+            database_version=version,
+            data_type="emissions",
         )
 
-    version = "v6.0"
-    species = "ch4"
-    default_source = "anthro"
+        edgar_data = search_results.retrieve_all()
+        metadata = edgar_data.metadata
 
-    output_key = f"{species}_{default_source}_{domain}_{date}"
-    assert output_key in proc_results
+        # TODO: Add tests for data as well?
+        # data_keys = search_results[key]["keys"]
 
-    search_results = search(
-        species=species,
-        date=date,
-        domain=domain,
-        database=database,  # would searching for lowercase not work?
-        database_version=version,
-        data_type="emissions",
-    )
+        expected_metadata = {
+            "species": species,
+            "domain": domain.lower(),
+            "source": "anthro",
+            "database": "edgar",
+            "database_version": version.replace(".", ""),
+            "date": "2015",
+            "author": "openghg cloud",
+            "start_date": "2015-01-01 00:00:00+00:00",
+            "end_date": "2015-12-31 23:59:59+00:00",
+            "min_longitude": -97.9,
+            "max_longitude": 39.38,
+            "min_latitude": 10.729,
+            "max_latitude": 79.057,
+            "time_resolution": "standard",
+            "time_period": "1 year",
+        }
 
-    edgar_data = search_results.retrieve_all()
-    metadata = edgar_data.metadata
-
-    # TODO: Add tests for data as well?
-    # data_keys = search_results[key]["keys"]
-
-    expected_metadata = {
-        "species": species,
-        "domain": domain.lower(),
-        "source": "anthro",
-        "database": "edgar",
-        "database_version": version.replace(".", ""),
-        "date": "2015",
-        "author": "openghg cloud",
-        "start_date": "2015-01-01 00:00:00+00:00",
-        "end_date": "2015-12-31 23:59:59+00:00",
-        "min_longitude": -97.9,
-        "max_longitude": 39.38,
-        "min_latitude": 10.729,
-        "max_latitude": 79.057,
-        "time_resolution": "standard",
-        "time_period": "1 year",
-    }
-
-    assert metadata.items() >= expected_metadata.items()
+        assert metadata.items() >= expected_metadata.items()
 
 
 def test_flux_schema():

--- a/tests/store/test_eulerian_model.py
+++ b/tests/store/test_eulerian_model.py
@@ -1,7 +1,9 @@
 from helpers import get_eulerian_datapath
+from openghg import standardise
 from openghg.retrieve import search
 from openghg.objectstore import get_bucket
 from openghg.store import EulerianModel
+from openghg.standardise._standardise import standardise
 from xarray import open_dataset
 
 
@@ -9,8 +11,7 @@ def test_read_file():
     test_datapath = get_eulerian_datapath("GEOSChem.SpeciesConc.20150101_0000z_reduced.nc4")
 
     bucket = get_bucket()
-    with EulerianModel(bucket=bucket) as em:
-        proc_results = em.read_file(filepath=test_datapath, model="GEOSChem", species="ch4")
+    proc_results = standardise(bucket=bucket, data_type="eulerian_model", filepath=test_datapath, model="GEOSChem", species="ch4")
 
     assert "geoschem_ch4_2015-01-01" in proc_results
 

--- a/tests/store/test_footprints.py
+++ b/tests/store/test_footprints.py
@@ -1,10 +1,32 @@
 import pytest
+from functools import partial
 from helpers import get_footprint_datapath
 from openghg.retrieve import search
 from openghg.objectstore import get_bucket
-from openghg.store import Footprints, load_metastore
+from openghg.store import Footprints
 from openghg.util import hash_bytes
-from openghg.standardise import standardise_footprint
+from openghg.standardise._standardise import standardise_footprint, standardise_from_binary_data
+
+@pytest.fixture(autouse=True, scope="module")
+def auto_bucket():
+    global bucket
+    bucket = get_bucket()
+    yield bucket
+    globals().pop('bucket')
+
+
+@pytest.fixture(autouse=True)
+def standardise():
+    """Use `standardise(**kwargs)` to standardise footprints data.
+
+    We only deal with footprints data in this test module, and most
+    tests just use `bucket = get_bucket()`, so this works for
+    most tests in this module.
+
+    This was added to help refactor `BaseStore` and its children
+    by removing uses of the context manager for using `read_file`.`
+    """
+    return partial(standardise_footprint, bucket=bucket)
 
 
 @pytest.mark.xfail(reason="Need to add a better way of passing in binary data to the read_file functions.")
@@ -33,9 +55,7 @@ def test_read_footprint_co2_from_data(mocker):
 
     # Expect co2 data to be high time resolution
     # - could include high_time_resolution=True but don't need to as this will be set automatically
-    bucket = get_bucket()
-    with Footprints(bucket=bucket) as fps:
-        result = fps.read_data(binary_data=binary_data, metadata=metadata, file_metadata=file_metadata)
+    result = standardise_from_binary_data(bucket=bucket, data_type="footprints", binary_data=binary_data, metadata=metadata, file_metadata=file_metadata)
 
     assert result == {"tac_test_NAME_100m": {"uuid": "test-uuid-1", "new": True}}
 
@@ -50,38 +70,23 @@ def test_read_footprint_co2_from_data(mocker):
         ("inlet", "100"),
     ],
 )
-def test_read_footprint_standard(keyword, value):
+def test_read_footprint_standard(keyword, value, standardise):
     """
     Test standard footprint which should contain (at least)
      - data variables: "fp"
      - coordinates: "height", "lat", "lev", "lon", "time"
     Check this for different variants of inlet and height inputs.
     """
-    datapath = get_footprint_datapath("TAC-100magl_EUROPE_201208.nc")
-
     site = "TAC"
     domain = "EUROPE"
     model = "NAME"
-
-    bucket = get_bucket()
-    if keyword == "inlet":
-        with Footprints(bucket=bucket) as fps:
-            fps.read_file(
-                filepath=datapath,
-                site=site,
-                model=model,
-                inlet=value,
-                domain=domain,
-            )
-    elif keyword == "height":
-        with Footprints(bucket=bucket) as fps:
-            fps.read_file(
-                filepath=datapath,
-                site=site,
-                model=model,
-                height=value,
-                domain=domain,
-            )
+    args = dict(filepath = get_footprint_datapath("TAC-100magl_EUROPE_201208.nc"),
+                site = site,
+                domain = domain,
+                model = model,
+                )
+    args[keyword] = value
+    standardise(**args)
 
     # Get the footprints data
     footprint_results = search(site=site, domain=domain, data_type="footprints")
@@ -121,7 +126,7 @@ def test_read_footprint_standard(keyword, value):
         assert footprint_data.attrs[key] == expected_attrs[key]
 
 
-def test_read_footprint_high_spatial_resolution():
+def test_read_footprint_high_spatial_resolution(standardise):
     """
     Test high spatial resolution footprint
      - expects additional parameters for `fp_low` and `fp_high`
@@ -129,26 +134,17 @@ def test_read_footprint_high_spatial_resolution():
      - expects keyword attributes to be set
        - "spatial_resolution": "high_spatial_resolution"
     """
-    datapath = get_footprint_datapath("footprint_test.nc")
-    # model_params = {"simulation_params": "123"}
-
     site = "TMB"
-    network = "LGHG"
-    inlet = "10m"
     domain = "EUROPE"
-    model = "test_model"
-
-    bucket = get_bucket()
-    with Footprints(bucket=bucket) as fps:
-        fps.read_file(
-            filepath=datapath,
-            site=site,
-            model=model,
-            network=network,
-            inlet=inlet,
-            domain=domain,
-            period="monthly",
-            high_spatial_resolution=True,
+    standardise(
+        filepath = get_footprint_datapath("footprint_test.nc"),
+        site = site,
+        network = "LGHG",
+        inlet = "10m",
+        domain = domain,
+        model = "test_model",
+        period="monthly",
+        high_spatial_resolution=True,
         )
 
     # Get the footprints data
@@ -277,7 +273,7 @@ def test_read_footprint_high_spatial_resolution():
         ),
     ],
 )
-def test_read_footprint_co2(site, inlet, metmodel, start, end, filename):
+def test_read_footprint_co2(site, inlet, metmodel, start, end, filename, standardise):
     """
     Test high spatial resolution footprint
      - expects additional parameter for `fp_HiTRes`
@@ -297,18 +293,15 @@ def test_read_footprint_co2(site, inlet, metmodel, start, end, filename):
 
     # Expect co2 data to be high time resolution
     # - could include high_time_resolution=True but don't need to as this will be set automatically
-
-    bucket = get_bucket()
-    with Footprints(bucket=bucket) as fps:
-        fps.read_file(
-            filepath=datapath,
-            site=site,
-            model=model,
-            metmodel=metmodel,
-            inlet=inlet,
-            species=species,
-            domain=domain,
-        )
+    standardise(
+        filepath=datapath,
+        site=site,
+        model=model,
+        metmodel=metmodel,
+        inlet=inlet,
+        species=species,
+        domain=domain,
+    )
 
     # Get the footprints data
     footprint_results = search(site=site, domain=domain, species=species, data_type="footprints")
@@ -352,7 +345,7 @@ def test_read_footprint_co2(site, inlet, metmodel, start, end, filename):
         assert footprint_data.attrs[key] == expected_attrs[key]
 
 
-def test_read_footprint_short_lived():
+def test_read_footprint_short_lived(standardise):
     datapath = get_footprint_datapath("WAO-20magl_UKV_rn_TEST_201801.nc")
 
     site = "WAO"
@@ -364,18 +357,15 @@ def test_read_footprint_short_lived():
 
     # Expect rn data to be short lived
     # - could include short_lifetime=True but shouldn't need to as this will be set automatically
-
-    bucket = get_bucket()
-    with Footprints(bucket=bucket) as fps:
-        fps.read_file(
-            filepath=datapath,
-            site=site,
-            model=model,
-            metmodel=metmodel,
-            inlet=inlet,
-            species=species,
-            domain=domain,
-        )
+    standardise(
+        filepath=datapath,
+        site=site,
+        model=model,
+        metmodel=metmodel,
+        inlet=inlet,
+        species=species,
+        domain=domain,
+    )
 
     # Get the footprints data
     footprint_results = search(site=site, domain=domain, species=species, data_type="footprints")

--- a/tests/store/test_obscolumn.py
+++ b/tests/store/test_obscolumn.py
@@ -1,6 +1,6 @@
 import numpy as np
 from helpers import get_column_datapath
-from openghg.store import ObsColumn
+from openghg.standardise import standardise_column
 from openghg.objectstore import get_bucket
 from openghg.store.base import Datasource
 from pandas import Timestamp
@@ -20,13 +20,13 @@ def test_read_openghg_format():
     species = "methane"
 
     bucket = get_bucket()
-    with ObsColumn(bucket=bucket) as obs_col:
-        results = obs_col.read_file(filepath=datafile,
-                                    source_format="OPENGHG",
-                                    satellite=satellite,
-                                    domain=domain,
-                                    species=species,
-                                    )
+    results = standardise_column(bucket=bucket,
+                                 filepath=datafile,
+                                 source_format="OPENGHG",
+                                 satellite=satellite,
+                                 domain=domain,
+                                 species=species,
+                                 )
 
     # Output style from ObsSurface - may want to use for ObsColumn as well
     # uuid = results["processed"][filename]["ch4"]["uuid"]

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -2,6 +2,8 @@ import os
 import json
 import pytest
 import xarray as xr
+from pandas import Timestamp
+from functools import partial
 from helpers import attributes_checker_obssurface, get_surface_datapath, clear_test_stores
 from pathlib import Path
 from openghg.objectstore import (
@@ -14,11 +16,18 @@ from openghg.objectstore import (
 from openghg.store import ObsSurface
 from openghg.store.base import Datasource
 from openghg.retrieve import search_surface
+from openghg.standardise import standardise_surface, standardise_from_binary_data, standardise_from_remote_source
 from openghg.util import create_daterange_str
 from pandas import Timestamp
 
 
-def test_raising_error_doesnt_save_to_store(mocker):
+@pytest.fixture
+def standardise():
+    bucket = get_bucket()
+    return partial(standardise_surface, bucket=bucket)
+
+
+def test_raising_error_doesnt_save_to_store(mocker, standardise):
     clear_test_stores()
     bucket = get_writable_bucket(name="user")
 
@@ -39,39 +48,30 @@ def test_raising_error_doesnt_save_to_store(mocker):
     one_min = get_surface_datapath("tac.picarro.1minute.100m.test.dat", source_format="CRDS")
 
     with pytest.raises(ValueError):
-        with ObsSurface(bucket=bucket) as obs:
-            obs.read_file(filepath=one_min, site="tac", network="decc", source_format="CRDS")
+        standardise(filepath=one_min, site="tac", network="decc", source_format="CRDS")
 
     assert not exists(bucket=bucket, key=key)
 
 
-def test_different_sampling_periods_diff_datasources():
+def test_different_sampling_periods_diff_datasources(standardise):
     clear_test_stores()
 
-    bucket = get_bucket()
-
     one_min = get_surface_datapath("tac.picarro.1minute.100m.test.dat", source_format="CRDS")
-
-    with ObsSurface(bucket=bucket) as obs:
-        one_min_res = obs.read_file(filepath=one_min, site="tac", network="decc", source_format="CRDS")
+    one_min_res = standardise(filepath=one_min, site="tac", network="decc", source_format="CRDS")
 
     min_uuids = one_min_res["processed"]["tac.picarro.1minute.100m.test.dat"]
-
     for sp, data in min_uuids.items():
         assert data["new"] is True
 
     one_hour = get_surface_datapath("tac.picarro.hourly.100m.test.dat", source_format="CRDS")
-
-    with ObsSurface(bucket=bucket) as obs:
-        one_hour_res = obs.read_file(filepath=one_hour, site="tac", network="decc", source_format="CRDS")
+    one_hour_res = standardise(filepath=one_hour, site="tac", network="decc", source_format="CRDS")
 
     hour_uuids = one_hour_res["processed"]["tac.picarro.hourly.100m.test.dat"]
-
     for sp, data in hour_uuids.items():
         assert data["new"] is True
 
 
-def test_same_source_data_same_datasource():
+def test_same_source_data_same_datasource(standardise):
     site = "tac"
     network = "DECC"
     source_format = "CRDS"
@@ -79,17 +79,13 @@ def test_same_source_data_same_datasource():
     tac_path1 = get_surface_datapath(filename="tac.picarro.1minute.100m.201208.dat", source_format="CRDS")
     tac_path2 = get_surface_datapath(filename="tac.picarro.1minute.100m.201407.dat", source_format="CRDS")
 
-    bucket = get_bucket()
+    res = standardise(
+        filepath=tac_path1, source_format=source_format, site=site, network=network, overwrite=True
+    )
 
-    with ObsSurface(bucket=bucket) as obs:
-        res = obs.read_file(
-            filepath=tac_path1, source_format=source_format, site=site, network=network, overwrite=True
-        )
-
-    with ObsSurface(bucket=bucket) as obs:
-        res_2 = obs.read_file(
-            filepath=tac_path2, source_format=source_format, site=site, network=network, overwrite=True
-        )
+    res_2 = standardise(
+        filepath=tac_path2, source_format=source_format, site=site, network=network, overwrite=True
+    )
 
     proc_data = res["processed"]["tac.picarro.1minute.100m.201208.dat"]
     proc_data_2 = res_2["processed"]["tac.picarro.1minute.100m.201407.dat"]
@@ -120,8 +116,11 @@ def test_read_data(mocker):
 
     file_metadata = {"filename": "bsd.picarro.1minute.248m.min.dat"}
 
-    with ObsSurface(bucket=bucket) as obs:
-        result = obs.read_data(binary_data=binary_bsd, metadata=metadata, file_metadata=file_metadata)
+    result = standardise_from_binary_data(bucket=bucket,
+                                          data_type="surface",
+                                          binary_data=binary_bsd,
+                                          metadata=metadata,
+                                          file_metadata=file_metadata)
 
     expected = {
         "processed": {
@@ -135,42 +134,38 @@ def test_read_data(mocker):
 
     assert result == expected
 
+    obs = ObsSurface(bucket=bucket)
     with pytest.raises(ValueError):
         metadata = {}
-        with ObsSurface(bucket=bucket) as obs:
-            obs.read_data(binary_data=binary_bsd, metadata=metadata, file_metadata=file_metadata)
+        obs.read_data(binary_data=binary_bsd, metadata=metadata, file_metadata=file_metadata)
 
     with pytest.raises(KeyError):
         file_metadata = {}
-        with ObsSurface(bucket=bucket) as obs:
-            obs.read_data(binary_data=binary_bsd, metadata=metadata, file_metadata=file_metadata)
+        obs.read_data(binary_data=binary_bsd, metadata=metadata, file_metadata=file_metadata)
 
 
 @pytest.mark.parametrize("sampling_period", ["60", 60, "60000000000", "twelve-thousand"])
-def test_read_CRDS_incorrect_sampling_period_raises(sampling_period):
+def test_read_CRDS_incorrect_sampling_period_raises(standardise, sampling_period):
     clear_test_stores()
-    bucket = get_bucket()
 
     filepath = get_surface_datapath(filename="bsd.picarro.1minute.248m.min.dat", source_format="CRDS")
 
     with pytest.raises(ValueError) as exec_info:
-        with ObsSurface(bucket=bucket) as obs:
-            obs.read_file(
-                filepath=filepath,
-                source_format="CRDS",
-                site="bsd",
-                network="DECC",
-                sampling_period=sampling_period,
-            )
-        assert "Invalid sampling period" in exec_info or "Could not evaluate sampling period" in exec_info
+        standardise(
+            filepath=filepath,
+            source_format="CRDS",
+            site="bsd",
+            network="DECC",
+            sampling_period=sampling_period,
+        )
+        assert "Invalid sampling period" in str(exec_info) or "Could not evaluate sampling period" in str(exec_info)
 
 
 def test_read_CRDS():
-    filepath = get_surface_datapath(filename="bsd.picarro.1minute.248m.min.dat", source_format="CRDS")
     bucket = get_bucket()
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(filepath=filepath, source_format="CRDS", site="bsd", network="DECC")
+    filepath = get_surface_datapath(filename="bsd.picarro.1minute.248m.min.dat", source_format="CRDS")
+    results = standardise_surface(bucket=bucket, filepath=filepath, source_format="CRDS", site="bsd", network="DECC")
 
     keys = results["processed"]["bsd.picarro.1minute.248m.min.dat"].keys()
 
@@ -212,6 +207,7 @@ def test_read_CRDS():
 
     filepath = get_surface_datapath(filename="bsd.picarro.1minute.248m.future.dat", source_format="CRDS")
 
+
     with ObsSurface(bucket=bucket) as obs:
         results = obs.read_file(filepath=filepath, source_format="CRDS", site="bsd", network="DECC")
         assert len(obs.datasources()) == 3
@@ -236,17 +232,19 @@ def test_read_CRDS():
     assert data_keys == new_expected_keys
 
 
-def test_read_GC():
+def test_read_GC(standardise):
     clear_test_stores()
     bucket = get_bucket()
 
     data_filepath = get_surface_datapath(filename="capegrim-medusa.18.C", source_format="GC")
     precision_filepath = get_surface_datapath(filename="capegrim-medusa.18.precisions.C", source_format="GC")
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(
-            filepath=(data_filepath, precision_filepath), source_format="GCWERKS", site="CGO", network="AGAGE"
-        )
+    results = standardise(
+        filepath=(data_filepath, precision_filepath),
+        source_format="GCWERKS",
+        site="CGO",
+        network="AGAGE"
+    )
 
     # 30/11/2021: Species labels were updated to be standardised in line with variable naming
     # This list of expected labels was updated.
@@ -353,10 +351,9 @@ def test_read_GC():
         filename="capegrim-medusa.future.precisions.C", source_format="GC"
     )
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(
-            filepath=(data_filepath, precision_filepath), source_format="GCWERKS", site="CGO", network="AGAGE"
-        )
+    results = standardise(
+        filepath=(data_filepath, precision_filepath), source_format="GCWERKS", site="CGO", network="AGAGE"
+    )
 
     datasource = Datasource.load(bucket=bucket, uuid=uuid_one)
     data_one = datasource.data()
@@ -367,16 +364,13 @@ def test_read_GC():
     ]
 
 
-def test_read_cranfield():
+def test_read_cranfield(standardise):
     clear_test_stores()
-    bucket = get_bucket()
 
     data_filepath = get_surface_datapath(filename="THB_hourly_means_test.csv", source_format="Cranfield_CRDS")
-
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(
-            filepath=data_filepath, source_format="CRANFIELD", site="TMB", network="CRANFIELD"
-        )
+    results = standardise(
+        filepath=data_filepath, source_format="CRANFIELD", site="TMB", network="CRANFIELD"
+    )
 
     expected_keys = ["ch4", "co", "co2"]
 
@@ -384,7 +378,7 @@ def test_read_cranfield():
 
     uuid = results["processed"]["THB_hourly_means_test.csv"]["ch4"]["uuid"]
 
-    ch4_data = Datasource.load(bucket=bucket, uuid=uuid, shallow=False).data()
+    ch4_data = Datasource.load(bucket=get_bucket(), uuid=uuid, shallow=False).data()
     ch4_data = ch4_data["2018-05-05-00:00:00+00:00_2018-05-13-16:00:00+00:00"]
 
     assert ch4_data.time[0] == Timestamp("2018-05-05")
@@ -418,7 +412,7 @@ def test_read_beaco2n():
     assert co2_data["co2_qc"][0] == 2
 
 
-def test_read_openghg_format():
+def test_read_openghg_format(standardise):
     """
     Test that files already in OpenGHG format can be read. This file includes:
      - appropriate variable names and types
@@ -430,8 +424,7 @@ def test_read_openghg_format():
 
     datafile = get_surface_datapath(filename="tac_co2_openghg.nc", source_format="OPENGHG")
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(filepath=datafile, source_format="OPENGHG", site="TAC", network="DECC")
+    results = standardise(filepath=datafile, source_format="OPENGHG", site="TAC", network="DECC")
 
     uuid = results["processed"]["tac_co2_openghg.nc"]["co2"]["uuid"]
 
@@ -443,7 +436,7 @@ def test_read_openghg_format():
     assert co2_data["co2_variability"][0] == 0.843
 
 
-def test_read_noaa_raw():
+def test_read_noaa_raw(standardise):
     clear_test_stores()
     bucket = get_bucket()
 
@@ -451,10 +444,9 @@ def test_read_noaa_raw():
         filename="co_pocn25_surface-flask_1_ccgg_event.txt", source_format="NOAA"
     )
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(
-            filepath=data_filepath, source_format="NOAA", site="POCN25", network="NOAA", inlet="flask"
-        )
+    results = standardise(
+        filepath=data_filepath, source_format="NOAA", site="POCN25", network="NOAA", inlet="flask"
+    )
 
     uuid = results["processed"]["co_pocn25_surface-flask_1_ccgg_event.txt"]["co"]["uuid"]
 
@@ -481,22 +473,21 @@ def test_read_noaa_raw():
     assert co_data["co_selection_flag"][-1] == 0
 
 
-def test_read_noaa_obspack():
+def test_read_noaa_obspack(standardise):
     bucket = get_bucket()
 
     data_filepath = get_surface_datapath(
         filename="ch4_esp_surface-flask_2_representative.nc", source_format="NOAA"
     )
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(
-            filepath=data_filepath,
-            inlet="flask",
-            source_format="NOAA",
-            site="esp",
-            network="NOAA",
-            overwrite=True,
-        )
+    results = standardise(
+        filepath=data_filepath,
+        inlet="flask",
+        source_format="NOAA",
+        site="esp",
+        network="NOAA",
+        overwrite=True,
+    )
 
     uuid = results["processed"]["ch4_esp_surface-flask_2_representative.nc"]["ch4"]["uuid"]
 
@@ -523,20 +514,19 @@ def test_read_noaa_obspack():
     assert data["ch4_variability"][0] == pytest.approx(2.093036e-09)
 
 
-def test_read_thames_barrier():
+def test_read_thames_barrier(standardise):
     clear_test_stores()
     bucket = get_bucket()
 
     data_filepath = get_surface_datapath(filename="thames_test_20190707.csv", source_format="THAMESBARRIER")
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(
-            filepath=data_filepath,
-            source_format="THAMESBARRIER",
-            site="TMB",
-            network="LGHG",
-            sampling_period="3600s",
-        )
+    results = standardise(
+        filepath=data_filepath,
+        source_format="THAMESBARRIER",
+        site="TMB",
+        network="LGHG",
+        sampling_period="3600s",
+    )
 
     expected_keys = sorted(["ch4", "co2", "co"])
 
@@ -558,19 +548,18 @@ def test_read_thames_barrier():
         assert sorted(obs._datasource_uuids.values()) == expected_keys
 
 
-def test_delete_Datasource():
+def test_delete_Datasource(standardise):
     bucket = get_bucket()
 
     data_filepath = get_surface_datapath(filename="thames_test_20190707.csv", source_format="THAMESBARRIER")
 
-    with ObsSurface(bucket=bucket) as obs:
-        obs.read_file(
-            filepath=data_filepath,
-            source_format="THAMESBARRIER",
-            site="tmb",
-            network="LGHG",
-            sampling_period="1m",
-        )
+    standardise(
+        filepath=data_filepath,
+        source_format="THAMESBARRIER",
+        site="tmb",
+        network="LGHG",
+        sampling_period="1m",
+    )
 
     with ObsSurface(bucket=bucket) as obs:
         datasources = obs.datasources()
@@ -592,17 +581,15 @@ def test_delete_Datasource():
         assert not exists(bucket=bucket, key=key)
 
 
-def test_add_new_data_correct_datasource():
+def test_add_new_data_correct_datasource(standardise):
     clear_test_stores()
-    bucket = get_bucket()
 
     data_filepath = get_surface_datapath(filename="capegrim-medusa.05.C", source_format="GC")
     precision_filepath = get_surface_datapath(filename="capegrim-medusa.05.precisions.C", source_format="GC")
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(
-            filepath=(data_filepath, precision_filepath), source_format="GCWERKS", site="CGO", network="AGAGE"
-        )
+    results = standardise(
+        filepath=(data_filepath, precision_filepath), source_format="GCWERKS", site="CGO", network="AGAGE"
+    )
 
     first_results = results["processed"]["capegrim-medusa.05.C"]
 
@@ -615,10 +602,9 @@ def test_add_new_data_correct_datasource():
     data_filepath = get_surface_datapath(filename="capegrim-medusa.06.C", source_format="GC")
     precision_filepath = get_surface_datapath(filename="capegrim-medusa.06.precisions.C", source_format="GC")
 
-    with ObsSurface(bucket=bucket) as obs:
-        new_results = obs.read_file(
-            filepath=(data_filepath, precision_filepath), source_format="GCWERKS", site="CGO", network="AGAGE"
-        )
+    new_results = standardise(
+        filepath=(data_filepath, precision_filepath), source_format="GCWERKS", site="CGO", network="AGAGE"
+    )
 
     second_results = new_results["processed"]["capegrim-medusa.06.C"]
 
@@ -844,14 +830,11 @@ def test_store_icos_carbonportal_data(mocker):
 
     data["co2"]["data"] = ds
 
-    with ObsSurface(bucket=bucket) as obs:
-        first_result = obs.store_data(data=data)
+    obs = ObsSurface(bucket=bucket)
+    first_result = obs.store_data(data=data)
+    second_result = obs.store_data(data=data)
 
     assert first_result == {"co2": {"uuid": "test-uuid-2", "new": True}}
-
-    with ObsSurface(bucket=bucket) as obs:
-        second_result = obs.store_data(data=data)
-
     assert second_result is None
 
 
@@ -887,30 +870,27 @@ def test_obs_schema(species, obs_variable):
     # TODO: Could also add checks for dims and dtypes?
 
 
-def test_check_obssurface_same_file_skips():
+def test_check_obssurface_same_file_skips(standardise):
     bucket = get_bucket()
 
     filepath = get_surface_datapath(filename="bsd.picarro.1minute.248m.min.dat", source_format="CRDS")
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(filepath=filepath, source_format="CRDS", site="bsd", network="DECC")
+    results = standardise(filepath=filepath, source_format="CRDS", site="bsd", network="DECC")
 
     assert results
 
-    with ObsSurface(bucket=bucket) as obs:
-        results = obs.read_file(filepath=filepath, source_format="CRDS", site="bsd", network="DECC")
+    results = standardise(filepath=filepath, source_format="CRDS", site="bsd", network="DECC")
 
     assert not results
 
 
-def test_gcwerks_fp_not_a_tuple_raises():
+def test_gcwerks_fp_not_a_tuple_raises(standardise):
     bucket = get_bucket()
     filepath = "/tmp/test_filepath.txt"
 
     with pytest.raises(TypeError):
-        with ObsSurface(bucket=bucket) as obs:
-            obs.read_file(filepath=filepath, source_format="GCWERKS", site="cgo", network="agage")
-            obs.read_file(filepath=filepath, source_format="gc", site="cgo", network="agage")
+        standardise(filepath=filepath, source_format="GCWERKS", site="cgo", network="agage")
+        standardise(filepath=filepath, source_format="gc", site="cgo", network="agage")
 
 
 def test_object_loads_if_invalid_objectstore_path_in_json(tmpdir):


### PR DESCRIPTION
This PR refactors tests to use "standardise" functions instead of directly using BaseStore children.
This serves two purposes:
1) It means that we can change how data is standardised without modifying all the tests.
2) It shows points where BaseStore children are (currently) being used to standardise data, 
as opposed to being used to access the metastore.

* **Summary of changes** (Bug fix, feature, docs update, ...)

Previously, `standardise_surface`, etc. could not accept a bucket as an argument, which meant that BaseStore children needed to be used in a context manager to standardise files. Now these functions do accept a bucket.

`standardise_surface`, `standardise_flux`, `standardise_footprints`, etc. now all call a generic `standardise` function that accepts a `data_type` argument.

I also added standardising function for binary data, remote data, and transformed data (these also accept a `data_type` argument). These functions are kind of ugly, but they're meant to help refactor the BaseStore children by providing an interface that hides the actual implementation details.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
