### PR TITLE
Updating documentation to remove references to Python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ has not changed. This is to prevent errors when concurrent writes are made to th
 
 - Datasource UUIDs are no longer stored in the storage class and are now only stored in the metadata store - [PR #752](https://github.com/openghg/openghg/pull/752)
 
-- Support dropped for Python 3.8 - [PR #818](https://github.com/openghg/openghg/pull/818)
+- Support dropped for Python 3.8 - [PR #818](https://github.com/openghg/openghg/pull/818). OpenGHG now supports Python >= 3.9.
 
 ## [0.6.2] - 2023-08-07
 

--- a/doc/source/development/python_devel.rst
+++ b/doc/source/development/python_devel.rst
@@ -8,7 +8,7 @@ The source code for OpenGHG is available on `GitHub <https://github.com/openghg/
 Setting up your computer
 =========================
 
-You'll need `git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ and Python >= 3.8, so please make sure you have both installed before continuing
+You'll need `git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ and Python >= 3.9, so please make sure you have both installed before continuing
 further.
 
 
@@ -129,7 +129,7 @@ To ensure everything is working on your system running the tests is a good idea.
 Coding Style
 ============
 
-OpenGHG is written in Python 3 (>= 3.8). We aim as much as possible to follow a
+OpenGHG is written in Python 3 (>= 3.9). We aim as much as possible to follow a
 `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__ python coding style and
 recommend that use a linter such as `flake8 <https://flake8.pycqa.org/en/latest/>`__.
 

--- a/doc/source/development/quickstart_devel.rst
+++ b/doc/source/development/quickstart_devel.rst
@@ -8,7 +8,7 @@ The main repository for OpenGHG can be found on `GitHub <https://github.com/open
 Setting up your computer
 =========================
 
-You'll need `git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ and Python >= 3.8, so please make sure you have both installed before continuing
+You'll need `git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ and Python >= 3.9, so please make sure you have both installed before continuing
 further.
 
 Clone OpenGHG

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -11,8 +11,8 @@ Checking your Python installation
 OpenGHG is developed and `tested on Linux and MacOS <https://github.com/openghg/openghg/actions>`__,
 support for Windows is planned.
 
-To install OpenGHG, you first need to install Python >= 3.8. To check
-if you have Python 3.8 installed type;
+To install OpenGHG, you first need to install Python >= 3.9. To check
+if you have Python 3.9 installed type;
 
 .. code-block:: bash
 
@@ -25,9 +25,9 @@ If the version number is ``2.x`` then you must use the ``python3`` command, if t
 
     python3 -V
 
-and see if you have a Python 3 that has a version number >= 3.8. If so, please use ``python3`` instead of ``python``.
+and see if you have a Python 3 that has a version number >= 3.9. If so, please use ``python3`` instead of ``python``.
 
-If you don't have Python >= 3.8 installed, then you can install Python either via your package manager if using Linux or
+If you don't have Python >= 3.9 installed, then you can install Python either via your package manager if using Linux or
 `Homebrew on MacOS <https://docs.brew.sh/Homebrew-and-Python>`__. An alternative for both platforms is `anaconda <https://anaconda.org>`__.
 
 Installation

--- a/doc/source/packaging.rst
+++ b/doc/source/packaging.rst
@@ -69,7 +69,7 @@ Now push this change back to GitHub, using;
 
    git push
 
-This will trigger a CI/CD run which will build and test everything on Linux for Python 3.8 - 3.10.
+This will trigger a CI/CD run which will build and test everything on Linux for Python 3.9 - 3.12.
 Everything should work, as "devel" should have been in a release-ready state.
 
 Testing the packages


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

In v0.7.0 support for Python 3.8 will be dropped. This change updates the documentation to include references to Python >=3.9 (and current support for 3.9 - 3.12).

* **Please check if the PR fulfills these requirements**

- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
