### PR TITLE
Correct header for pytest to read from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,5 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 110
 
-[pytest]
+[tool.pytest.ini_options]
 timeout = 300


### PR DESCRIPTION
* **Summary of changes**

This corrects the header so pytest reads from the `pyproject.toml` file properly.
