### PR TITLE
Enable read-only opening of metastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bug where the object store path being written to JSON led to an invalid path being given to some users - [PR #741](https://github.com/openghg/openghg/pull/741)
 
+### Changes
+
+- Added read-only opening of the metadata store of each storage class when searching. This is done using a `mode` argument pased to the `load_metastore` function - [PR #763](https://github.com/openghg/openghg/pull/763)
+
 ## [0.6.1] - 2023-08-04
 
 ### Added

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -4,6 +4,7 @@
 """
 import logging
 from typing import Any, Dict, List, Optional, Union
+from openghg.store import load_metastore
 from openghg.store.spec import define_data_type_classes, define_data_types
 from openghg.objectstore import get_readable_buckets
 from openghg.util import decompress, running_on_hub
@@ -595,9 +596,9 @@ def _base_search(**kwargs: Any) -> SearchResults:
     for bucket_name, bucket in readable_buckets.items():
         metastore_records = []
         for data_type_class in types_to_search:
-            with data_type_class(bucket=bucket) as dclass:
-                metastore = dclass._metastore
+            metakey = data_type_class._metakey
 
+            with load_metastore(bucket=bucket, key=metakey, mode="r") as metastore:
                 for v in expanded_search:
                     res = metastore.search(Query().fragment(v))
                     if res:

--- a/openghg/types/__init__.py
+++ b/openghg/types/__init__.py
@@ -21,6 +21,7 @@ from ._errors import (
     SearchError,
     AttrMismatchError,
     ConfigFileError,
+    MetastoreError,
     construct_xesmf_import_error,
 )
 from ._types import (

--- a/openghg/types/_errors.py
+++ b/openghg/types/_errors.py
@@ -53,6 +53,10 @@ class ConfigFileError(OpenGHGError):
     """Raised for errors with configuraion file"""
 
 
+class MetastoreError(OpenGHGError):
+    """Raised for errors with the metadata store"""
+
+
 def construct_xesmf_import_error(exception: Optional[ImportError] = None) -> str:
     xesmf_error_message = (
         "Unable to import xesmf for use with regridding algorithms."

--- a/tests/store/test_metastore.py
+++ b/tests/store/test_metastore.py
@@ -1,0 +1,17 @@
+from openghg.store import load_metastore
+from openghg.objectstore import get_writable_bucket, get_object_from_json
+
+def test_metastore_read_write_mode():
+    bucket = get_writable_bucket(name="user")
+    key = "test_readonly_store"
+    with load_metastore(bucket=bucket, key=key, mode="rw") as db:
+        db.insert({"some_key": "some_value"})
+
+    metastore_data_a = get_object_from_json(bucket=bucket, key=key)
+
+    with load_metastore(bucket=bucket, key=key, mode="r") as db:
+        db.insert({"another_key": "some_value"})
+
+    metastore_data_b = get_object_from_json(bucket=bucket, key=key)
+
+    assert metastore_data_a == metastore_data_b


### PR DESCRIPTION
* **Summary of changes**

This enables the read-only opening of the metastore by passing the a `mode` keyword to `load_metastore` and the constructor of the store.

* **Please check if the PR fulfills these requirements**

- [x] Closes #762 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
