### PR TITLE
configuration_file to specify tinydb or mongodb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.6.2...HEAD)
 
 ### Added
+- Added database configuration file to specify database type as tinydb or mongodb. - [PR #800](https://github.com/openghg/openghg/pull/800)
+
 - Added `DeprecationWarning` to the functions `parse_cranfield` and  `parse_btt`. - [PR #792](https://github.com/openghg/openghg/pull/792)
 
 - Added `environment-dev.yaml` file for developer conda environment - [PR #769](https://github.com/openghg/openghg/pull/769)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lazy loading via `xarray.open_dataset` - [PR #755](https://github.com/openghg/openghg/pull/755)
 
 - Added progress bars using `rich` package - [PR #718](https://github.com/openghg/openghg/pull/718) 
+
 - Added database configuration file to specify database type as tinydb or mongodb. - [PR #800](https://github.com/openghg/openghg/pull/800)
 
 

--- a/openghg/db_config.toml
+++ b/openghg/db_config.toml
@@ -1,0 +1,6 @@
+config_version = ""
+[database]
+  type = ""
+
+  [database.mongodb]
+    uri = "mongodb connection string"

--- a/openghg/db_config.yaml
+++ b/openghg/db_config.yaml
@@ -1,8 +1,0 @@
-config_version: ""
-database:
-  type: "" #tinydb or "mongodb"
-  tinydb:
-    file_path: "tinydb config file"
-  mongodb:
-    uri: "mongodb connection string"
-  

--- a/openghg/db_config.yaml
+++ b/openghg/db_config.yaml
@@ -1,0 +1,8 @@
+config_version: ""
+database:
+  type: "" #tinydb or "mongodb"
+  tinydb:
+    file_path: "tinydb config file"
+  mongodb:
+    uri: "mongodb connection string"
+  


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

    Created a configuration file that specifies the version and mentions 2 database types `tinyBD` and `mongoDB`.
    The connection string for MongoDB or config file path for tiny DB configuration is not added as they are unknown.

* **Please check if the PR fulfills these requirements**

- [x] Closes #757 (Replace xxxx with the Github issue number)
- [ ] Reading and writing functions added
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] Documentation and tutorials updated/added
