### PR TITLE
Ensure dataset chunking matches what's already there

### DIFF
--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -331,6 +331,12 @@ class LocalZarrStore(Store):
                 )
 
             logger.warning(msg)
+
+            # For coordinates we haven't chunked over we'll use the full size
+            for k in dataset.coords:
+                if k not in stored_actually_chunked:
+                    stored_actually_chunked[k] = dataset.sizes[k]
+
             return stored_actually_chunked
 
         return {}

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -333,7 +333,7 @@ class LocalZarrStore(Store):
             logger.warning(msg)
 
             # For coordinates we haven't chunked over we'll use the full size
-            for k in dataset.coords:
+            for k in dataset.dims:
                 if k not in stored_actually_chunked:
                     stored_actually_chunked[k] = dataset.sizes[k]
 

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -408,4 +408,5 @@ def test_standardise_footprint_different_chunking_schemes(caplog):
     search_results = search(data_type="footprints", model="chunk_model", store="user")
     fp_data = search_results.retrieve_all()
 
+    # Check that the chunking scheme is what was specified with the first standardise call
     assert dict(fp_data.data.chunks) == {"time": (2, 2, 2), "lat": (12,), "lon": (12,), "height": (20,)}

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -299,44 +299,6 @@ def test_standardise_footprint():
     assert "tmb_europe_test_model_10m" in results
 
 
-def test_standardise_footprint_different_chunking_schemes(caplog):
-    datapath_a = get_footprint_datapath("TAC-100magl_UKV_TEST_201607.nc")
-    datapath_b = get_footprint_datapath("TAC-100magl_UKV_TEST_201608.nc")
-
-    site = "TAC"
-    network = "UKV"
-    height = "100m"
-    domain = "EUROPE"
-    model = "chunk_model"
-
-    standardise_footprint(
-        filepath=datapath_a,
-        site=site,
-        model=model,
-        network=network,
-        height=height,
-        domain=domain,
-        store="user",
-        chunks={"time": 2},
-    )
-
-    standardise_footprint(
-        filepath=datapath_b,
-        site=site,
-        model=model,
-        network=network,
-        height=height,
-        domain=domain,
-        store="user",
-        chunks={"time": 2, "lat": 5, "lon": 5},
-    )
-
-    search_results = search(data_type="footprints", model="chunk_model", store="user")
-    fp_data = search_results.retrieve_all()
-
-    assert dict(fp_data.data.chunks) == {"time": (2, 2, 2), "lat": (12,), "lon": (12,), "height": (20,)}
-
-
 def test_standardise_flux():
     test_datapath = get_flux_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
 
@@ -409,3 +371,41 @@ def test_cloud_standardise(monkeypatch, mocker, tmpdir):
             },
         }
     )
+
+
+def test_standardise_footprint_different_chunking_schemes(caplog):
+    datapath_a = get_footprint_datapath("TAC-100magl_UKV_TEST_201607.nc")
+    datapath_b = get_footprint_datapath("TAC-100magl_UKV_TEST_201608.nc")
+
+    site = "TAC"
+    network = "UKV"
+    height = "100m"
+    domain = "EUROPE"
+    model = "chunk_model"
+
+    standardise_footprint(
+        filepath=datapath_a,
+        site=site,
+        model=model,
+        network=network,
+        height=height,
+        domain=domain,
+        store="user",
+        chunks={"time": 2},
+    )
+
+    standardise_footprint(
+        filepath=datapath_b,
+        site=site,
+        model=model,
+        network=network,
+        height=height,
+        domain=domain,
+        store="user",
+        chunks={"time": 2, "lat": 5, "lon": 5},
+    )
+
+    search_results = search(data_type="footprints", model="chunk_model", store="user")
+    fp_data = search_results.retrieve_all()
+
+    assert dict(fp_data.data.chunks) == {"time": (2, 2, 2), "lat": (12,), "lon": (12,), "height": (20,)}

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -224,6 +224,7 @@ def test_local_obs_metadata_mismatch_fail():
     Same attributes / metadata as described in 'test_local_obs_metadata_mismatch()'.
     """
     from helpers import clear_test_stores
+
     clear_test_stores()
     filepath = get_surface_datapath(
         filename="DECC-picarro_TAC_20130131_co2-999m-20220929_mismatch.nc", source_format="OPENGHG"
@@ -296,6 +297,44 @@ def test_standardise_footprint():
 
     assert "error" not in results
     assert "tmb_europe_test_model_10m" in results
+
+
+def test_standardise_footprint_different_chunking_schemes(caplog):
+    datapath_a = get_footprint_datapath("TAC-100magl_UKV_TEST_201607.nc")
+    datapath_b = get_footprint_datapath("TAC-100magl_UKV_TEST_201608.nc")
+
+    site = "TAC"
+    network = "UKV"
+    height = "100m"
+    domain = "EUROPE"
+    model = "chunk_model"
+
+    standardise_footprint(
+        filepath=datapath_a,
+        site=site,
+        model=model,
+        network=network,
+        height=height,
+        domain=domain,
+        store="user",
+        chunks={"time": 2},
+    )
+
+    standardise_footprint(
+        filepath=datapath_b,
+        site=site,
+        model=model,
+        network=network,
+        height=height,
+        domain=domain,
+        store="user",
+        chunks={"time": 2, "lat": 5, "lon": 5},
+    )
+
+    search_results = search(data_type="footprints", model="chunk_model", store="user")
+    fp_data = search_results.retrieve_all()
+
+    assert dict(fp_data.data.chunks) == {"time": (2, 2, 2), "lat": (12,), "lon": (12,), "height": (20,)}
 
 
 def test_standardise_flux():

--- a/tests/store/storage/test_localzarrstore.py
+++ b/tests/store/storage/test_localzarrstore.py
@@ -102,7 +102,7 @@ def test_copy_to_memory_store(store):
 
 
 def test_update(store):
-    fp_1 = get_footprint_datapath("TAC-100magl_UKV_EUROPE_201607.nc")
+    fp_1 = get_footprint_datapath("TAC-100magl_UKV_TEST_201607.nc")
     fp_2 = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")
 
     with xr.open_dataset(fp_1) as ds:
@@ -200,12 +200,16 @@ def test_match_chunking(store):
 
     store.delete_all()
 
+    # Let's add some data and then try and add some data with different chunking
     chunks = {"time": 4}
-    data_a_chunked = data_a.chunk(chunks)
     store.add(version="v0", dataset=data_a)
+
+    data_a_chunked = data_a.chunk(chunks)
     chunking = store.match_chunking(version="v0", dataset=data_a_chunked)
 
-    assert not chunking
+    # As the data we originally put in wasn't chunked then we get the full size of the time coordinate
+    # which is 31 here
+    assert chunking == {'time': 31}
 
     # Now try it the other way round, add chunked data and then try to match it with unchunked data
     store.delete_all()


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This makes sure incoming data with different chunks is actually stored with the original schema. In the current version if data is passed in with different chunks then the rechunk in `LocalZarrStore.add` doesn't get rid of the chunks in different coordinates.
