### PR TITLE
added deprecation warnings to parse function for cranfield and btt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.6.2...HEAD)
 
 ### Added
+- Added `DeprecationWarning` to the functions `parse_cranfield` and  `parse_btt`. - [PR #792](https://github.com/openghg/openghg/pull/792)
+
 - Added `environment-dev.yaml` file for developer conda environment - [PR #769](https://github.com/openghg/openghg/pull/769)
 
 - Added generic `standardise` function that accepts a bucket as an argument, and used this to refactor `standardise_surface` etc, and tests that standardise data - [PR #760](https://github.com/openghg/openghg/pull/760)

--- a/openghg/standardise/surface/_btt.py
+++ b/openghg/standardise/surface/_btt.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Dict, Optional, Union
+import warnings
 
 
 def parse_btt(
@@ -28,13 +29,14 @@ def parse_btt(
     from numpy import nan as np_nan
     from openghg.standardise.meta import assign_attributes
     from openghg.util import clean_string, load_internal_json, get_site_info, format_inlet
-    from pandas import Timestamp, isnull, read_csv, to_timedelta
+    from pandas import Timestamp, isnull, read_csv, to_timedelta   
 
     # TODO: Decide what to do about inputs which aren't use anywhere
     # at present - inlet, instrument, sampling_period, measurement_type
 
     data_filepath = Path(data_filepath)
 
+    warnings.warn("This function will be removed in a future release", DeprecationWarning)
     site = "BTT"
 
     # Rename these columns

--- a/openghg/standardise/surface/_btt.py
+++ b/openghg/standardise/surface/_btt.py
@@ -29,7 +29,7 @@ def parse_btt(
     from numpy import nan as np_nan
     from openghg.standardise.meta import assign_attributes
     from openghg.util import clean_string, load_internal_json, get_site_info, format_inlet
-    from pandas import Timestamp, isnull, read_csv, to_timedelta   
+    from pandas import Timestamp, isnull, read_csv, to_timedelta
 
     # TODO: Decide what to do about inputs which aren't use anywhere
     # at present - inlet, instrument, sampling_period, measurement_type

--- a/openghg/standardise/surface/_cranfield.py
+++ b/openghg/standardise/surface/_cranfield.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Dict, List, Optional, Union
+import warnings
 
 
 def parse_cranfield(
@@ -24,6 +25,8 @@ def parse_cranfield(
     """
     from openghg.util import clean_string, format_inlet
     from pandas import read_csv
+
+    warnings.warn("This function will be removed in a future release", DeprecationWarning)
 
     if sampling_period is None:
         sampling_period = "NOT_SET"


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

     Added deprecation warning to the parse function of Cranfield and BTT.

* **Please check if the PR fulfills these requirements**

- [x] Closes #770  (Replace xxxx with the Github issue number)
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

**Not Required**
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] Documentation and tutorials updated/added
