### PR TITLE
Dropping support for Python 3.8 and adding Python 3.12

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,15 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- - Bug fix for sampling period attribute having a value of "NOT_SET" and combining the observation and footprint data. Previously this was raising a ValueError. [PR #808](https://github.com/openghg/openghg/pull/808)
+- Bug fix for sampling period attribute having a value of "NOT_SET" and combining the observation and footprint data. Previously this was raising a ValueError. [PR #808](https://github.com/openghg/openghg/pull/808)
+
+- Bug where `radon` was not fetched using `retrieve_atmospheric` from icos data. - [PR #794](https://github.com/openghg/openghg/pull/794)
 
 ### Changed
 
 - Datasource UUIDs are no longer stored in the storage class and are now only stored in the metadata store - [PR #752](https://github.com/openghg/openghg/pull/752)
 
+- Support dropped for Python 3.8 - [PR #818](https://github.com/openghg/openghg/pull/818)
+
 ### Fixed
 
-- Bug where `radon` was not fetched using `retrieve_atmospheric` from icos data. - [PR #794](https://github.com/openghg/openghg/pull/794)
+
 
 ## [0.6.2] - 2023-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support dropped for Python 3.8 - [PR #818](https://github.com/openghg/openghg/pull/818)
 
-### Fixed
-
-
-
 ## [0.6.2] - 2023-08-07
 
 ### Fixed

--- a/openghg/__init__.py
+++ b/openghg/__init__.py
@@ -32,8 +32,8 @@ __all__ = [
     "util",
 ]
 
-if _sys.version_info < (3, 8):
-    raise ImportError("openghg requires Python >= 3.8")
+if _sys.version_info < (3, 9):
+    raise ImportError("openghg requires Python >= 3.9")
 
 v = get_versions()
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Dropping support for Python 3.8. This has become necessary because the dependencies for openghg no longer support it (e.g. `xarray` dropped support as of [v2023.02.0](https://docs.xarray.dev/en/stable/whats-new.html#v2023-02-0-feb-7-2023)).

As a part of this, this also adds a check for [Python 3.12](https://www.python.org/downloads/release/python-3120/) which was released on 02/10/2023.

* **Please check if the PR fulfills these requirements**

- [x] Closes #817
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

* **Additional note**

Had to update branch protection rules on GitHub for both `devel` and `master` to remove "Run the tests (3.8)" from the list of checks and replace this with "Run the tests (3.11)".
