### PR TITLE
Copernicus Met retrieving - WIP v2

### DIFF
--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -47,6 +47,7 @@ dependencies:
   - types-requests
   - types-toml
   - types-urllib3
+  - pandas-stubs
   - pip:
       - cfchecker @ git+https://github.com/openghg/cf-checker@master#egg=cf-checker
       - msgpack-types

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,3 +41,6 @@ ignore_errors = True
 
 [mypy-rich]
 ignore_missing_imports = True
+
+[mypy-cdsapi]
+ignore_missing_imports = True

--- a/openghg/plotting/__init__.py
+++ b/openghg/plotting/__init__.py
@@ -1,2 +1,3 @@
 from ._footprint import plot_footprint
 from ._timeseries import plot_timeseries
+from ._met_timeseries import plot_met_timeseries

--- a/openghg/plotting/_met_timeseries.py
+++ b/openghg/plotting/_met_timeseries.py
@@ -1,0 +1,96 @@
+from typing import Optional, List
+
+import plotly.graph_objects as go
+from openghg.dataobjects import METData
+from plotly.subplots import make_subplots
+from pandas import Timestamp
+import numpy as np
+
+from openghg.util import get_site_location
+
+
+# from openghg.retrieve.met import get_site_pressure
+
+
+def plot_met_timeseries(
+    data: METData,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    title: Optional[str] = None,
+    variables: Optional[List[str]] = None,
+) -> go.Figure:
+    """Plot a timeseries
+
+    Args:
+        data: ObsData object or list of objects
+        title: Title for figure
+        xvar: x axis variable, defaults to time
+        yvar: y axis variable, defaults to species
+        xlabel: Label for x axis
+        ylabel: Label for y axis
+        units: Units for y axis
+    Returns:
+        go.Figure: Plotly Graph Object Figure
+    """
+
+    # if not isinstance(data, list):
+    #    data = [data]
+
+    if title is None:
+        title = "Met Variables"
+
+    if variables is None:
+        print(list(data.data.keys()))
+        variables = list(data.data.data_vars)
+    else:
+        for v in variables:
+            if v not in list(data.data.keys()):
+                raise ValueError(
+                    f"{v} is not one of the variables in the data, please select one of {list(data.data.keys())} or fetch more data"
+                )
+    site = data.metadata["site"]
+    site_info = get_site_location(site=site, network=data.metadata["network"])
+    # measure_pressure = get_site_pressure(inlet_heights=inlet_heights, site_height=site_height)
+
+    if start_date is not None or end_date is not None:
+        start_date = Timestamp(data.data.time.values[0]) if start_date is None else start_date
+        end_date = Timestamp(data.data.time.values[-1]) if start_date is None else end_date
+        dataset = data.data.sel(time=slice(Timestamp(start_date), Timestamp(end_date)))
+        if len(dataset.time) == 0:
+            raise ValueError("The dates that you passed are not contained in this met data!")
+    else:
+        dataset = data.data
+
+    layouts = {}
+
+    fig = make_subplots(rows=len(variables), cols=1, shared_xaxes=True, subplot_titles=variables)
+
+    for nvar, v in enumerate(variables):
+        units = data.data[v].attrs["units"]
+
+        layouts[f"yaxis{nvar + 1}"] = {"title": units}
+
+        fig.add_trace(
+            go.Scatter(
+                name=data.data[v].attrs["standard_name"],
+                x=dataset.time.values,
+                y=np.squeeze(
+                    dataset[v]
+                    .interp(
+                        latitude=site_info["latitude"],
+                        longitude=site_info["longitude"],
+                        level=dataset[v].level.values[0],
+                    )
+                    .values
+                ),
+                mode="lines",
+            ),
+            row=nvar + 1,
+            col=1,
+        )
+
+    layouts[f"xaxis{nvar + 1}"] = {"title": "time"}
+    layouts["title"] = {"text": f"Met variables for {site}", "font": {"size": 24}}
+    fig.update_layout(layouts)
+
+    return fig

--- a/openghg/retrieve/met/_ecmwf.py
+++ b/openghg/retrieve/met/_ecmwf.py
@@ -1,8 +1,23 @@
 from __future__ import annotations
 
-# import cdsapi  # type: ignore
-# import numpy as np
-from typing import TYPE_CHECKING, List, Optional, Union
+import numpy as np
+from typing import List, Optional, Union, Tuple
+import os
+import pandas as pd
+import xarray as xr
+from pandas.tseries.offsets import MonthEnd
+
+from openghg.dataobjects import METData
+from openghg.util import get_start_and_end_date
+from itertools import product
+from datetime import datetime
+
+import logging
+
+import cdsapi
+
+logger = logging.getLogger("openghg.store")
+logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
 # import requests
 # from xarray import open_dataset, Dataset
@@ -10,20 +25,36 @@ from typing import TYPE_CHECKING, List, Optional, Union
 # from requests.packages.urllib3.util.retry import Retry
 # from openghg.util import timestamp_tzaware
 
-if TYPE_CHECKING:
-    from openghg.dataobjects import METData
 
 __all__ = ["retrieve_met", "METData"]
+
+
+def launch_cds_request(request: dict, dataset_savepath: str) -> bool:
+    cds_client = cdsapi.Client()
+    dataset_name = "reanalysis-era5-pressure-levels"
+
+    try:
+        cds_client.retrieve(dataset_name, request, dataset_savepath)
+
+        return True
+
+    except Exception as e:
+        logger.warn(f"Retrieve process failed with error {e}")
+
+        return False
 
 
 def retrieve_met(
     site: str,
     network: str,
-    years: Union[str, List[str]],
+    years: Optional[Union[str, List[str]]] = None,
+    months: Optional[Union[str, List[str]]] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     variables: Optional[List[str]] = None,
-) -> METData:
-    """Retrieve METData data. Note that this function will only download a
-    full year of data which may take some time.
+    save_path: Optional[str] = None,
+) -> List[METData]:
+    """Retrieve METData data. Downloads single file with the whole time period.
 
     This function currently on retrieves data from the "reanalysis-era5-pressure-levels"
     dataset but may be modified for other datasets in the future.
@@ -34,25 +65,146 @@ def retrieve_met(
     Returns:
         METData: METData object holding data and metadata
     """
-    raise NotImplementedError("The met retrieval module needs updating and doesn't currently work.")
+
+    # check right date
+    if years is None and (start_date is None or end_date is None):
+        raise AttributeError("You /must pass either the argument years or both start_date and end_date")
+
+    if variables is None:
+        variables = ["u_component_of_wind", "v_component_of_wind"]
+
+        valid_variables = [
+            "divergence",
+            "fraction_of_cloud_cover",
+            "geopotential",
+            "ozone_mass_mixing_ratio",
+            "potential_vorticity",
+            "relative_humidity",
+            "specific_cloud_ice_water_content",
+            "specific_cloud_liquid_water_content",
+            "specific_humidity",
+            "specific_rain_water_content",
+            "specific_snow_water_content",
+            "temperature",
+            "u_component_of_wind",
+            "v_component_of_wind",
+            "vertical_velocity",
+            "vorticity",
+        ]
+
+        print(variables)
+        assert np.all(
+            [var in valid_variables for var in variables]
+        ), f"One of more of the variables passed does not exist in ERA5 data. The problematic variables are {set(variables) - set(valid_variables)}"
+
+    latitude, longitude, site_height, inlet_heights = get_site_data(site=site, network=network)
+
+    # Get the area to retrieve data for
+    ecmwf_area = _get_ecmwf_area(site_lat=latitude, site_long=longitude)
+    # Calculate the pressure at measurement height(s)
+    measure_pressure = get_site_pressure(inlet_heights=inlet_heights, site_height=site_height)
+    # Calculate the ERA5 pressure levels required
+    ecmwf_pressure_levels = _altitude_to_ecmwf_pressure(measure_pressure=measure_pressure)
+
+    if start_date is not None and end_date is not None:
+        download_list = pd.period_range(start=start_date, end=end_date, freq="M")
+        start_d = pd.to_datetime(start_date)
+        end_d = pd.to_datetime(end_date)
+
+        years = list(set([str(download_date).split("-")[0] for download_date in download_list]))
+        months = list(set([str(download_date).split("-")[1] for download_date in download_list]))
+
+    elif years is not None:
+        (start_date, end_date) = get_start_and_end_date(years=years, months=months)
+        start_d = pd.to_datetime(start_date)
+        end_d = pd.to_datetime(end_date)
+
+    default_save_path = os.path.join(os.getcwd().split("openghg")[0], "openghg/metdata")
+    save_path = default_save_path if save_path is None else save_path
+    assert os.path.isdir(
+        save_path
+    ), f"The save path {save_path} is not a directory. Please create it or pass a different save_path"
+
+    logger.info(f"Retrieving to {save_path}")
+
+    request = {
+        "product_type": "reanalysis",
+        "format": "netcdf",
+        "variable": variables,
+        "pressure_level": ecmwf_pressure_levels,
+        "year": years,
+        "month": months,
+        "day": [str(x).zfill(2) for x in range(1, 32)],
+        "time": [f"{str(x).zfill(2)}:00" for x in range(0, 24)],
+        "area": ecmwf_area,
+    }
+
+    dataset_savepath = os.path.join(
+        save_path,
+        f"Met_{site}_{network}_{start_d.year}{start_d.month}_{end_d.year}{end_d.month}_temp.nc",
+    )
+
+    # use this to create a file in the expected format and test the whole pipelne without requesting
+    # request_status = _create_dummy_dataset(request,dataset_savepath)
+
+    # retrieve from copernicus and save requested data to a temp file
+    request_status = launch_cds_request(request, dataset_savepath)
+
+    if not request_status:
+        return []
+
+    dataset = xr.open_dataset(
+        os.path.join(
+            save_path,
+            f"Met_{site}_{network}_{start_d.year}{start_d.month}_{end_d.year}{end_d.month}_temp.nc",
+        )
+    )
+
+    met_objects = []
+
+    for year in np.unique(dataset.time.dt.year.values):
+        for month in np.unique(dataset.time.dt.month.values):
+            metadata = {
+                "product_type": request["product_type"],
+                "format": request["format"],
+                "variable": request["variable"],
+                "pressure_level": request["pressure_level"],
+                "area": request["area"],
+                "site": site,
+                "network": network,
+                "start_date": str(pd.to_datetime(f"{year}-{month}-1", format="%Y-%m-%d")),
+                "end_date": str(pd.to_datetime(f"{year}-{month}-1", format="%Y-%m-%d") + MonthEnd(0)),
+                "month": int(month),
+                "year": int(year),
+            }
+
+            for k in metadata:
+                print(k, type(metadata[k]))
+            # resaving with attributes
+            dataset.attrs.update(metadata)
+            dataset.to_netcdf(
+                os.path.join(
+                    save_path,
+                    f"Met_{site}_{network}_{year}{month}.nc",
+                )
+            )
+
+            met_objects.append(METData(data=dataset, metadata=metadata))
+    # remove temp file
+    os.remove(
+        os.path.join(
+            save_path, f"Met_{site}_{network}_{start_d.year}{start_d.month}_{end_d.year}{end_d.month}_temp.nc"
+        )
+    )
+
+    return met_objects
+
+    # Retrieve metadata from Copernicus about the dataset, this includes
+    # the location of the data netCDF file.
+    # result = cds_client.retrieve(dataset_name, request, filepath)
+
+    # raise NotImplementedError("The met retrieval module needs updating and doesn't currently work.")
     # from openghg.dataobjects import METData
-
-    # if variables is None:
-    #     variables = ["u_component_of_wind", "v_component_of_wind"]
-
-    # latitude, longitude, site_height, inlet_heights = _get_site_data(site=site, network=network)
-
-    # # Get the area to retrieve data for
-    # ecmwf_area = _get_ecmwf_area(site_lat=latitude, site_long=longitude)
-    # # Calculate the pressure at measurement height(s)
-    # measure_pressure = _get_site_pressure(inlet_heights=inlet_heights, site_height=site_height)
-    # # Calculate the ERA5 pressure levels required
-    # ecmwf_pressure_levels = _altitude_to_ecmwf_pressure(measure_pressure=measure_pressure)
-
-    # if not isinstance(years, list):
-    #     years = [years]
-    # else:
-    #     years = sorted(years)
 
     # # TODO - we might need to customise this further in the future to
     # # request other types of weather data
@@ -142,122 +294,161 @@ def retrieve_met(
 #     return dataset
 
 
-# def _two_closest_values(diff: np.ndarray) -> np.ndarray:
-#     """Get location of two closest values in an array of differences.
+def _two_closest_values(diff: np.ndarray) -> np.ndarray:
+    """Get location of two closest values in an array of differences.
 
-#     Args:
-#         diff: Numpy array of values
-#     Returns:
-#         np.ndarry: Numpy array of two closes values
-#     """
-#     closest_values: np.ndarray = np.argpartition(np.abs(diff), 2)[:2]
-#     return closest_values
-
-
-# def _get_site_data(site: str, network: str) -> Tuple[float, float, float, List]:
-#     """Extract site location data from site attributes file.
-
-#     Args:
-#         site: Site code
-#     Returns:
-#         dict: Dictionary of site data
-#     """
-#     from openghg.util import load_json
-
-#     network = network.upper()
-#     site = site.upper()
-
-#     site_info = load_json("site_info.json")
-
-#     try:
-#         site_data = site_info[site][network]
-#         latitude = float(site_data["latitude"])
-#         longitute = float(site_data["longitude"])
-#         site_height = float(site_data["height_station_masl"])
-#         inlet_heights = site_data["height_name"]
-#     except KeyError as e:
-#         raise KeyError(f"Incorrect site or network : {e}")
-
-#     return latitude, longitute, site_height, inlet_heights
+    Args:
+        diff: Numpy array of values
+    Returns:
+        np.ndarry: Numpy array of two closes values
+    """
+    closest_values: np.ndarray = np.argpartition(np.abs(diff), 2)[:2]
+    return closest_values
 
 
-# def _get_ecmwf_area(site_lat: float, site_long: float) -> List:
-#     """Find out the area required from ERA5.
+def get_site_data(site: str, network: str) -> Tuple[float, float, float, List]:
+    """Extract site location data from site attributes file.
 
-#     Args:
-#         site_lat: Latitude of site
-#         site_long: Site longitude
-#     Returns:
-#         list: List of min/max lat long values
-#     """
-#     ecwmf_lat = np.arange(-90, 90.25, 0.25)
-#     ecwmf_lon = np.arange(-180, 180.25, 0.25)
+    Args:
+        site: Site code
+    Returns:
+        dict: Dictionary of site data
+    """
+    from openghg.util import load_json
+    from openghg_defs import site_info_file
 
-#     ecwmf_lat_indices = _two_closest_values(ecwmf_lat - site_lat)
-#     ecwmf_lon_indices = _two_closest_values(ecwmf_lon - site_long)
+    network = network.upper()
+    site = site.upper()
+    site_info = load_json(site_info_file)
 
-#     return [
-#         np.max(ecwmf_lat[ecwmf_lat_indices]),
-#         np.min(ecwmf_lon[ecwmf_lon_indices]),
-#         np.min(ecwmf_lat[ecwmf_lat_indices]),
-#         np.max(ecwmf_lon[ecwmf_lon_indices]),
-#     ]
+    try:
+        site_data = site_info[site][network]
+        latitude = float(site_data["latitude"])
+        longitute = float(site_data["longitude"])
+        site_height = float(site_data["height_station_masl"])
+        inlet_heights = site_data["height_name"]
+    except KeyError as e:
+        raise KeyError(f"Incorrect site or network : {e}")
 
-
-# def _get_site_pressure(inlet_heights: List, site_height: float) -> List[float]:
-#     """Calculate the pressure levels required
-
-#     Args:
-#         inlet_height: Height(s) of inlets
-#         site_height: Height of site
-#     Returns:
-#         list: List of pressures
-#     """
-#     import re
-
-#     if not isinstance(inlet_heights, list):
-#         inlet_heights = [inlet_heights]
-
-#     measured_pressure = []
-#     for h in inlet_heights:
-#         try:
-#             # Extract the number from the inlet height str using regex
-#             inlet = float(re.findall(r"\d+(?:\.\d+)?", h)[0])
-#             measurement_height = inlet + float(site_height)
-#             # Calculate the pressure
-#             pressure = 1000 * np.exp((-1 * measurement_height) / 7640)
-#             measured_pressure.append(pressure)
-#         except IndexError:
-#             pass
-
-#     return measured_pressure
+    return latitude, longitute, site_height, inlet_heights
 
 
-# def _altitude_to_ecmwf_pressure(measure_pressure: List[float]) -> List[str]:
-#     """Find out what pressure levels are required from ERA5.
+def _get_ecmwf_area(site_lat: float, site_long: float) -> List:
+    """Find out the area required from ERA5.
 
-#     Args:
-#         measure_pressure: List of pressures
-#     Returns:
-#         list: List of desired pressures
-#     """
-#     from openghg.util import load_json
+    Args:
+        site_lat: Latitude of site
+        site_long: Site longitude
+    Returns:
+        list: List of min/max lat long values
+    """
+    ecwmf_lat = np.arange(-90, 90.25, 0.25)
+    ecwmf_lon = np.arange(-180, 180.25, 0.25)
 
-#     ecmwf_metadata = load_json("ecmwf_dataset_info.json")
-#     dataset_metadata = ecmwf_metadata["datasets"]
-#     valid_levels = dataset_metadata["reanalysis_era5_pressure_levels"]["valid_levels"]
+    ecwmf_lat_indices = _two_closest_values(ecwmf_lat - site_lat)
+    ecwmf_lon_indices = _two_closest_values(ecwmf_lon - site_long)
 
-#     # Available ERA5 pressure levels
-#     era5_pressure_levels = np.array(valid_levels)
+    return [
+        np.max(ecwmf_lat[ecwmf_lat_indices]),
+        np.min(ecwmf_lon[ecwmf_lon_indices]),
+        np.min(ecwmf_lat[ecwmf_lat_indices]),
+        np.max(ecwmf_lon[ecwmf_lon_indices]),
+    ]
 
-#     # Match pressure to ERA5 pressure levels
-#     ecwmf_pressure_indices = np.zeros(len(measure_pressure) * 2)
 
-#     for index, m in enumerate(measure_pressure):
-#         ecwmf_pressure_indices[(index * 2) : (index * 2 + 2)] = _two_closest_values(m - era5_pressure_levels)
+def get_site_pressure(inlet_heights: List, site_height: float) -> List[float]:
+    """Calculate the pressure levels required
 
-#     desired_era5_pressure = era5_pressure_levels[np.unique(ecwmf_pressure_indices).astype(int)]
+    Args:
+        inlet_height: Height(s) of inlets
+        site_height: Height of site
+    Returns:
+        list: List of pressures
+    """
+    import re
 
-#     pressure_levels: List = desired_era5_pressure.astype(str).tolist()
+    if not isinstance(inlet_heights, list):
+        inlet_heights = [inlet_heights]
 
-#     return pressure_levels
+    measured_pressure = []
+    for h in inlet_heights:
+        try:
+            # Extract the number from the inlet height str using regex
+            inlet = float(re.findall(r"\d+(?:\.\d+)?", h)[0])
+            measurement_height = inlet + float(site_height)
+            # Calculate the pressure
+            pressure = 1000 * np.exp((-1 * measurement_height) / 7640)
+            measured_pressure.append(pressure)
+        except IndexError:
+            pass
+
+    return measured_pressure
+
+
+def _altitude_to_ecmwf_pressure(measure_pressure: List[float]) -> List[str]:
+    """Find out what pressure levels are required from ERA5.
+
+    Args:
+        measure_pressure: List of pressures
+    Returns:
+        list: List of desired pressures
+    """
+    from openghg.util import load_internal_json
+
+    ecmwf_metadata = load_internal_json(filename="ecmwf_dataset_info.json")
+    dataset_metadata = ecmwf_metadata["datasets"]
+    valid_levels = dataset_metadata["reanalysis_era5_pressure_levels"]["valid_levels"]
+
+    # Available ERA5 pressure levels
+    era5_pressure_levels = np.array(valid_levels)
+
+    # Match pressure to ERA5 pressure levels
+    ecwmf_pressure_indices = np.zeros(len(measure_pressure) * 2)
+
+    for index, m in enumerate(measure_pressure):
+        ecwmf_pressure_indices[(index * 2) : (index * 2 + 2)] = _two_closest_values(m - era5_pressure_levels)
+
+    desired_era5_pressure = era5_pressure_levels[np.unique(ecwmf_pressure_indices).astype(int)]
+
+    pressure_levels: List = desired_era5_pressure.astype(str).tolist()
+
+    return pressure_levels
+
+
+def _create_dummy_dataset(request: dict, dataset_savepath: str) -> xr.Dataset:
+
+    date_time_combinations = product(request["year"], request["month"], request["day"], request["time"])
+
+    times = []
+    for year, month, day, time in date_time_combinations:
+        try:
+            times.append(datetime.strptime(f"{year}-{month}-{day} {time}", "%Y-%m-%d %H:%M"))
+        except ValueError:
+            continue
+
+    coords = {
+        "longitude": [request["area"][1], request["area"][3]],
+        "latitude": [request["area"][0], request["area"][1]],
+        "level": request["pressure_level"],
+        "time": times,
+    }
+    data = np.zeros((len(times), len(request["pressure_level"]), 2, 2))
+
+    dims = ("time", "level", "latitude", "longitude")
+
+    attrs = {
+        "product_type": "reanalysis",
+        "format": "netcdf",
+        "variable": ["u_component_of_wind"],
+        "pressure_level": request["pressure_level"],
+        "area": request["area"],
+    }
+
+    dummy_dataset = xr.Dataset({"u": (dims, data)}, coords=coords, attrs=attrs)
+    try:
+        dummy_dataset.to_netcdf(dataset_savepath)
+        print(dataset_savepath, "saved")
+        return True
+    except PermissionError:
+        logger.error(f"Permission denied for folder {dataset_savepath}")
+        return False

--- a/openghg/store/_metstore.py
+++ b/openghg/store/_metstore.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Union
+import logging
 
+from typing import List, Union, Optional, Dict
+
+from openghg.store import DataSchema
 from openghg.store.base import BaseStore
 from pandas import Timestamp
+from openghg.util import get_start_and_end_date
 
-if TYPE_CHECKING:
-    from openghg.dataobjects import METData
+import os
+import glob
+
+import numpy as np
+import xarray as xr
+import pandas as pd
+from xarray import Dataset
+from openghg.dataobjects import METData
+from openghg.util import to_lowercase
+
+logger = logging.getLogger("openghg.store")
+logger.setLevel(logging.DEBUG)
 
 
 class METStore(BaseStore):
@@ -18,61 +32,168 @@ class METStore(BaseStore):
 
     _root = "METStore"
     _uuid = "9fcabd0c-9b68-4ab4-a116-bc30a4472d67"
+    _metakey = f"{_root}/uuid/{_uuid}/metastore"
 
-    def save(self) -> None:
-        """Save the object to the object store
+    def __init__(self, bucket: str) -> None:
+        super().__init__(bucket)
 
-        Args:
-            bucket: Bucket for data
-        Returns:
-            None
-        """
-        raise NotImplementedError("We are working to replace the MetStore.")
-        from openghg.objectstore import get_bucket, set_object_from_json
+        self.required_keys = ["site", "network", "start_date", "end_date"]
 
-        bucket = get_bucket()
+        self._datasource_uuids_dict: Dict[str, str] = {}
 
-        obs_key = f"{METStore._root}/uuid/{METStore._uuid}"
+    # def save(self) -> None:
+    #     """Save the object to the object store
+    #     TODO is this redundant?
+    #     Args:
+    #         bucket: Bucket for data
+    #     Returns:
+    #         None
+    #     """
+    #     raise NotImplementedError("We are working to replace the MetStore.")
+    #     from openghg.objectstore import get_bucket, set_object_from_json
 
-        self._stored = True
-        set_object_from_json(bucket=bucket, key=obs_key, data=self.to_data())
+    #     bucket = get_bucket()
 
-    @staticmethod
-    def retrieve(site: str, network: str, years: Union[str, List[str]]) -> METData:
-        """Retrieve data from either the local METStore or from a
-        remote store if we don't have it locally
+    #     obs_key = f"{METStore._root}/uuid/{METStore._uuid}"
+
+    #     self._stored = True
+    #     set_object_from_json(bucket=bucket, key=obs_key, data=self.to_data())
+
+    def retrieve(
+        self,
+        site: str,
+        network: str,
+        years: Optional[Union[str, List[str]]] = None,
+        months: Optional[Union[str, List[str]]] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        variables: Optional[List[str]] = None,
+        save_path: Optional[str] = None,
+    ) -> Union[METData, None]:
+        """Retrieve data from the local METStore, or from a
+        remote store if not found locally
 
         Args:
             site: Three letter site code
             network: Network name
             years: Year(s) required
+            start_date and end_date: full-date string or month/year strings defining the beginning and end of period to retrieve (either years or start_date and end_date are required)
+            variables: list of variables to retrieve
+            save_path: path to save met data. Defaults to openghg/metdata
         Returns:
             METData: METData object holding data and metadata
         """
-        raise NotImplementedError("We are working to replace the MetStore.")
         from openghg.retrieve.met import retrieve_met
-        from pandas import Timestamp
 
-        if not isinstance(years, list):
-            years = [years]
+        # check right date
+        if years is None and (start_date is None or end_date is None):
+            raise AttributeError("You must pass either the argument years or both start_date and end_date")
+
+        if start_date is None and end_date is None and years is not None:
+            (start_date, end_date) = get_start_and_end_date(years=years, months=months)
+
+        start_date = pd.to_datetime(start_date)
+        end_date = pd.to_datetime(end_date)
+
+        logger.info("Retrieving")
+
+        # check the local store
+        result_search = self.search(site=site, network=network, start_date=start_date, end_date=end_date)
+
+        # If not found in the local store, retrieve from the Copernicus store and save
+        if result_search is None:
+            results = retrieve_met(
+                site=site,
+                network=network,
+                start_date=start_date,
+                end_date=end_date,
+                years=years,
+                months=months,
+                save_path=save_path,
+                variables=variables,
+            )
+
+            if not results:
+                return None
+
+            logger.info("Storing")
+
+            for it in results:
+
+                metadata = {
+                    "site": site,
+                    "network": network,
+                    "variables": it.metadata["variable"],
+                    "product_type": it.metadata["product_type"],
+                    "format": it.metadata["format"],
+                    "pressure_level": it.metadata["pressure_level"],
+                    "area": it.metadata["area"],
+                    "start_date": str(start_date),
+                    "end_date": str(end_date),
+                    "month": it.metadata["month"],
+                    "year": it.metadata["year"],
+                }
+
+                it = METData(data=it.data, metadata=metadata)
+                self._store(it)
+
+            # once stored, search again to load
+            result_search = self.search(site=site, network=network, start_date=start_date, end_date=end_date)
+
         else:
-            years = sorted(years)
+            logger.info("File already exists in the local store")
 
-        store = METStore.load()
+        return result_search
 
-        # We'll just do full years for now, I don't think it's a huge amount of data (currently)
-        start_date = Timestamp(f"{years[0]}-1-1")
-        end_date = Timestamp(f"{years[-1]}-12-31")
+    # def schema
+    # def validate data
 
-        result = store.search(site=site, network=network, start_date=start_date, end_date=end_date)
+    def populate(self, store_path: Optional[str] = None) -> None:
+        """
+        Populate MetStore with existing met files.
+        Args:
+            store_path: path to folder with met data. Defaults to openghg/metdata
+        """
 
-        # Retrieve from the Copernicus store
-        if result is None:
-            result = retrieve_met(site=site, network=network, years=years)
+        default_store_path = os.path.join(os.getcwd().split("openghg")[0], "openghg/metdata")
+        store_path = default_store_path if store_path is None else store_path
 
-            store._store(met_data=result)
+        files = sorted(glob.glob(os.path.join(store_path, "Met_*.nc")))
 
-        return result
+        min_keys = len(self.required_keys)
+
+        successful_files_added = 0
+        sites_added = []
+
+        for file in files:
+            try:
+                dataset = xr.open_dataset(file)
+
+            except KeyError:
+                logger.warn(f"Could not open file {file}")
+                continue
+
+            # check required metadata is present in attributes
+            required_metadata = {
+                k.lower(): to_lowercase(v) for k, v in dataset.attrs.items() if k in self.required_keys
+            }
+            if len(required_metadata) < min_keys:
+                logger.warn(
+                    f"The metadata for file {file} doesn't contain enough information, we need: {self.required_keys}"
+                )
+                continue
+
+            metadata = dict((key, str(dataset.attrs[key])) for key in list(dataset.attrs.keys()))
+
+            METStore.validate_data(dataset)
+
+            data = METData(data=dataset, metadata=metadata)
+            self._store(met_data=data)
+
+            successful_files_added += 1
+            sites_added.append(metadata["site"])
+
+        logger.info(f"Added {successful_files_added} files for {len(set(sites_added))} different sites")
 
     def search(
         self,
@@ -92,45 +213,184 @@ class METStore(BaseStore):
         Returns:
             METData or None: METData object if found else None
         """
-        raise NotImplementedError("We are working to replace the MetStore.")
-        from openghg.dataobjects import METData
         from openghg.store.base import Datasource
 
-        datasources = (Datasource.load(uuid=uuid, shallow=True) for uuid in self._datasource_uuids)
+        datasources = (
+            Datasource.load(uuid=uuid, bucket=self._bucket, shallow=True)
+            for uuid in self._datasource_uuids_dict
+        )
 
-        # We should only get one datasource here currently
+        met_objects = []
         for datasource in datasources:
             if datasource.search_metadata(site=site, network=network, find_all=True):
                 if datasource.in_daterange(start_date=start_date, end_date=end_date):
+                    # print(datasource.metadata())
                     data = next(iter(datasource.data().values()))
-                    return METData(data=data, metadata=datasource.metadata())
+                    # print(datasource.metadata())
+                    # print(data)
 
-        return None
+                    met_objects.append(METData(data=data, metadata=datasource.metadata()))
+
+        if len(met_objects) == 1:
+            return met_objects[0]
+        elif len(met_objects) > 1:
+            try:
+                data = xr.concat([d.data for d in met_objects], dim="time")
+                data.attrs["end_date"] = met_objects[-1].data.attrs["end_date"]
+            except Exception as e:
+                print(f"there was error {e} when concatenating data across the requested months")
+            metadata = met_objects[0].metadata.copy()
+            metadata["end_date"] = met_objects[-1].metadata["end_date"]
+            return METData(data=data, metadata=metadata)
+        else:
+            return None
+
+    # def store_data(
+    #     self,
+    #     data: Dict,
+    #     overwrite: bool = False,
+    #     force: bool = False,
+    #     required_metakeys: Optional[Sequence] = None,
+    # ) -> Optional[Dict]:
+    #     """Store data in metedata - note that this function might be redundant against self._store
+    #     Args:
+    #         data: Dictionary of data in standard format, see the data spec under
+    #             Development -> Data specifications in the documentation
+    #         overwrite: If True overwrite currently stored data
+    #         force: Force adding of data even if this is identical to data stored (checked based on previously retrieved file hashes).
+    #         required_metakeys: Keys in the metadata we should use to store this metadata in the object store
+    #             if None it defaults to:
+    #                 TODO update this
+    #     Returns:
+    #         Dict or None:
+    #     """
+    #     from openghg.util import hash_retrieved_data
+
+    #     # Very rudimentary hash of the data and associated metadata
+    #     data = {"met": data}
+    #     hashes = hash_retrieved_data(to_hash=data)
+
+    #     # Find the keys in data we've seen before
+    #     if force:
+    #         file_hashes_to_compare = set()
+    #     else:
+    #         file_hashes_to_compare = {next(iter(v)) for k, v in hashes.items() if k in self._retrieved_hashes}
+
+    #     if len(file_hashes_to_compare) == len(data):
+    #         logger.warning("Note: There is no new data to process.")
+    #         return None
+
+    #     keys_to_process = set(data.keys())
+    #     if file_hashes_to_compare:
+    #         # TODO - add this to log
+    #         logger.warning(f"Note: We've seen {file_hashes_to_compare} before. Processing new data only.")
+    #         keys_to_process -= file_hashes_to_compare
+
+    #     to_process = {k: v for k, v in data.items() if k in keys_to_process}
+
+    #     if required_metakeys is None:
+    #         required_metakeys = self.required_keys
+
+    #     # Create Datasources, save them to the object store and get their UUIDs
+    #     data_type = "met"
+    #     # This adds the parsed data to new or existing Datasources by performing a lookup
+    #     # in the metastore
+    #     datasource_uuids = self.assign_data(
+    #         data=to_process,
+    #         overwrite=overwrite,
+    #         data_type=data_type,
+    #         required_keys=required_metakeys,
+    #     )
+
+    #     self.store_hashes(hashes=hashes)
+    #     self._datasource_uuids_dict.append(datasource_uuids)
+
+    #     return datasource_uuids
+
+    def store_hashes(self, hashes: Dict) -> None:
+        """Store hashes of data retrieved from Copernicus. This takes the full dictionary of hashes, removes the ones we've seen before and adds the new.
+
+        Args:
+            hashes: Dictionary of hashes provided by the hash_retrieved_data function
+        Returns:
+            None
+        """
+        new = {k: v for k, v in hashes.items() if k not in self._retrieved_hashes}
+        self._retrieved_hashes.update(new)
 
     def _store(self, met_data: METData) -> None:
         """Store MET data within a Datasource
-
-        Here we do some retrieve on the request JSON to
-        make the metadata more easily searchable and of a similar
-        format to Datasources used in other modules of OpenGHG.
-
+        This function might replace store_data
         Args:
             met_data: Dataset
         Returns:
             None
         """
-        raise NotImplementedError("We are working to replace the MetStore.")
-        from openghg.store.base import Datasource
+        # raise NotImplementedError("We are working to replace the MetStore.")
+
+        # from openghg.store import load_metastore  # ,assign_data, datasource_lookup
 
         metadata = met_data.metadata
 
+        # metastore = load_metastore(key=self._metakey)
+
+        # met = METStore.load()
+        from openghg.store.base import Datasource
+
         datasource = Datasource()
         datasource.add_data(metadata=metadata, data=met_data.data, data_type="met")
-        datasource.save()
+        datasource.save(bucket=self._bucket)
 
-        date_str = f"{metadata['start_date']}_{metadata['end_date']}"
+        if "year" in metadata.keys() and "month" in metadata.keys():
+            date_str = f"{metadata['year']}{metadata['month']}"
+        else:
+            # this is just a quick fix - all files downloaded should already have year and month in there
+            date_str = f"{metadata['start_date'][:4]}{metadata['start_date'][5:7]}"
 
         name = "_".join((metadata["site"], metadata["network"], date_str))
-        self._datasource_uuids[datasource.uuid()] = name
+        self._datasource_uuids_dict[datasource.uuid()] = name
+
+        # met.add_single_datasource(uuid={name: datasource.uuid()}, data=met_data, metastore=metastore)
+
+        # met.save()
+        # metastore.close()
+
         # Write this updated object back to the object store
         self.save()
+
+    def datasources(self) -> List[str]:
+        """Return the list of Datasources UUIDs associated with this object
+
+        Returns:
+            list: List of Datasource UUIDs
+        """
+        return list(self._datasource_uuids_dict.keys())
+
+    def see_datasources(self) -> Dict[str, str]:
+        """Return the list of Datasources UUIDs associated with this object
+        Equivalent to datasources in Base, but edited to work around typechecking
+
+        Returns:
+            list: List of Datasource UUIDs
+        """
+        return self._datasource_uuids_dict
+
+    @staticmethod
+    def schema() -> DataSchema:
+
+        # Internal data types of data variables and coordinates
+        dtypes = {
+            "lat": np.floating,  # Covers np.float16, np.float32, np.float64 types
+            "lon": np.floating,
+            "time": np.datetime64,
+        }
+
+        expected_dims = ["latitude", "longitude", "level", "time"]
+
+        data_format = DataSchema(dims=expected_dims, dtypes=dtypes)
+        return data_format
+
+    @staticmethod
+    def validate_data(data: Dataset) -> None:
+        data_schema = METStore.schema()
+        data_schema.validate_data(data)

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -64,6 +64,7 @@ from ._time import (
     timestamp_tzaware,
     trim_daterange,
     valid_daterange,
+    get_start_and_end_date,
 )
 from ._user import create_config, get_user_id, get_user_config_path, read_local_config, check_config
 from ._util import (

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -33,7 +33,7 @@ from ._file import (
 )
 from ._hashing import hash_bytes, hash_file, hash_retrieved_data, hash_string
 from ._inlet import format_inlet, extract_height_name
-from ._site import get_site_info, sites_in_network
+from ._site import get_site_info, sites_in_network, get_site_location
 from ._species import get_species_info, check_lifetime_monthly, molar_mass, species_lifetime, synonyms
 from ._strings import clean_string, is_number, remove_punctuation, to_lowercase
 from ._time import (

--- a/openghg/util/_site.py
+++ b/openghg/util/_site.py
@@ -5,6 +5,38 @@ from openghg.types import optionalPathType
 __all__ = ["get_site_info", "sites_in_network"]
 
 
+def get_site_location(site: str, network: str, site_filepath: optionalPathType = None) -> Dict[str, Any]:
+    """Extract site location data from site attributes file.
+
+    Args:
+        site: Site code
+        network: network name
+        site_filepath: Alternative site info file.
+    Returns:
+        dict: Dictionary of site data
+    """
+    network = network.upper()
+    site = site.upper()
+
+    site_info = get_site_info(site_filepath)
+
+    try:
+        site_data = site_info[site][network]
+        latitude = float(site_data["latitude"])
+        longitude = float(site_data["longitude"])
+        site_height = float(site_data["height_station_masl"])
+        inlet_heights = site_data["height_name"]
+    except KeyError as e:
+        raise KeyError(f"Incorrect site or network : {e}")
+
+    return {
+        "latitude": latitude,
+        "longitude": longitude,
+        "site_height": site_height,
+        "inlet_heights": inlet_heights,
+    }
+
+
 def get_site_info(site_filepath: optionalPathType = None) -> Dict[str, Any]:
     """Extract data from site info JSON file as a dictionary.
 

--- a/openghg/util/_time.py
+++ b/openghg/util/_time.py
@@ -4,6 +4,10 @@ from typing import Dict, List, Optional, Tuple, Union
 from pandas import DataFrame, DateOffset, DatetimeIndex, Timedelta, Timestamp
 from xarray import Dataset
 
+from pandas import to_datetime
+from pandas.tseries.offsets import MonthEnd
+
+
 __all__ = [
     "timestamp_tzaware",
     "timestamp_now",
@@ -858,3 +862,44 @@ def in_daterange(
     end_b = timestamp_tzaware(end_b)
 
     return bool((start_a <= end_b) and (end_a >= start_b))
+
+
+def get_start_and_end_date(
+    years: Union[str, List[str], int, List[int]],
+    months: Optional[Union[str, List[str], int, List[int]]] = None,
+) -> Tuple[str, str]:
+    """
+    Get the start date and end date for a set of years and months
+
+    Args:
+        years: Year(s) to include
+        months: month(s) to include.
+    Returns:
+        (start_date, end_date)
+
+    """
+
+    if not isinstance(years, list):
+        years = [int(years)]
+    elif isinstance(years, list) and isinstance(years[0], str):
+        years = [int(year) for year in years]
+
+    years_list = sorted(years)
+
+    if months is None:
+        start_date = f"{years_list[0]}/01/01"
+        end_date = f"{years_list[-1]}/12/31"
+
+    else:
+        if not isinstance(months, list):
+            months = [int(months)]
+        elif isinstance(months, list) and isinstance(months[0], str):
+            months = [int(month) for month in months]
+
+        months_list = sorted(months)
+
+        start_date = f"{years_list[0]}/{months_list[0]}/01"
+        end_date_ts = to_datetime(f"{years_list[-1]}/{months_list[-1]}/01") + MonthEnd(0)
+        end_date = f"{end_date_ts.year}/{end_date_ts.month}/{end_date_ts.day}"
+
+    return (start_date, end_date)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ pytest-tornasync
 pytest-cov
 pytest-mock
 requests-mock
+pandas-stubs
 # For mypy
 mypy==1.7.1
 types-paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ tinydb
 toml
 urllib3 >= 1.26.3
 xarray
+cdsapi

--- a/tests/store/test_metstore.py
+++ b/tests/store/test_metstore.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+"""from pathlib import Path
 
 import pytest
 from openghg.objectstore import get_bucket
@@ -72,3 +72,4 @@ def test_incorrect_site_or_network_raises():
 
     with pytest.raises(KeyError):
         METStore.retrieve(site="CGO", network="EGAGA", years="2012")
+"""


### PR DESCRIPTION
Summary of changes (Bug fix, feature, docs update, ...)

- Added capability to retrieve met from Copernicus, and store in Metastore.
- Currently functional. Structure/functions:
    - retrieve_met in _ecmwf.py - retrieves met from copernicus, downloads requested timeperiod in monthly files
    - MetStore
        - populate - finds stored .nc files (defaults to openghg/metdata) and populates metadata
        - search - searches metastore and returns if data exists locally
        - retrieve - returns data if it exists locally, otherwise retrieves from Copernicus
    - plot_met_timeseries in plotting - plots met object returned from search or retrieve between given dates

Please check if the PR fulfills these requirements

[x] Addresses issue https://github.com/openghg/openghg/issues/83, related to PR https://github.com/openghg/openghg/pull/615 and https://github.com/openghg/openghg/pull/833
[ ] Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
[ ]All code checks passing - black --line-length 110 run over code, mypy and flake8 not showing any errors
 Documentation and tutorials updated/added
 Added an entry in the latest CHANGELOG.md file if fixing a bug or adding a new feature
[x]  Added any new requirements to requirements.txt and recipes/meta.yaml