### PR TITLE
Fixup for pr928

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -112,7 +112,7 @@ class ModelScenario:
         footprint: Optional[FootprintData] = None,
         flux: Union[FluxData, Dict[str, FluxData], None] = None,
         bc: Optional[BoundaryConditionsData] = None,
-        store: Union[str, list[str], None] = None,
+        store: Optional[str] = None,
     ):
         """
         Create a ModelScenario instance based on a set of keywords to be


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

I forgot to change one of the type annotations for `ModelScenario.__init__` so that this now fails the checks for mypy.

```
$ mypy openghg/
openghg/analyse/_scenario.py:174: error: Argument "store" to "add_obs" of "ModelScenario" has incompatible type "str | list[str] | None"; expected "str | None"  [arg-type]
openghg/analyse/_scenario.py:199: error: Argument "store" to "add_footprint" of "ModelScenario" has incompatible type "str | list[str] | None"; expected "str | None"  [arg-type]
openghg/analyse/_scenario.py:211: error: Argument "store" to "add_flux" of "ModelScenario" has incompatible type "str | list[str] | None"; expected "str | None"  [arg-type]
openghg/analyse/_scenario.py:222: error: Argument "store" to "add_bc" of "ModelScenario" has incompatible type "str | list[str] | None"; expected "str | None"  [arg-type]
```
This fixes that.

* **Please check if the PR fulfills these requirements**

- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors