### PR TITLE
Adding pytest-timeout to stop any tests taking longer than 300s

### DIFF
--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -51,3 +51,4 @@ dependencies:
       - cfchecker @ git+https://github.com/openghg/cf-checker@master#egg=cf-checker
       - msgpack-types
       - icoscp
+      - pytest-timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 110
+
+[pytest]
+timeout = 60

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,4 @@ build-backend = "setuptools.build_meta"
 line-length = 110
 
 [pytest]
-timeout = 60
+timeout = 300

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pytest >= 6.2.5
 pytest-tornasync
 pytest-cov
 pytest-mock
+pytest-timeout
 requests-mock
 # For mypy
 mypy==1.7.1


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This adds the [`pytest-timeout`](https://github.com/pytest-dev/pytest-timeout) plugin which will stop any individual tests after they've run for a specified time, here 60s. 
