### PR TITLE
Iss695 object store lockfile

### DIFF
--- a/openghg/objectstore/__init__.py
+++ b/openghg/objectstore/__init__.py
@@ -27,6 +27,7 @@ else:
         get_bucket,
         get_object,
         get_object_data_path,
+        get_object_lock_path,
         get_object_from_json,
         get_object_names,
         get_objectstore_info,

--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -248,6 +248,9 @@ def get_object_lock_path(bucket: str, key: str) -> Path:
         Path to object lock file
     """
     lock_path = Path(f"{bucket}/{key}._data.lock")
+    if not lock_path.parent.exists():
+        lock_path.parent.mkdir(parents=True)
+
     return lock_path
 
 

--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -238,6 +238,19 @@ def get_object_data_path(bucket: str, key: str) -> Path:
         raise ObjectStoreError(f"No object at key '{key}'")
 
 
+def get_object_lock_path(bucket: str, key: str) -> Path:
+    """Get path to object lock file at key in passed bucket.
+
+    Args:
+        bucket: Bucket containing data
+        key: Key for data in bucket
+    Returns:
+        Path to object lock file
+    """
+    lock_path = Path(f"{bucket}/{key}._data.lock")
+    return lock_path
+
+
 def set_object(bucket: str, key: str, data: bytes) -> None:
     """Store data in bucket at key
 

--- a/openghg/objectstore/metastore/__init__.py
+++ b/openghg/objectstore/metastore/__init__.py
@@ -1,2 +1,2 @@
 from ._metastore import MetaStore, TinyDBMetaStore
-from ._classic_metastore import open_metastore, ClassicMetaStore
+from ._classic_metastore import open_metastore, DataClassMetaStore

--- a/openghg/objectstore/metastore/_classic_metastore.py
+++ b/openghg/objectstore/metastore/_classic_metastore.py
@@ -29,7 +29,7 @@ from typing import Any, cast, Literal, Optional, Type
 
 from filelock import FileLock
 from openghg.objectstore import exists, get_object, set_object_from_json, get_object_lock_path
-from openghg.objectstore.metastore._metastore import TinyDBMetaStore
+from openghg.objectstore.metastore import TinyDBMetaStore
 from openghg.types import MetastoreError
 from openghg.util import hash_string
 import tinydb

--- a/openghg/objectstore/metastore/_classic_metastore.py
+++ b/openghg/objectstore/metastore/_classic_metastore.py
@@ -193,6 +193,11 @@ class SafetyCachingMiddleware(Middleware):
                     "Could not write to object store: object store modified while write in progress."
                 )
 
+        # if close is called explicitly, rather than through a context manager,
+        # then the cache should be empty, otherwise if the metastore instance is reused
+        # it won't reflect the actual state of the metastore. (This is an edge case.)
+        self.cache = None
+
         # let underlying storage clean up
         self.storage.close()
 

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -119,71 +119,79 @@ class BaseStore:
 
         uuids = {}
 
-        lookup_results = self.datasource_lookup(data=data, required_keys=required_keys, min_keys=min_keys)
-        # TODO - remove this when the lowercasing of metadata gets removed
-        # We currently lowercase all the metadata and some keys we don't want to change, such as paths to the object store
-        skip_keys = ["object_store"]
+        self._metastore.acquire_lock()
+        try:
+            lookup_results = self.datasource_lookup(data=data, required_keys=required_keys, min_keys=min_keys)
+            # TODO - remove this when the lowercasing of metadata gets removed
+            # We currently lowercase all the metadata and some keys we don't want to change, such as paths to the object store
+            skip_keys = ["object_store"]
 
-        for key, parsed_data in data.items():
-            metadata = parsed_data["metadata"]
-            _data = parsed_data["data"]
+            for key, parsed_data in data.items():
+                metadata = parsed_data["metadata"]
+                _data = parsed_data["data"]
 
-            # Our lookup results and gas data have the same keys
-            uuid = lookup_results[key]
+                # Our lookup results and gas data have the same keys
+                uuid = lookup_results[key]
 
-            # Add the read metadata to the Dataset attributes being careful
-            # not to overwrite any attributes that are already there
-            def convert_to_netcdf4_types(value: Any) -> Union[int, float, str, list]:
-                """Attributes in a netCDF file can be strings, numbers, or sequences:
-                http://unidata.github.io/netcdf4-python/#attributes-in-a-netcdf-file
+                # Add the read metadata to the Dataset attributes being careful
+                # not to overwrite any attributes that are already there
+                def convert_to_netcdf4_types(value: Any) -> Union[int, float, str, list]:
+                    """Attributes in a netCDF file can be strings, numbers, or sequences:
+                    http://unidata.github.io/netcdf4-python/#attributes-in-a-netcdf-file
 
-                This function converts any data whose type is not int, float, str, or list
-                to strings.
-                Booleans are converted to strings, even though they are a subtype of int.
-                """
-                if isinstance(value, (int, float, str, list)) and not isinstance(value, bool):
-                    return value
+                    This function converts any data whose type is not int, float, str, or list
+                    to strings.
+                    Booleans are converted to strings, even though they are a subtype of int.
+                    """
+                    if isinstance(value, (int, float, str, list)) and not isinstance(value, bool):
+                        return value
+                    else:
+                        return str(value)
+
+                to_add = {k: convert_to_netcdf4_types(v) for k, v in metadata.items() if k not in _data.attrs}
+                _data.attrs.update(to_add)
+
+                # If we have a UUID for this Datasource load the existing object
+                # from the object store
+                # If we haven't stored data with this metadata before we create a new Datasource
+                # and add the metadata to our metastore
+
+                # Take a copy of the metadata so we can update it
+                meta_copy = metadata.copy()
+                new_ds = uuid is False
+
+                if new_ds:
+                    datasource = Datasource()
+                    uid = datasource.uuid()
+                    meta_copy["uuid"] = uid
+                    # Make sure all the metadata is lowercase for easier searching later
+                    # TODO - do we want to do this or should be just perform lowercase comparisons?
+                    meta_copy = to_lowercase(d=meta_copy, skip_keys=skip_keys)
                 else:
-                    return str(value)
+                    datasource = Datasource.load(bucket=self._bucket, uuid=uuid)
 
-            to_add = {k: convert_to_netcdf4_types(v) for k, v in metadata.items() if k not in _data.attrs}
-            _data.attrs.update(to_add)
+                # Add the dataframe to the datasource
+                datasource.add_data(
+                    metadata=meta_copy,
+                    data=_data,
+                    overwrite=overwrite,
+                    data_type=data_type,
+                    skip_keys=skip_keys,
+                )
+                # Save Datasource to object store
+                datasource.save(bucket=self._bucket)
 
-            # If we have a UUID for this Datasource load the existing object
-            # from the object store
-            # If we haven't stored data with this metadata before we create a new Datasource
-            # and add the metadata to our metastore
+                # Add the metadata to the metastore and make sure it's up to date with the metadata stored
+                # in the Datasource
+                datasource_metadata = datasource.metadata()
+                if new_ds:
+                    self._metastore.insert(datasource_metadata)
+                else:
+                    self._metastore.update(where={"uuid": datasource.uuid()}, to_update=datasource_metadata)
 
-            # Take a copy of the metadata so we can update it
-            meta_copy = metadata.copy()
-            new_ds = uuid is False
-
-            if new_ds:
-                datasource = Datasource()
-                uid = datasource.uuid()
-                meta_copy["uuid"] = uid
-                # Make sure all the metadata is lowercase for easier searching later
-                # TODO - do we want to do this or should be just perform lowercase comparisons?
-                meta_copy = to_lowercase(d=meta_copy, skip_keys=skip_keys)
-            else:
-                datasource = Datasource.load(bucket=self._bucket, uuid=uuid)
-
-            # Add the dataframe to the datasource
-            datasource.add_data(
-                metadata=meta_copy, data=_data, overwrite=overwrite, data_type=data_type, skip_keys=skip_keys
-            )
-            # Save Datasource to object store
-            datasource.save(bucket=self._bucket)
-
-            # Add the metadata to the metastore and make sure it's up to date with the metadata stored
-            # in the Datasource
-            datasource_metadata = datasource.metadata()
-            if new_ds:
-                self._metastore.insert(datasource_metadata)
-            else:
-                self._metastore.update(where={"uuid": datasource.uuid()}, to_update=datasource_metadata)
-
-            uuids[key] = {"uuid": datasource.uuid(), "new": new_ds}
+                uuids[key] = {"uuid": datasource.uuid(), "new": new_ds}
+        finally:
+            self._metastore.release_lock()
 
         return uuids
 

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Sequence, TypeVar, Union
 from pandas import Timestamp
 
 from openghg.objectstore import get_object_from_json, exists, set_object_from_json
-from openghg.objectstore.metastore import ClassicMetaStore
+from openghg.objectstore.metastore import DataClassMetaStore
 from openghg.types import DatasourceLookupError
 from openghg.util import timestamp_now, to_lowercase
 
@@ -43,7 +43,7 @@ class BaseStore:
             # Update myself
             self.__dict__.update(data)
 
-        self._metastore = ClassicMetaStore.from_bucket(bucket=bucket, data_type=self._data_type)
+        self._metastore = DataClassMetaStore(bucket=bucket, data_type=self._data_type)
         self._bucket = bucket
         self._datasource_uuids = self._metastore.select("uuid")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ xarray
 urllib3 >= 1.26.3
 openghg_defs
 rich
+filelock

--- a/tests/objectstore/test_file_locks.py
+++ b/tests/objectstore/test_file_locks.py
@@ -1,0 +1,58 @@
+from threading import Thread
+from timeit import default_timer
+
+from openghg.objectstore.metastore import DataClassMetaStore
+import pytest
+
+
+@pytest.fixture
+def get_metastores(tmp_path, mocker):
+    bucket = str(tmp_path)
+    key = "key"
+    mocker.patch("openghg.objectstore.metastore._classic_metastore.get_metakey", return_value=key)
+
+    ms1 = DataClassMetaStore(bucket, key)
+    ms2 = DataClassMetaStore(bucket, key)
+
+    yield ms1, ms2
+
+    ms1.close()
+    ms2.close()
+
+
+def test_lock(get_metastores):
+    """Check that a second DataClassMetaStore instance
+    must wait to acquire a lock if the metastore is already
+    locked.
+    """
+    ms1, ms2 = get_metastores
+    expected_duration = 2.0
+
+    ms1.acquire_lock()
+
+    # attempt to acquire lock, but give up
+    # if it takes longer than 'expected_duration'
+    t = Thread(target=ms2.acquire_lock)
+    start = default_timer()
+    t.start()
+    t.join(timeout=expected_duration)
+    duration = default_timer() - start
+
+    assert duration >= expected_duration
+
+
+def test_no_lock(get_metastores):
+    """Check that a second DataClassMetaStore instance
+    doesn't need to wait to acquire a lock if the metastore
+    is *not* already locked.
+    """
+    ms1, ms2 = get_metastores
+    expected_duration = 2.0
+
+    t = Thread(target=ms2.acquire_lock)
+    start = default_timer()
+    t.start()
+    t.join(timeout=expected_duration)
+    duration = default_timer() - start
+
+    assert duration < expected_duration

--- a/tests/objectstore/test_file_locks.py
+++ b/tests/objectstore/test_file_locks.py
@@ -30,8 +30,8 @@ def test_lock(get_metastores):
 
     ms1.acquire_lock()
 
-    # attempt to acquire lock, but give up
-    # if it takes longer than 'expected_duration'
+    # attempt to acquire lock, but give up if
+    # it takes longer than 'expected_duration'
     t = Thread(target=ms2.acquire_lock)
     start = default_timer()
     t.start()
@@ -56,3 +56,38 @@ def test_no_lock(get_metastores):
     duration = default_timer() - start
 
     assert duration < expected_duration
+
+
+def test_lock_is_advisory(tmp_path, mocker):
+    """Check that the metastore can be modified by a second metastore
+    instance even if it is locked by a first metastore instance.
+
+    Thus, only acquiring a lock is stopped by the filelock. This means
+    that the lock is "advisory", and must be opted into explicitly in
+    our code.
+
+    NOTE: due to the cache in SafetyCachingMiddleware
+    """
+    bucket = str(tmp_path)
+    key = "key1"
+    mocker.patch("openghg.objectstore.metastore._classic_metastore.get_metakey", return_value=key)
+
+    ms1 = DataClassMetaStore(bucket, key)
+    ms1.insert({"key": "val"})
+    ms1.close()  # need to call close to write due to SafetyCachingMiddleware
+    ms1.acquire_lock()  # this is actually still possible...
+
+    assert len(ms1._db.all()) == 1
+
+    ms2 = DataClassMetaStore(bucket, key)
+    ms2.delete({"key": "val"})
+    ms2.close()  # commit changes
+
+    ms1.release_lock()
+
+    # now check length (with new instance to be sure
+    # the metastore is read from disk)
+    ms3 = DataClassMetaStore(bucket, key)
+
+    assert len(ms3._db.all()) == 0
+    ms3.close()

--- a/tests/objectstore/test_local_object_store.py
+++ b/tests/objectstore/test_local_object_store.py
@@ -5,6 +5,8 @@ from openghg.objectstore import (
     get_user_objectstore_path,
     get_bucket,
     get_writable_bucket,
+    get_object_data_path,
+    get_object_lock_path,
 )
 from openghg.types import ObjectStoreError
 import tempfile
@@ -69,3 +71,21 @@ def test_get_bucket():
     tmpdir = tempfile.gettempdir()
     b = get_bucket()
     assert tmpdir in b
+
+
+def test_get_object_lock_path(tmp_path):
+    bucket = str(tmp_path)
+    key1 = "key1"
+    obj_path = tmp_path / (key1 + "._data")
+    obj_path.touch()
+
+    data_path = get_object_data_path(bucket, key1)
+    lock_path = get_object_lock_path(bucket, key1)
+
+    assert data_path.stem == lock_path.stem.split(".")[0]
+    assert data_path.suffix == lock_path.suffixes[0]
+    assert lock_path.suffixes[1] == ".lock"
+
+    # test getting lock even if file doesn't exist yet
+    key2 = "key2"
+    lock_path = get_object_lock_path(bucket, key2)


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
`ClassicMetaStore` was removed and replaced by `DataClassMetaStore`, 
since only the children of `BaseStore` use `ClassicMetaStore` directly.
`open_metastore` now uses `TinyDBMetaStore` directly.
This means that we don't need a class method for use in `BaseStore`.

File locks were added to `DataClassMetaStore`, and used in `BaseStore.assign_data`.
Tests were added to show that
1) the locks stop other instances of `DataClassMetaStore` from acquiring a lock on a locked file
2) the locks are "advisory", meaning that they don't actually stop access to the file. So, read operations
work on locked files. (This also means that we might need to add locks to other places where write operations occur.)

This could be improved by making the "read" and "read/write" modes of our custom TinyDB storage
class be enforced via locks. Thus any write operation much acquire a lock.

I didn't do this initially, since acquiring a lock in `BaseStore.assign_data` means the lock is held for
less time than if it were acquired when a child class of `BaseStore` is instantiated (e.g. from `standardise`).

* **Please check if the PR fulfills these requirements**

- [ ] Closes #695 #765 
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
