### PR TITLE
Ensure parent folder is created for lockfile path

### DIFF
--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -248,6 +248,9 @@ def get_object_lock_path(bucket: str, key: str) -> Path:
         Path to object lock file
     """
     lock_path = Path(f"{bucket}/{key}._data.lock")
+    if not lock_path.parent.exists():
+        lock_path.parent.mkdir(parents=True)
+
     return lock_path
 
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

I had a lot of errors caused by it trying to create a lockfile in a folder that didn't exist yet. This is a workaround for that and makes all my tests pass. Happy for the same thing to be done somewhere else though.