### PR TITLE
Adding fix and test for issue reported within 620

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -631,7 +631,6 @@ class ModelScenario:
                 infer_sampling_period = True
             else:
                 obs_data_period_s = float(sampling_period)
-            obs_data_period_s = float(obs_attributes["sampling_period"])
         elif "sampling_period_estimate" in obs_attributes:
             estimate = obs_attributes["sampling_period_estimate"]
             logger.warning(f"Using estimated sampling period of {estimate}s for observational data")
@@ -653,6 +652,10 @@ class ModelScenario:
             # Check if the periods differ by more than 1 second
             if max_diff > 1.0:
                 raise ValueError("Sample period can be not be derived from observations")
+
+            estimate = f"{obs_data_period_s:.1f}"
+            logger.warning(f"Sampling period was estimated (inferred) from data frequency: {estimate}s")
+            self.obs.data.attrs["sampling_period_estimate"] = estimate
 
         # TODO: Check regularity of the data - will need this to decide is resampling
         # is appropriate or need to do checks on a per time point basis
@@ -773,7 +776,7 @@ class ModelScenario:
         try:
             mf = obs.data["mf"]
             units: Optional[float] = float(mf.attrs["units"])
-        except KeyError:
+        except (ValueError, KeyError):
             units = None
         except AttributeError:
             raise AttributeError("Unable to read mf attribute from observation data.")

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -550,6 +550,36 @@ def test_footprints_data_merge(model_scenario_1):
     assert attributes["resample_to"] == "coarsest"
 
 
+def test_combine_obs_sampling_period_infer():
+    """
+    If the sampling_period is "NOT_SET" then when combining obs and footprints
+    this should infer the sampling period from the frequency of the data but this
+    was raising a value error. Reported as part of Issue #---.
+
+    Test to ensure this functionality is now working.
+     - sampling_period attribute for WAO data file is "NOT_SET"
+    """
+    start_date = "2021-12-01"
+    end_date = "2022-01-01"
+
+    site = "wao"
+    domain = "TEST"
+    species = "rn"
+    inlet = "10m"
+
+    model_scenario = ModelScenario(
+        site=site, species=species, inlet=inlet, domain=domain, start_date=start_date, end_date=end_date
+    )
+
+    obs_data_1 = model_scenario.obs.data
+    assert obs_data_1.attrs["sampling_period"] == "NOT_SET"
+
+    model_scenario.combine_obs_footprint()  # Check operation can be run
+
+    obs_data_2 = model_scenario.obs.data
+    assert obs_data_2.attrs["sampling_period_estimate"] == "3600.0"
+
+
 # TODO: Dummy tests included below but may want to add checks which use real
 # data for short-lived species (different footprint)
 # - species with single lifetime (e.g. "Rn")


### PR DESCRIPTION


* **Summary of changes** (Bug fix, feature, docs update, ...)

There was a bug reported in relation to Issue 620, which was related to observation data (specifically ICOS and TAC). When the sampling_period attribute has a value of 'NOT_SET', this raised a ValueError when trying to combine observations and data with ModelScenario (using `ModelScenario.combine_obs_footprint`).

The ValueError was raised because this was trying to cast the string 'NOT_SET' as a float but this line could just be removed.

* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
