### PR TITLE
Idea for bool -> str for current data [skip ci]

### DIFF
--- a/openghg/util/_versions.py
+++ b/openghg/util/_versions.py
@@ -13,7 +13,7 @@ import platform
 import struct
 import subprocess
 import sys
-from typing import List, IO, Union, Tuple, Optional, cast
+from typing import List, IO, Union, Tuple
 
 __all__ = ["show_versions", "check_if_need_new_version"]
 
@@ -166,44 +166,48 @@ def show_versions(file: IO = sys.stdout) -> None:
         print(f"{k}: {stat}", file=file)
 
 
-def check_if_need_new_version(if_exists: str = "default", save_current: Optional[bool] = None) -> bool:
+def check_if_need_new_version(if_exists: str = "default", current_version: str = "default") -> bool:
     """
-    Check combination of if_exists and save_current keywords to determine
+    Check combination of if_exists and current_version keywords to determine
     whether a new version should be created.
 
     Output related to these parameters:
-        - if_exists="default", save_current=None
+        - if_exists="default", current_version=None
            - new_version=False (default) - If both values are set
              to None, data will only be updated if there is no
              overlapping data. In this case we can safely write
              to the same version with no data conflict.
-        - if_exists="replace"/"new", save_current=None
+        - if_exists="replace"/"new", current_version=None
            - new_version=True - If a scheme has been set for the
-             combination of new and current data and save_current is None,
+             combination of new and current data and current_version is None,
              create a new version.
-        - if_exists="default"/"replace"/"new", save_current=True
-           - new_version=True - If save_current is explicitly set
+        - if_exists="default"/"replace"/"new", current_version=True
+           - new_version=True - If current_version is explicitly set
              to True, create a new version.
-        - if_exists="default"/"replace"/"new", save_current=False
-           - new_version=False - If save_current is explicitly set
+        - if_exists="default"/"replace"/"new", current_version=False
+           - new_version=False - If current_version is explicitly set
              to False, allow previous version to be overwritten.
 
     Args:
         if_exists: How to combine new and current data, if present.
-        save_current: Whether to save current data or replace this.
+        current_version: Whether to save current data or replace this.
     Returns:
         bool: Whether new version should be created
     """
     # Determining whether a new version should be created based on inputs.
-    if if_exists == "default" and save_current is None:
+    if if_exists == "default" and current_version == "default":
         # Add new (non-overlapping) data on the same version
         new_version = False
-    elif if_exists != "default" and save_current is None:
+    elif if_exists != "default" and current_version == "default":
         # If data could be modified based on if_exists input
         # default to creating a new version.
         new_version = True
-    elif save_current is not None:
-        # Otherwise match new version to the save_current input.
-        new_version = cast(bool, save_current)
+    elif current_version == "ignore":
+        # Otherwise match new version to the current_version input.
+        new_version = False
+    elif current_version == "keep":
+        new_version = True
+    else:
+        raise ValueError("Invalid combination of if_exists and current_version. See documentation.")
 
     return new_version


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Just an idea on how to use a `str` instead of an optional bool. To me it makes it clearer but I'm not sure everyone will agree.