### PR TITLE
Added `store` argument to ModelScenario init

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -102,16 +102,17 @@ class ModelScenario:
         domain: Optional[str] = None,
         model: Optional[str] = None,
         metmodel: Optional[str] = None,
-        fp_inlet: Optional[Union[str, list]] = None,
+        fp_inlet: Union[str, list, None] = None,
         source: Optional[str] = None,
         sources: Optional[Union[str, Sequence]] = None,
         bc_input: Optional[str] = None,
-        start_date: Optional[Union[str, Timestamp]] = None,
-        end_date: Optional[Union[str, Timestamp]] = None,
+        start_date: Union[str, Timestamp, None] = None,
+        end_date: Union[str, Timestamp, None] = None,
         obs: Optional[ObsData] = None,
         footprint: Optional[FootprintData] = None,
-        flux: Optional[Union[FluxData, Dict[str, FluxData]]] = None,
+        flux: Union[FluxData, Dict[str, FluxData], None] = None,
         bc: Optional[BoundaryConditionsData] = None,
+        store: Union[str, list[str], None] = None,
     ):
         """
         Create a ModelScenario instance based on a set of keywords to be
@@ -126,22 +127,23 @@ class ModelScenario:
          - Flux data: species, sources, domain, start_date, end_date
 
         Args:
-            site : Site code e.g. "TAC"
-            species : Species code e.g. "ch4"
-            inlet : Inlet value e.g. "10m"
+            site: Site code e.g. "TAC"
+            species: Species code e.g. "ch4"
+            inlet: Inlet value e.g. "10m"
             height: Alias for inlet.
-            network : Network name e.g. "AGAGE"
-            domain : Domain name e.g. "EUROPE"
-            model : Model name used in creation of footprint e.g. "NAME"
-            metmodel : Name of met model used in creation of footprint e.g. "UKV"
-            fp_inlet : Specify footprint release height options if this doesn't match to site value.
-            sources : Emissions sources
-            bc_input : Input keyword for boundary conditions e.g. "mozart" or "cams"
-            start_date : Start of date range to use. Note for flux this may not be applied
-            end_date : End of date range to use. Note for flux this may not be applied
-            obs : Supply ObsData object directly (e.g. from get_obs...() functions)
-            footprint : Supply FootprintData object directly (e.g. from get_footprint() function)
-            flux : Supply FluxData object directly (e.g. from get_flux() function)
+            network: Network name e.g. "AGAGE"
+            domain: Domain name e.g. "EUROPE"
+            model: Model name used in creation of footprint e.g. "NAME"
+            metmodel: Name of met model used in creation of footprint e.g. "UKV"
+            fp_inlet: Specify footprint release height options if this doesn't match to site value.
+            sources: Emissions sources
+            bc_input: Input keyword for boundary conditions e.g. "mozart" or "cams"
+            start_date: Start of date range to use. Note for flux this may not be applied
+            end_date: End of date range to use. Note for flux this may not be applied
+            obs: Supply ObsData object directly (e.g. from get_obs...() functions)
+            footprint: Supply FootprintData object directly (e.g. from get_footprint() function)
+            flux: Supply FluxData object directly (e.g. from get_flux() function)
+            store: name of object store to retrieve data from.
         Returns:
             None
 
@@ -169,6 +171,7 @@ class ModelScenario:
             start_date=start_date,
             end_date=end_date,
             obs=obs,
+            store=store,
         )
 
         # Make sure obs data is present, make sure inputs match to metadata
@@ -193,6 +196,7 @@ class ModelScenario:
             end_date=end_date,
             species=species,
             footprint=footprint,
+            store=store,
         )
 
         # Add flux data (directly or through keywords)
@@ -204,6 +208,7 @@ class ModelScenario:
             start_date=start_date,
             end_date=end_date,
             flux=flux,
+            store=store,
         )
 
         # Add boundary conditions (directly or through keywords)
@@ -214,6 +219,7 @@ class ModelScenario:
             start_date=start_date,
             end_date=end_date,
             bc=bc,
+            store=store,
         )
 
         # Initialise attributes used for caching
@@ -284,6 +290,7 @@ class ModelScenario:
         start_date: Optional[Union[str, Timestamp]] = None,
         end_date: Optional[Union[str, Timestamp]] = None,
         obs: Optional[ObsData] = None,
+        store: Optional[str] = None,
     ) -> None:
         """
         Add observation data based on keywords or direct ObsData object.
@@ -307,6 +314,7 @@ class ModelScenario:
                 "network": network,
                 "start_date": start_date,
                 "end_date": end_date,
+                "store": store,
             }
 
             obs = self._get_data(obs_keywords, data_type="obs_surface")
@@ -333,6 +341,7 @@ class ModelScenario:
         fp_inlet: Optional[Union[str, list]] = None,
         network: Optional[str] = None,
         footprint: Optional[FootprintData] = None,
+        store: Optional[str] = None,
     ) -> None:
         """
         Add footprint data based on keywords or direct FootprintData object.
@@ -388,6 +397,7 @@ class ModelScenario:
                     # "metmodel": metmodel,  # Should be added to inputs for get_footprint()
                     "start_date": start_date,
                     "end_date": end_date,
+                    "store": store,
                 }
 
                 # Check whether general inert footprint should be extracted (suitable for long-lived species)
@@ -419,6 +429,7 @@ class ModelScenario:
         start_date: Optional[Union[str, Timestamp]] = None,
         end_date: Optional[Union[str, Timestamp]] = None,
         flux: Optional[Union[FluxData, Dict[str, FluxData]]] = None,
+        store: Optional[str] = None,
     ) -> None:
         """
         Add flux data based on keywords or direct FluxData object.
@@ -443,7 +454,7 @@ class ModelScenario:
                 sources = [sources]
 
             for name in sources:
-                flux_keywords_1 = {"species": species, "source": name, "domain": domain}
+                flux_keywords_1 = {"species": species, "source": name, "domain": domain, "store": store}
 
                 # For CO2 we need additional emissions data before a start_date to
                 # match to high time resolution footprints.
@@ -511,6 +522,7 @@ class ModelScenario:
         start_date: Optional[Union[str, Timestamp]] = None,
         end_date: Optional[Union[str, Timestamp]] = None,
         bc: Optional[BoundaryConditionsData] = None,
+        store: Optional[str] = None,
     ) -> None:
         """
         Add boundary conditions data based on keywords or direct BoundaryConditionsData object.
@@ -525,7 +537,7 @@ class ModelScenario:
                 "bc_input": bc_input,
                 "start_date": start_date,
                 "end_date": end_date,
-                "species": species,
+                "store": store,
             }
 
             bc = self._get_data(bc_keywords, data_type="boundary_conditions")


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

I added an option pass an object store name to the `ModelScenario` `__init__` method. The same store must be used for retrieving all data types. We will make this more flexible in the future.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #704 
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
