### PR TITLE
Fix for standardisation test error

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -2,6 +2,7 @@ from .cfchecking import check_cf_compliance
 from .helpers import (
     all_datasource_keys,
     call_function_packager,
+    clear_test_store,
     clear_test_stores,
     get_bc_datapath,
     get_column_datapath,

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -1,5 +1,6 @@
 """ Some helper functions for things we do in tests frequently
 """
+
 import shutil
 import tempfile
 from pathlib import Path
@@ -16,7 +17,21 @@ def temporary_store_paths() -> Dict[str, Path]:
     }
 
 
+def clear_test_store(name: str) -> None:
+    """Clear one of the testing object stores
+
+    Args:
+        name: Name of store to clear
+    Returns:
+        None
+    """
+    tmp_stores = temporary_store_paths()
+    path = tmp_stores[name]
+    shutil.rmtree(path=path, ignore_errors=True)
+
+
 def clear_test_stores() -> None:
+    """Clears the testing object stores"""
     # Clears the testing object stores
     tmp_stores = temporary_store_paths()
     for path in tmp_stores.values():

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import pytest
-from helpers import get_flux_datapath, get_footprint_datapath, get_surface_datapath, get_column_datapath, clear_test_stores
+from helpers import get_flux_datapath, get_footprint_datapath, get_surface_datapath, get_column_datapath, clear_test_stores, clear_test_store
 from openghg.retrieve import get_obs_surface, search
 from openghg.standardise import (
     standardise_column,
@@ -78,6 +78,7 @@ def test_standardise_obs_openghg():
      - "inlet_height_magl" in metadata was just being set to "inlet" from metadata ("185m")
      - sync_surface_metadata was trying to compare the two values of 185.0 and "185m" but "185m" could not be converted to a float - ValueError
     """
+    clear_test_store("user")
     filepath = get_surface_datapath(
         filename="DECC-picarro_TAC_20130131_co2-185m-20220929_cut.nc", source_format="OPENGHG"
     )


### PR DESCRIPTION
* **Summary of changes**
This fixes the test failure in `test_standardise_obs_openghg` that was being caused by the same file being processed previously. I've added a new function `clear_test_store` which I've used to clear the test store before this test is run so the file can be standardised properly. This function just clears the store that's specified instead of deleting all three test stores.


* **Please check if the PR fulfills these requirements**

- [ ] Closes #932 
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
