### PR TITLE
Added CHANGELOG.md to push paths-ignore

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -9,6 +9,8 @@ on:
       - 'CHANGELOG.md'
   pull_request:
     branches: [master, devel]
+    paths-ignore:
+      - 'CHANGELOG.md'
 
 jobs:
   test:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,6 +5,8 @@ on:
     branches: [master, devel]
     tags:
       - "*"
+    paths-ignore:
+      - 'CHANGELOG.md'
   pull_request:
     branches: [master, devel]
 


### PR DESCRIPTION
This should make it so that changing the change log doesn't trigger CI.

* **Summary of changes** (Bug fix, feature, docs update, ...)


* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
