### PR TITLE
Hashing test fix

### DIFF
--- a/openghg/util/_hashing.py
+++ b/openghg/util/_hashing.py
@@ -85,8 +85,8 @@ def hash_retrieved_data(to_hash: Dict[str, Dict]) -> Dict:
 
         ds = data["data"]
 
-        start_date = str(ds.time.min())
-        end_date = str(ds.time.max())
+        start_date = str(ds.time.min().values)
+        end_date = str(ds.time.max().values)
         n_timestamps = str(ds.time.size)
 
         basic_info = f"{start_date}_{end_date}_{n_timestamps}".encode("utf8")

--- a/tests/util/test_hashing.py
+++ b/tests/util/test_hashing.py
@@ -60,7 +60,7 @@ def test_hash_retrieved_data(mocker):
 
     hashes = hash_retrieved_data(to_hash=to_hash)
 
-    assert hashes == {"e0e05110e110cfdb1d0d2cc2b45cb98c4b8a9f85": {"rome": "1970-01-01 00:00:00+00:00"}}
+    assert hashes == {"c70ece789ca7cc076d5bcada824bd5f247469020": {"rome": "1970-01-01 00:00:00+00:00"}}
 
     second_hash = hash_retrieved_data(to_hash=to_hash)
 
@@ -70,7 +70,7 @@ def test_hash_retrieved_data(mocker):
 
     diff_data_hashes = hash_retrieved_data(to_hash=to_hash)
 
-    expected_diff_data = {"c0d2cd5c1cf95fe5966582ed8cbd2cd22a8d2223": {"rome": "1970-01-01 00:00:00+00:00"}}
+    expected_diff_data = {"00b607872783cfeaf6f22ad1aada805746ddadaa": {"rome": "1970-01-01 00:00:00+00:00"}}
 
     assert diff_data_hashes == expected_diff_data
     assert diff_data_hashes != hashes
@@ -87,6 +87,6 @@ def test_hash_retrieved_data(mocker):
 
     hashes = hash_retrieved_data(to_hash=to_hash)
 
-    expected_london = {"c7543e8c4285ccf8825fd5d22820c36f9aedcf56": {"london": "1970-01-01 00:00:00+00:00"}}
+    expected_london = {"4fc2e7ef1c301af0ca69f60f7197e624584949f8": {"london": "1970-01-01 00:00:00+00:00"}}
 
     assert hashes == expected_london

--- a/tests/util/test_hashing.py
+++ b/tests/util/test_hashing.py
@@ -60,7 +60,7 @@ def test_hash_retrieved_data(mocker):
 
     hashes = hash_retrieved_data(to_hash=to_hash)
 
-    assert hashes == {"c70ece789ca7cc076d5bcada824bd5f247469020": {"rome": "1970-01-01 00:00:00+00:00"}}
+    assert hashes == {"d7f77d27c8edd2618cef1adc5762d764d81314d0": {"rome": "1970-01-01 00:00:00+00:00"}}
 
     second_hash = hash_retrieved_data(to_hash=to_hash)
 
@@ -70,7 +70,7 @@ def test_hash_retrieved_data(mocker):
 
     diff_data_hashes = hash_retrieved_data(to_hash=to_hash)
 
-    expected_diff_data = {"00b607872783cfeaf6f22ad1aada805746ddadaa": {"rome": "1970-01-01 00:00:00+00:00"}}
+    expected_diff_data = {"90f583e3d52a708ff41a1b652af6d021d6106065": {"rome": "1970-01-01 00:00:00+00:00"}}
 
     assert diff_data_hashes == expected_diff_data
     assert diff_data_hashes != hashes
@@ -87,6 +87,6 @@ def test_hash_retrieved_data(mocker):
 
     hashes = hash_retrieved_data(to_hash=to_hash)
 
-    expected_london = {"4fc2e7ef1c301af0ca69f60f7197e624584949f8": {"london": "1970-01-01 00:00:00+00:00"}}
+    expected_london = {"85d7f85ce42c5ce4fd459cdd54595beeb2f40832": {"london": "1970-01-01 00:00:00+00:00"}}
 
     assert hashes == expected_london


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The test `test_hash_retrieved_data` started failing recently, possibly due to an upstream change. I updated the "expected" hashes and now the test passes reliably.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
