### PR TITLE
Find the stuck test

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -38,5 +38,5 @@ jobs:
         run: conda develop .
         shell: micromamba-shell {0}
       - name: Run the tests
-        run: pytest tests/
+        run: pytest -v tests/
         shell: micromamba-shell {0}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Test with pytest
         run: |
           pip install --upgrade pytest
-          pytest --run-cfchecks --cov=./ --cov-report=xml
+          pytest -v --run-cfchecks --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This adds the verbose flag to the CI so we can hopefully diagnose slow / stuck tests easier. Doesn't have to be merged but I want the CI to run.

