### PR TITLE
Adding back commented out tests in test_site.py for sites_in_network

### DIFF
--- a/tests/util/test_site.py
+++ b/tests/util/test_site.py
@@ -26,11 +26,11 @@ def test_site_info_file_mock():
     "network,expected_site",
     [
         ("NOAA", "MHD"),
-        # ("AGAGE", "MHD"),
-        # ("ICOS", "MHD"),
-        # ("icos", "MHD"),
-        # ("DECC", "TAC"),
-        # ("nonetwork", None)
+        ("AGAGE", "MHD"),
+        ("ICOS", "MHD"),
+        ("icos", "MHD"),
+        ("DECC", "TAC"),
+        ("nonetwork", None)
     ]
 )
 def test_sites_in_network(network, expected_site):


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Some of the parameterised tests in `tests/util/test_site.py::test_sites_in_network` had been commented out (in 02/2023 [as part of commit 87f90e1](https://github.com/openghg/openghg/pull/537/commits/87f90e16da2bee565a0744709adbbb86ee655725#diff-5166e94f0cd4b507533b4b27567723ced669d5c847501a9fc548edcee5835ab1)) but there doesn't seem to be a reason for these tests to not be included. These tests are able to pass and do include more testing for the specified function.

* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing)