### PR TITLE
try/except for opening dataset

### DIFF
--- a/openghg/standardise/surface/_openghg.py
+++ b/openghg/standardise/surface/_openghg.py
@@ -66,10 +66,10 @@ def parse_openghg(
 
     data_filepath = Path(data_filepath)
 
-    if data_filepath.suffix != ".nc":
-        raise ValueError("Input file must be a .nc (netcdf) file.")
-
-    data = xr.open_dataset(data_filepath)  # Change this to with statement?
+    try:
+        data = xr.open_dataset(data_filepath)  # Change this to with statement?
+    except ValueError as e:
+        raise ValueError(f"Input file {data_filepath.name} could not be opened by xarray.") from e
 
     # Extract current attributes from input data
     attributes = data.attrs


### PR DESCRIPTION
instead of checking for ".nc" suffix

This will allow us to use "._data" files from old
object stores.

* **Summary of changes** (Bug fix, feature, docs update, ...)


* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
