### PR TITLE
Update CRDS parse function to only drop values with NaNs and not the whole row

### DIFF
--- a/openghg/standardise/surface/_crds.py
+++ b/openghg/standardise/surface/_crds.py
@@ -143,10 +143,6 @@ def _read_data(
             index_col="time",
         )
 
-    # Drop any rows with NaNs
-    # This is now done before creating metadata
-    data = data.dropna(axis="rows", how="any")
-
     dupes = find_duplicate_timestamps(data=data)
 
     if dupes and not drop_duplicates:
@@ -212,6 +208,7 @@ def _read_data(
         gas_data.index = to_datetime(gas_data.index, format="%y%m%d %H%M%S")
         # Cast data to float64 / double
         gas_data = gas_data.astype("float64")
+        gas_data = gas_data.dropna(axis="rows", how="any")
 
         # Here we can convert the Dataframe to a Dataset and then write the attributes
         gas_data = gas_data.to_xarray()

--- a/tests/data/proc_test_data/CRDS/rgl.picarro.1minute.90m.minimum.dat
+++ b/tests/data/proc_test_data/CRDS/rgl.picarro.1minute.90m.minimum.dat
@@ -1,0 +1,6 @@
+Created: 10 Nov 23 07:37 GMT
+     -      -         -    -       ch4     ch4   ch4       co2     co2   co2 
+  date   time      type port         C   stdev     N         C   stdev     N 
+140616 033330       air   10       nan     nan   nan       nan     nan   nan 
+140616 033430       air   10   1906.27   1.697    17       nan     nan   nan 
+140616 033530       air   10   1907.20   0.792    17    405.30   0.382    17 

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -1,6 +1,7 @@
 import os
 import json
 import pytest
+import numpy as np
 import xarray as xr
 from pandas import Timestamp
 from helpers import attributes_checker_obssurface, get_surface_datapath, clear_test_stores
@@ -15,7 +16,7 @@ from openghg.objectstore import (
 from openghg.store import ObsSurface
 from openghg.store.base import Datasource
 from openghg.objectstore.metastore import open_metastore
-from openghg.retrieve import search_surface
+from openghg.retrieve import search_surface, get_obs_surface
 from openghg.standardise import standardise_surface, standardise_from_binary_data
 from openghg.util import create_daterange_str
 from pandas import Timestamp
@@ -898,3 +899,48 @@ def test_object_loads_if_invalid_objectstore_path_in_json(tmpdir):
 
     # Now we search for the object, in versions before 0.6.2 this would cause a PermissionError
     search_surface(site="bsd", species="ch4")
+
+
+def test_drop_only_correct_nan():
+    """
+    Create a test for Issue #826 where all columns were being dropped from CRDS data even if
+    only column contains NaN values.
+
+    Example to demonstrate this:
+     -      -         -    -       ch4     ch4   ch4       co2     co2   co2 
+    date   time      type port         C   stdev     N         C   stdev     N 
+    ...
+    140616 033330       air   10       nan     nan   nan       nan     nan   nan 
+    140616 033430       air   10   1906.27   1.697    17       nan     nan   nan 
+    140616 033530       air   10   1907.20   0.792    17    405.30   0.382    17 
+    """
+
+    rgl_filepath = get_surface_datapath(filename="rgl.picarro.1minute.90m.minimum.dat", source_format="CRDS")
+
+    standardise_surface(filepath=rgl_filepath,
+                        source_format="CRDS",
+                        network="DECC",
+                        site="RGL",
+                        store="group")
+
+    # Compare output to GCWerks - there should be a valid CH4 data point at 2014-06-16 03:34
+
+    rgl_ch4 = get_obs_surface(site="rgl",
+                              species="ch4",
+                              inlet="90m")
+    rgl_ch4_data = rgl_ch4.data
+
+    time_str1 = "2014-06-16T03:34:30"
+    time_str2 = "2014-06-16T03:35:30"
+
+    assert len(rgl_ch4_data["time"]) == 2
+    assert np.isclose(rgl_ch4_data.sel(time=time_str1)["mf"].values, 1906.27)
+    assert np.isclose(rgl_ch4_data.sel(time=time_str2)["mf"].values, 1907.20)
+    
+    rgl_co2 = get_obs_surface(site="rgl",
+                              species="co2",
+                              inlet="90m")
+    rgl_co2_data = rgl_co2.data
+
+    assert len(rgl_co2_data["time"]) == 1
+    assert np.isclose(rgl_co2_data.sel(time=time_str2)["mf"].values, 405.30)


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Added to fix to only drop NaN values for the missing data and not the whole row within the CRDS input data.

* **Please check if the PR fulfills these requirements**

- [x] Closes #826  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
