### PR TITLE
Iss764: cache metastore writes and only update if "safe"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `force` option to `retrieve_atmospheric` and `ObsSurface.store_data` so that retrieved hashes can be ignored - [PR #819](https://github.com/openghg/openghg/pull/819)
 )
 
+- Added `SafetyCachingMiddleware` to metastore, which caches writes and only saves them to disk if the underlying file
+has not changed. This is to prevent errors when concurrent writes are made to the metastore. [PR #836](https://github.com/openghg/openghg/pull/836)
 
 ### Fixed
 

--- a/openghg/objectstore/metastore/_classic_metastore.py
+++ b/openghg/objectstore/metastore/_classic_metastore.py
@@ -146,11 +146,22 @@ class SafetyCachingMiddleware(Middleware):
     """
 
     def __init__(self, storage_cls: tinydb.Storage) -> None:
+        """Follows the standard pattern for middleware.
+
+        Args:
+            storage_cls: tinydb storage class to wrap with Middleware
+        Returns:
+            None
+        """
         super().__init__(storage_cls)
-        self.cache = None
-        self.database_hash = None
+        self.cache = None  # in-memory version of database
+        self.database_hash = None  # hash taken when database first read
+        self.writes_made = False  # flag to check if writes made
 
     def read(self):
+        """Read the database from the cache, if present, otherwise load
+        the database from the underlying storage and save a hash of the result.
+        """
         if self.cache is None:
             self.cache = self.storage.read()
             self.database_hash = hash_string(self.cache)
@@ -158,22 +169,29 @@ class SafetyCachingMiddleware(Middleware):
         return self.cache
 
     def write(self, data):
-        # store data in cache
+        """Store data in the cache.
+
+        Args:
+            data: data to store (this is used internally by TinyDB)
+        """
         self.cache = data
+        self.writes_made = True
 
     def close(self):
-        # check if stored hash matches current hash
-        if self.database_hash == hash_string(self.storage.read()):
-            # if underlying file not changed, write data
-            self.storage.write(self.cache)
-        elif self.cache is not None and hash_string(self.cache) != self.database_hash:
-            # changes were made and the underlying file was changed
-            # NOTE: if self.cache is None, then self.database_hash will not equal
-            # the hash of `None`, but we don't want to raise an error if the file
-            # was not read.
-            raise MetastoreError(
-                "Could not write to object store: object store modified while write in progress."
-            )
+        """Close the database. If writes have been made, and the underlying
+        file has not changed, writes will be saved to disk at this point.
+
+        Raises: MetaStoreError if writes have been made and the underlying file *has* been changed.
+        """
+        if self.writes_made:
+            # check if stored hash matches current hash
+            if self.database_hash == hash_string(self.storage.read()):
+                # if underlying file not changed, write data
+                self.storage.write(self.cache)
+            else:
+                raise MetastoreError(
+                    "Could not write to object store: object store modified while write in progress."
+                )
 
         # let underlying storage clean up
         self.storage.close()
@@ -195,7 +213,7 @@ def open_metastore(
         ClassicMetaStore instance.
     """
     key = get_metakey(data_type)
-    with tinydb.TinyDB(bucket, key, mode, storage=CachingMiddleware(BucketKeyStorage)) as db:
+    with tinydb.TinyDB(bucket, key, mode, storage=SafetyCachingMiddleware(BucketKeyStorage)) as db:
         metastore = ClassicMetaStore(database=db, data_type=data_type)
         yield metastore
 
@@ -225,7 +243,7 @@ class ClassicMetaStore(TinyDBMetaStore):
             ClassicMetastore object for given bucket and data type.
         """
         key = get_metakey(data_type)
-        database = tinydb.TinyDB(bucket, key, mode="rw", storage=CachingMiddleware(BucketKeyStorage))
+        database = tinydb.TinyDB(bucket, key, mode="rw", storage=SafetyCachingMiddleware(BucketKeyStorage))
         return cls(database=database, data_type=data_type)
 
     def close(self) -> None:

--- a/openghg/objectstore/metastore/_classic_metastore.py
+++ b/openghg/objectstore/metastore/_classic_metastore.py
@@ -28,6 +28,7 @@ import json
 from typing import Literal, Optional, TypeVar
 
 import tinydb
+from tinydb.middlewares import Middleware
 
 from openghg.objectstore import exists, get_object, set_object_from_json
 from openghg.objectstore.metastore._metastore import TinyDBMetaStore
@@ -130,7 +131,7 @@ class BucketKeyStorage(tinydb.Storage):
         pass
 
 
-class SafetyCachingMiddleware(tinydb.Middleware):
+class SafetyCachingMiddleware(Middleware):
     """Middleware that caches changes to the database, and writes
     these changes when the database is closed. Changes are only written
     if the underlying file has not changed. (The underlying file is the

--- a/openghg/objectstore/metastore/_classic_metastore.py
+++ b/openghg/objectstore/metastore/_classic_metastore.py
@@ -28,7 +28,6 @@ import json
 from typing import Literal, Optional, TypeVar
 
 import tinydb
-from tinydb.middlewares import Middleware, CachingMiddleware
 
 from openghg.objectstore import exists, get_object, set_object_from_json
 from openghg.objectstore.metastore._metastore import TinyDBMetaStore
@@ -131,7 +130,7 @@ class BucketKeyStorage(tinydb.Storage):
         pass
 
 
-class SafetyCachingMiddleware(Middleware):
+class SafetyCachingMiddleware(tinydb.Middleware):
     """Middleware that caches changes to the database, and writes
     these changes when the database is closed. Changes are only written
     if the underlying file has not changed. (The underlying file is the

--- a/tests/objectstore/test_classic_metastore.py
+++ b/tests/objectstore/test_classic_metastore.py
@@ -2,7 +2,10 @@ import pytest
 
 from openghg.objectstore import get_object_from_json
 from openghg.objectstore.metastore import open_metastore
+from openghg.objectstore.metastore._classic_metastore import SafetyCachingMiddleware
 from openghg.types import MetastoreError
+import tinydb
+from tinydb.storages import JSONStorage
 
 
 def test_metastore_read_write_mode(tmp_path):
@@ -17,7 +20,7 @@ def test_metastore_read_write_mode(tmp_path):
     with open_metastore(bucket=bucket, data_type=key, mode="r") as metastore:
         records = metastore.search()
 
-    assert records == [{'some_key': 'some_value'}]
+    assert records == [{"some_key": "some_value"}]
 
     with pytest.raises(MetastoreError):
         with open_metastore(bucket=bucket, data_type=key, mode="r") as metastore:
@@ -30,3 +33,45 @@ def test_metastore_read_write_mode(tmp_path):
     with pytest.raises(ValueError):
         with open_metastore(bucket=bucket, data_type=key, mode="a") as metastore:
             metastore.insert({"another_key": "some_value"})
+
+
+def test_safety_caching_middleware_cache(tmp_path):
+    db_file = tmp_path / "test.json"
+    with tinydb.TinyDB(db_file, storage=SafetyCachingMiddleware(JSONStorage)) as db:
+        db.insert({"some_key": "some_value"})
+
+        # nothing written yet
+        with tinydb.TinyDB(db_file) as db2:
+            assert len(db2) == 0
+
+    with tinydb.TinyDB(db_file) as db2:
+        assert len(db2) == 1
+
+
+def test_safety_caching_middleware_error(tmp_path):
+    # add some data to tinydb
+    db_file = tmp_path / "test.json"
+    with tinydb.TinyDB(db_file) as db:
+        first_item = db.insert({"some_key": "some_value"})
+
+    # show that data won't be saved if tinydb changed before writes happen
+    with pytest.raises(MetastoreError):
+        with tinydb.TinyDB(db_file, storage=SafetyCachingMiddleware(JSONStorage)) as db:
+            db.insert({"another_key": "another_value"})
+
+            # another modification made elsewhere
+            with tinydb.TinyDB(db_file) as db2:
+                db2.remove(doc_ids=[first_item])
+
+
+def test_safety_caching_middleware_no_write_no_error(tmp_path):
+    # add some data to tinydb
+    db_file = tmp_path / "test.json"
+    with tinydb.TinyDB(db_file) as db:
+        first_item = db.insert({"some_key": "some_value"})
+
+    # unlike the previous test, no error will be raised here
+    with tinydb.TinyDB(db_file, storage=SafetyCachingMiddleware(JSONStorage)) as db:
+        # another modification made elsewhere
+        with tinydb.TinyDB(db_file) as db2:
+            db2.remove(doc_ids=[first_item])

--- a/tests/objectstore/test_classic_metastore.py
+++ b/tests/objectstore/test_classic_metastore.py
@@ -36,6 +36,9 @@ def test_metastore_read_write_mode(tmp_path):
 
 
 def test_safety_caching_middleware_cache(tmp_path):
+    """Check that SafetyCachingMiddleware only writes once
+    database is closed.
+    """
     db_file = tmp_path / "test.json"
     with tinydb.TinyDB(db_file, storage=SafetyCachingMiddleware(JSONStorage)) as db:
         db.insert({"some_key": "some_value"})
@@ -49,7 +52,13 @@ def test_safety_caching_middleware_cache(tmp_path):
 
 
 def test_safety_caching_middleware_error(tmp_path):
-    # add some data to tinydb
+    """Check that SafetyCachingMiddleware raises and error
+    if the database is changed by another process.
+
+    The error will be raised when the database opened with Safety caching
+    is closed.
+    """
+    # Add some data to tinydb
     db_file = tmp_path / "test.json"
     with tinydb.TinyDB(db_file) as db:
         first_item = db.insert({"some_key": "some_value"})
@@ -65,6 +74,9 @@ def test_safety_caching_middleware_error(tmp_path):
 
 
 def test_safety_caching_middleware_no_write_no_error(tmp_path):
+    """A similar scenario to the error test, but no writes are made, so
+    no error is raised.
+    """
     # add some data to tinydb
     db_file = tmp_path / "test.json"
     with tinydb.TinyDB(db_file) as db:
@@ -72,6 +84,9 @@ def test_safety_caching_middleware_no_write_no_error(tmp_path):
 
     # unlike the previous test, no error will be raised here
     with tinydb.TinyDB(db_file, storage=SafetyCachingMiddleware(JSONStorage)) as db:
+        # make a read
+        results = db.all()
+
         # another modification made elsewhere
         with tinydb.TinyDB(db_file) as db2:
             db2.remove(doc_ids=[first_item])


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)*
 
Custom TinyDB middleware was added to cache writes to the metastore and
only write the changes if the metastore has not changed on disk.

If there are cached writes and the metastore has changed on disk, then a `MetastoreError`
is raised and the cached changes are not saved.

* **Please check if the PR fulfills these requirements**

- [x] Closes #764 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
