### PR TITLE
Added black line length = 110 to toml

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Format code with black
         run: |
           python -m pip install black
-          black --check --line-length 110 openghg/
+          black --check openghg/
       - name: Lint with flake8
         run: |
           python -m pip install --upgrade pip wheel setuptools flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
-        args: [--line-length=110]
         exclude: tests
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added compression to `Datasource.save` and modified `Datasource.load` to take advantage of
   lazy loading via `xarray.open_dataset` - [PR #755](https://github.com/openghg/openghg/pull/755)
 
-- Added progress bars using `rich` package - [PR #718](https://github.com/openghg/openghg/pull/718) 
+- Added progress bars using `rich` package - [PR #718](https://github.com/openghg/openghg/pull/718)
+
+- Added config for Black to `pyproject.toml` - [PR #822](https://github.com/openghg/openghg/pull/822)
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 110


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Black is configured using the `pyproject.toml` file (unlike flake8, which is configured in the setup.cfg file).

Putting `line-length=110` in the pyproject toml means that this setting can be found by IDEs.

* **Please check if the PR fulfills these requirements**

- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

