### PR TITLE
Updating new_object_store to incorporate `force` keyword on add_data

### DIFF
--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -561,6 +561,10 @@ class ObsSurface(BaseStore):
         else:
             file_hashes_to_compare = {next(iter(v)) for k, v in hashes.items() if k in self._retrieved_hashes}
 
+        # Making sure data can be force overwritten if force keyword is included.
+        if force and if_exists == "default":
+            if_exists = "new"
+
         if len(file_hashes_to_compare) == len(data):
             logger.warning("Note: There is no new data to process.")
             return None


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The `force` keyword was added for ObsSurface.add_data to fix issue observed in #815 (PR #819 ) but for the new functionality of `new_object_store` this also needs the `if_exists` keyword to be set to an appropriate value to let this add to the object store. This adds an additional update for this.

Without this the retrieve icos `test_force_allows_storing_twice` was failing - this fixes that.

* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature