### PR TITLE
Adding reference to LPDM model used to tutorial details

### DIFF
--- a/doc/source/tutorials/local/Adding_new_data/Adding_ancillary_data.rst
+++ b/doc/source/tutorials/local/Adding_new_data/Adding_ancillary_data.rst
@@ -5,7 +5,8 @@ This tutorial demonstrates how to add ancillary spatial data to the
 OpenGHG store. These are split into several data types which currently
 include:
 
--  “footprints”: regional outputs from an LPDM model [#f3]_ (e.g. NAME)
+-  “footprints”: regional outputs from an LPDM model [#f3]_ (e.g. NAME).
+   The LPDM set up for these outputs is based on e.g. `Lunt et al. 2016 <https://gmd.copernicus.org/articles/9/3213/2016/>`
 -  “emissions”: estimates of species emissions/flux [#f2]_ within a region
 -  “boundary_conditions”: vertical curtains at the boundary of a
    regional domain

--- a/doc/source/tutorials/local/Analysing_data/Comparing_with_emissions.rst
+++ b/doc/source/tutorials/local/Analysing_data/Comparing_with_emissions.rst
@@ -36,6 +36,8 @@ Omit this step if you want to analyse data in your local object store.
 
 We begin by adding observation, footprint, flux, and (optionally)
 boundary conditions data to the object store.
+See :ref:`Adding ancillary spatial data <Adding ancillary spatial data>` for more details
+on these inputs.
 This data relates to Tacolneston (TAC) site within the DECC
 network and the area around Europe (EUROPE domain).
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Adding requested change to tutorial documents (from umbrella issue - #547 ). This is to add reference to the specific LPDM model methodology used to create the footprint format we accept in OpenGHG.

* **Please check if the PR fulfills these requirements**

- [x] Documentation and tutorials updated/added