### PR TITLE
Mypy fix for local_zarr_store

### DIFF
--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -327,6 +327,7 @@ class LocalZarrStore(Store):
 
             # For coordinates we haven't chunked over we'll use the full size
             for k in dataset.dims:
+                k = str(k)  # xr.Dataset.dims returns a Mapping with Hashable keys, which may not be strings
                 if k not in stored_actually_chunked:
                     stored_actually_chunked[k] = dataset.sizes[k]
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

`xr.Dataset.dims` returns a `Mapping` with `Hashable` keys, while
our chunk `dict` specify strings for keys. To appease mypy, I converted
the Hashable keys to strings. (It is conceivable that a dim is some
Hashable with no custom str method, so the call to `str` would return
the `repr` instead, which might be ugly... but at least it will never
cause an error.)

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
