### PR TITLE
Edgar parser

### DIFF
--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -463,6 +463,7 @@ def standardise_flux(
     continuous: bool = True,
     overwrite: bool = False,
     store: Optional[str] = None,
+    source_format: str = "openghg",
 ) -> dict:
     """Process flux data
 
@@ -478,6 +479,7 @@ def standardise_flux(
         continuous: Whether time stamps have to be continuous.
         overwrite: Should this data overwrite currently stored data.
         store: Name of store to write to
+        source_format: format of raw data file (e.g. "openghg" or "edgar")
 
     Returns:
         dict: Dictionary of Datasource UUIDs data assigned to
@@ -530,6 +532,7 @@ def standardise_flux(
             continuous=continuous,
             chunks=chunks,
             overwrite=overwrite,
+            source_format=source_format,
         )
 
 

--- a/openghg/standardise/emissions/__init__.py
+++ b/openghg/standardise/emissions/__init__.py
@@ -1,1 +1,1 @@
-from ._openghg import parse_openghg
+from ._openghg import parse_openghg, parse_edgar

--- a/openghg/standardise/emissions/_openghg.py
+++ b/openghg/standardise/emissions/_openghg.py
@@ -224,7 +224,7 @@ def parse_edgar(
         )
         regridded_data[flux_data_var].attrs["units"] = "mol/m2/s"
 
-        return regridded_data
+        return regridded_data.rename({flux_data_var: "flux"})
 
     return _parse_generic(
         filepath=filepath,

--- a/openghg/standardise/emissions/_openghg.py
+++ b/openghg/standardise/emissions/_openghg.py
@@ -217,6 +217,12 @@ def parse_edgar(
             {"time": [pd.to_datetime(year)]}, axis=2
         )
 
+        # when regridding in EASTASIA, can generate a line of NaN values along 180 
+        # degrees E/W. Remove these, and replace with zeroes (shouldn't be any 
+        # emissions here anyway, at least for F-gases)
+
+        regridded_data[flux_data_var] = regridded_data[flux_data_var].fillna(0)
+
         # convert kg/m^2/s to mol/m^2/s
         kg_to_g = 1e3
         species_name = define_species_label(species, filepath)[0]

--- a/openghg/standardise/emissions/_openghg.py
+++ b/openghg/standardise/emissions/_openghg.py
@@ -181,6 +181,9 @@ def parse_edgar(
     """
     Read and parse input emissions data downloaded from EDGAR in netCDF format.
 
+    The expected units are kg / (m^2 s). For v8.0, these are the "flx" files from
+    the EDGAR website (not the "emi" files).
+
     Args:
         filepath: Path to data file
         chunks: Chunk size to use when parsing NetCDF, useful for large datasets.

--- a/openghg/transform/__init__.py
+++ b/openghg/transform/__init__.py
@@ -1,2 +1,2 @@
 from ._transform import transform_emissions_data
-from ._regrid import regrid_uniform_cc
+from ._regrid import regrid_uniform_cc, regrid_2d

--- a/openghg/types/_enum.py
+++ b/openghg/types/_enum.py
@@ -36,6 +36,7 @@ class EmissionsTypes(Enum):
     """For standardising emissions/flux inputs"""
 
     OPENGHG = "OPENGHG"
+    EDGAR = "EDGAR"
 
 
 class EmissionsDatabases(Enum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ dask
 h5netcdf
 icoscp
 ipywidgets
+scitools-iris
 matplotlib
 msgpack
 netcdf4


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
This is a very rough version of a parser for EDGAR data in netCDF format.

It assumes that the data is annual, and that there is only one flux source per netCDF file.

It uses the scitools `iris` package to do regridding instead of `xesmf`.

Also, the organisation of the modules doesn't really make sense now, since `openghg.standardise.emissions._openghg.py` now has a generic parser, plus parsers for openghg and edgar formats.

On the other hand, the code works and can be used to regrid and add EDGAR flux files to the object store.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
