### PR TITLE
Iss #815 fix for re-adding ICOS data after removing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added compression to `Datasource.save` and modified `Datasource.load` to take advantage of
   lazy loading via `xarray.open_dataset` - [PR #755](https://github.com/openghg/openghg/pull/755)
 
-- Added progress bars using `rich` package - [PR #718](https://github.com/openghg/openghg/pull/718) 
+- Added progress bars using `rich` package - [PR #718](https://github.com/openghg/openghg/pull/718)
+
+- Added `force` option to `retrieve_atmospheric` and `ObsSurface.store_data` so that retrieved hashes can be ignored.
 
 ### Fixed
 

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -50,8 +50,7 @@ def retrieve_atmospheric(
                 - "never" - don't update mismatches and raise an AttrMismatchError
                 - "from_source" / "attributes" - update mismatches based on attributes from ICOS Header
                 - "from_definition" / "metadata" - update mismatches based on input metadata
-        force: If True, disregard previously retrieved hashes. Use this if you are unable to re-add
-            previously deleted data.
+        force: Force adding of data even if this is identical to data stored (checked based on previously retrieved file hashes).
     Returns:
         ObsData, list[ObsData] or None
     """
@@ -182,8 +181,7 @@ def local_retrieve(
                 - "never" - don't update mismatches and raise an AttrMismatchError
                 - "from_source" / "attributes" - update mismatches based on attributes from ICOS Header
                 - "from_definition" / "metadata" - update mismatches based on input metadata
-        force: If True, disregard previously retrieved hashes. Use this if you are unable to re-add
-            previously deleted data.
+        force: Force adding of data even if this is identical to data stored (checked based on previously retrieved file hashes).
     Returns:
         ObsData, list[ObsData] or None
     """
@@ -239,7 +237,12 @@ def local_retrieve(
         for data in standardised_data.values():
             measurement_data = data["data"]
             # These contain URLs that are case sensitive so skip lowercasing these
-            skip_keys = ["citation_string", "instrument_data", "dobj_pid", "dataset_source"]
+            skip_keys = [
+                "citation_string",
+                "instrument_data",
+                "dobj_pid",
+                "dataset_source",
+            ]
             metadata = to_lowercase(data["metadata"], skip_keys=skip_keys)
             obs_data.append(ObsData(data=measurement_data, metadata=metadata))
 

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -21,6 +21,7 @@ def retrieve_atmospheric(
     dataset_source: Optional[str] = None,
     store: Optional[str] = None,
     update_mismatch: str = "never",
+    force: bool = False,
 ) -> Union[ObsData, List[ObsData], None]:
     """Retrieve ICOS atmospheric measurement data. If data is found in the object store it is returned. Otherwise
     data will be retrieved from the ICOS Carbon Portal. Data retrieval from the Carbon Portal may take a short time.
@@ -49,6 +50,8 @@ def retrieve_atmospheric(
                 - "never" - don't update mismatches and raise an AttrMismatchError
                 - "from_source" / "attributes" - update mismatches based on attributes from ICOS Header
                 - "from_definition" / "metadata" - update mismatches based on input metadata
+        force: If True, disregard previously retrieved hashes. Use this if you are unable to re-add
+            previously deleted data.
     Returns:
         ObsData, list[ObsData] or None
     """
@@ -64,6 +67,7 @@ def retrieve_atmospheric(
         dataset_source=dataset_source,
         update_mismatch=update_mismatch,
         store=store,
+        force=force,
     )
 
 
@@ -148,6 +152,7 @@ def local_retrieve(
     dataset_source: Optional[str] = None,
     store: Optional[str] = None,
     update_mismatch: str = "never",
+    force: bool = False,
     **kwargs: Any,
 ) -> Union[ObsData, List[ObsData], None]:
     """Retrieve ICOS atmospheric measurement data. If data is found in the object store it is returned. Otherwise
@@ -177,6 +182,8 @@ def local_retrieve(
                 - "never" - don't update mismatches and raise an AttrMismatchError
                 - "from_source" / "attributes" - update mismatches based on attributes from ICOS Header
                 - "from_definition" / "metadata" - update mismatches based on input metadata
+        force: If True, disregard previously retrieved hashes. Use this if you are unable to re-add
+            previously deleted data.
     Returns:
         ObsData, list[ObsData] or None
     """
@@ -225,7 +232,7 @@ def local_retrieve(
 
         bucket = get_writable_bucket(name=store)
         with ObsSurface(bucket=bucket) as obs:
-            obs.store_data(data=standardised_data)
+            obs.store_data(data=standardised_data, force=force)
 
         # Create the expected ObsData type
         obs_data = []


### PR DESCRIPTION
Added `force` option to `retrieve_atmospheric` and `ObsSurface.store_data`. If `force=True`, then retrieved hashes will be ignored.

Two tests were added, one to check that if `force=False` (the default option) then `retrieve_atmospheric` issues a warning that there is no new data to process. If `force=True`, then this warning is not issued (and the data is added again, although this is not explicitly checked).

* **Summary of changes** (Bug fix, feature, docs update, ...)


* **Please check if the PR fulfills these requirements**

- [x]  Quick fix for #815 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
