### PR TITLE
Bug fix to retrieve `radon` using retrieve_atmospheric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bug where the object store path being written to JSON led to an invalid path being given to some users - [PR #741](https://github.com/openghg/openghg/pull/741)
 
-### Changes
+### Changed
 
 - Added read-only opening of the metadata store of each storage class when searching. This is done using a `mode` argument pased to the `load_metastore` function - [PR #763](https://github.com/openghg/openghg/pull/763)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Datasource UUIDs are no longer stored in the storage class and are now only stored in the metadata store - [PR #752](https://github.com/openghg/openghg/pull/752)
 
+### Fixed
+
+- Bug where `radon` was not fetched using `retrieve_atmospheric` from icos data. - [PR #794](https://github.com/openghg/openghg/pull/794)
 
 ## [0.6.2] - 2023-08-07
 

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -319,6 +319,13 @@ def _retrieve_remote(
     # Now filter the dataframe so we can extract the PIDS
     filtered_sources = data_pids[data_pids["specLabel"].str.contains(search_str)]
 
+    if filtered_sources.empty:
+        species_lower = [s.lower() for s in species]
+        # For this see https://stackoverflow.com/a/55335207
+        search_str = r"\b(?:{})\b".format("|".join(map(re.escape, species_lower)))
+        # Now filter the dataframe so we can extract the PIDS
+        filtered_sources = data_pids[data_pids["specLabel"].str.contains(search_str)]
+
     if inlet is not None:
         inlet = str(float(inlet.rstrip("m")))
         height_filter = [inlet in str(x) for x in filtered_sources["samplingheight"]]


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
      Added conversion of species to lower if filtered sources are empty. As it was not detecting species like radon.

* **Please check if the PR fulfills these requirements**

- [x] Closes #649  (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature


**Not Required**
- Documentation and tutorials updated/added
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
