### PR TITLE
Iss786 model scenario flux key

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -464,6 +464,8 @@ class ModelScenario:
                 flux_source = self._get_data(flux_keywords, data_type="flux")
                 # TODO: May need to update this check if flux_source is empty FluxData() object
                 if flux_source is not None:
+                    if name is None and len(sources) == 1:
+                        name = flux_source.metadata.get("source", "no_source_specified")
                     flux[name] = flux_source
 
         elif flux is not None:

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -1445,6 +1445,39 @@ def test_stack_datasets_with_alignment(flux_daily, flux_daily_small_dim_diff):
     np.testing.assert_allclose(output_flux, expected_flux)
 
 
+def test_scenario_infer_flux_source_ch4():
+    """
+    Test ModelScenario can find the source of a flux
+    if only a single flux matches the given metadata
+    and source is in the flux metadata.
+    """
+    start_date = "2012-08-01"
+    end_date = "2012-09-01"
+
+    site = "tac"
+    domain = "EUROPE"
+    inlet = "100m"
+    network = "DECC"
+
+    species = "ch4"
+    source = "anthro"
+
+    bc_input = "MOZART"
+
+    model_scenario = ModelScenario(
+        site=site,
+        species=species,
+        inlet=inlet,
+        network=network,
+        domain=domain,
+        bc_input=bc_input,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    assert source in model_scenario.fluxes
+
+
 def test_modelscenario_doesnt_error_empty_objectstore():
     clear_test_stores()
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

If 'source' or 'sources' is not specified, but `ModelScenario` only finds one flux file matching the given arguments,
then `ModelScenario.add_flux` tries to infer the source, and if not found, it sets the key for the added flux to 'source_not_specified'.

A test was added to check this.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #786 (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
