### PR TITLE
Bugfix_862_get_obs_surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.7.0...HEAD)
 
+### Fixed
+
+- Bug fix for conversion of species parameter inside get_obs_surface_local. [PR #871](https://github.com/openghg/openghg/pull/871)
+
 ## [0.7.0] - 2023-12-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bug fix for conversion of species parameter inside get_obs_surface_local. [PR #871](https://github.com/openghg/openghg/pull/871)
+- Bug fix for conversion of species parameter with its synonym value inside get_obs_surface_local. [PR #871](https://github.com/openghg/openghg/pull/871)
 
 ## [0.7.0] - 2023-12-15
 

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -236,11 +236,15 @@ def get_obs_surface_local(
     from openghg.retrieve import search_surface
     from openghg.util import clean_string, format_inlet, load_json, synonyms, timestamp_tzaware, get_site_info
     from pandas import Timedelta
+    from openghg.util import synonyms
 
     if running_on_hub():
         raise ValueError(
             "This function cannot be used on the OpenGHG Hub. Please use openghg.retrieve.get_obs_surface instead."
         )
+
+    if species is not None:
+        species = synonyms(species)
 
     data_type = "surface"
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

* Added use of synonyms function inside get_obs_surface_local. This ensures the conversion of species parameters passed to have the name of species in cohesion with the openghg.

* **Please check if the PR fulfills these requirements**

- [x] Closes #862  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

* **Not required**
* 
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
- [ ] - [ ] Documentation and tutorials updated/added
