### PR TITLE
Update meta.yaml and workflow to fetch git tag on master

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -2,7 +2,7 @@ name: OpenGHG tests
 
 on:
   push:
-    branches: 'feature/Iss946-071_to_conda_trial_fix'
+    branches: [master, devel]
     tags:
       - "*"
     paths-ignore:
@@ -88,6 +88,33 @@ jobs:
           branch: gh-pages
           folder: "doc/build/html"
           clean: true
+  release_pypi:
+    name: Build and publish Python distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    needs: ["test", "docs"]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - name: Install pypa/build
+        run: |
+          pip install --upgrade build
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build --sdist --wheel --outdir dist/
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
   release_conda:
     name: Build and publish conda package
     runs-on: ubuntu-latest
@@ -110,6 +137,6 @@ jobs:
           conda mambabuild --croot ${{ github.workspace }}/build recipes -c conda-forge
           BUILD_DIR=${GITHUB_WORKSPACE}/build
           BUILD=$(find "$BUILD_DIR" -name '*.tar.bz2')
+          anaconda --token "$ANACONDA_TOKEN" upload --user openghg --label main "$BUILD"
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          GIT_TAG: ${{ github.ref_name }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -140,3 +140,4 @@ jobs:
           anaconda --token "$ANACONDA_TOKEN" upload --user openghg --label main "$BUILD"
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          GIT_TAG: ${{ github.ref_name }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -112,3 +112,4 @@ jobs:
           BUILD=$(find "$BUILD_DIR" -name '*.tar.bz2')
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          GIT_TAG: ${{ github.ref_name }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -2,7 +2,7 @@ name: OpenGHG tests
 
 on:
   push:
-    branches: [master, devel]
+    branches: 'feature/Iss946-071_to_conda_trial_fix'
     tags:
       - "*"
     paths-ignore:
@@ -88,33 +88,6 @@ jobs:
           branch: gh-pages
           folder: "doc/build/html"
           clean: true
-  release_pypi:
-    name: Build and publish Python distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-latest
-    needs: ["test", "docs"]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-          cache: "pip"
-      - name: Install pypa/build
-        run: |
-          pip install --upgrade build
-      - name: Build a binary wheel and a source tarball
-        run: |
-          python -m build --sdist --wheel --outdir dist/
-      - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
   release_conda:
     name: Build and publish conda package
     runs-on: ubuntu-latest
@@ -137,6 +110,5 @@ jobs:
           conda mambabuild --croot ${{ github.workspace }}/build recipes -c conda-forge
           BUILD_DIR=${GITHUB_WORKSPACE}/build
           BUILD=$(find "$BUILD_DIR" -name '*.tar.bz2')
-          anaconda --token "$ANACONDA_TOKEN" upload --user openghg --label main "$BUILD"
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/doc/source/packaging.rst
+++ b/doc/source/packaging.rst
@@ -102,4 +102,4 @@ that is included in the package to tag versions.
 
 This will also trigger a full CI/CD to test and build the new version.
 Again, it should work as this tag was taken from your fully-tested
-"main" branch.
+"master" branch.

--- a/doc/source/packaging.rst
+++ b/doc/source/packaging.rst
@@ -87,7 +87,7 @@ the command would be;
 
 .. code-block:: bash
 
-   git tag -a 0.7.1 -m "0.7.1 release"
+   git tag -a 0.7.1 -m "OpenGHG release v0.7.1"
 
 Next, push your tag to GitHub;
 

--- a/doc/source/packaging.rst
+++ b/doc/source/packaging.rst
@@ -6,7 +6,7 @@ Pack and Doc is now fully tested and deployed using GitHub actions.
 The development process should be;
 
 * New features are developed on feature branches, called ``feature-{feature}``,
-  either in the `main Pack and Doc repository <https://github.com/openghg/openghg>`__
+  either in the `devel OpenGHG repository <https://github.com/openghg/openghg>`__
   for authorised developers, or in personal forks for
   new developers.
 * Bug fixes or issue fixes are developed on fix branches, called
@@ -16,14 +16,13 @@ The development process should be;
   request can be merged into ``devel``.
 
 The result of this is that "devel" should contain the fully-working and
-tested, and most up-to-date version of ``pack and doc``. However, this
+tested, and most up-to-date version of ``OpenGHG``. However, this
 version should not be used for production runs.
 
 Defining a release
 ------------------
 
-We will release ``pack and doc`` regularly. Releases aim to be backwards
-compatible and capable of being used for production runs, at least for
+Releases aim to be backwards compatible and capable of being used for production runs, at least for
 the functionality that is fully described in the tutorial.
 
 We use `semantic versioning <https://semver.org>`__ and take care

--- a/doc/source/packaging.rst
+++ b/doc/source/packaging.rst
@@ -2,15 +2,14 @@
 Packaging releases
 ==================
 
-Pack and Doc is now fully tested and deployed using GitHub actions.
+OpenGHG is now fully tested and deployed using GitHub actions.
 The development process should be;
 
 * New features are developed on feature branches, called ``feature-{feature}``,
   either in the `devel OpenGHG repository <https://github.com/openghg/openghg>`__
-  for authorised developers, or in personal forks for
-  new developers.
+  for authorised developers.
 * Bug fixes or issue fixes are developed on fix branches, called
-  ``fix-issue-{number}`` (again in either the main repository or forks).
+  ``fix-issue-{number}``.
 * Pull requests are issued from these branches to ``devel``. All merge conflicts
   must be fixed in the branch and all tests must pass before the pull
   request can be merged into ``devel``.
@@ -31,45 +30,19 @@ not to cause breaking changes in the public API.
 Creating a release
 ------------------
 
-To create a release first checkout the "main" branch.
+To create a release first checkout the "devel" branch.
 
 .. code-block:: bash
 
-   git checkout master
+   git checkout devel
    git pull
 
-Next, merge in all changes from the "devel" branch.
+Make sure to have a fully working devel branch.
 
-.. code-block:: bash
+Now create a PR to merge "devel" into "master".
+Make sure all of the "changelog" is updated.
 
-   git pull origin devel
-
-Next, update the :doc:`changelog` with details about this release. This
-should include the link at the top of the release that shows the commit
-differences between versions. This can be easily copied from a previous
-release and updated, e.g.
-
-::
-
-  `0.7.0 <https://github.com/openghg/openghg/compare/0.6.2...0.7.0>`__ - May 11th 2020
-
-
-could be changed to
-
-::
-
-  `0.7.1 <https://github.com/openghg/openghg/compare/0.7.0...0.7.1>`__ - May 18th 2020
-
-when moving from the 0.7.0 to 0.7.1 release.
-
-Now push this change back to GitHub, using;
-
-.. code-block:: bash
-
-   git push
-
-This will trigger a CI/CD run which will build and test everything on Linux for Python 3.9 - 3.12.
-Everything should work, as "devel" should have been in a release-ready state.
+Upon PR approval the changes from "devel" can be merged into "master".
 
 Tagging a new release
 ---------------------
@@ -79,6 +52,7 @@ version. Do this using the ``git tag`` command, e.g.
 
 .. code-block:: bash
 
+   git checkout master
    git tag -a {VERSION} -m "{VERSION} release"
 
 replacing ``{VERSION}`` with the version number. For this 0.12.0 release

--- a/doc/source/packaging.rst
+++ b/doc/source/packaging.rst
@@ -36,7 +36,7 @@ To create a release first checkout the "main" branch.
 
 .. code-block:: bash
 
-   git checkout main
+   git checkout master
    git pull
 
 Next, merge in all changes from the "devel" branch.
@@ -52,16 +52,16 @@ release and updated, e.g.
 
 ::
 
-  `0.11.2 <https://github.com/metawards/MetaWards/compare/0.11.1...0.11.2>`__ - May 11th 2020
+  `0.7.0 <https://github.com/openghg/openghg/compare/0.6.2...0.7.0>`__ - May 11th 2020
 
 
 could be changed to
 
 ::
 
-  `0.12.0 <https://github.com/metawards/MetaWards/compare/0.11.2...0.12.0>`__ - May 18th 2020
+  `0.7.1 <https://github.com/openghg/openghg/compare/0.7.0...0.7.1>`__ - May 18th 2020
 
-when moving from the 0.11.2 to 0.12.0 release.
+when moving from the 0.7.0 to 0.7.1 release.
 
 Now push this change back to GitHub, using;
 
@@ -71,51 +71,6 @@ Now push this change back to GitHub, using;
 
 This will trigger a CI/CD run which will build and test everything on Linux for Python 3.9 - 3.12.
 Everything should work, as "devel" should have been in a release-ready state.
-
-Testing the packages
---------------------
-
-`GitHub actions <https://github.com/metawards/MetaWards/actions>`__ will
-produce the source and binary wheels for ``metawards`` on all supported
-platforms. This will be in an artifact called ``dist`` which you should
-download and unpack.
-
-.. image:: images/github_artifacts.jpg
-   :alt: Image of the GitHub Actions interface showing the dist artifact
-
-You should unpack these into the ``dist`` directory, e.g.
-
-.. code-block:: bash
-
-   cd dist
-   unzip ~/Downloads/dist.zip
-
-This should result in six binary wheels and once source package, e.g.
-
-::
-
-    metawards-0.11.1+7.g52b3671-cp37-cp37m-macosx_10_14_x86_64.whl
-    metawards-0.11.1+7.g52b3671-cp37-cp37m-manylinux1_x86_64.whl
-    metawards-0.11.1+7.g52b3671-cp37-cp37m-win_amd64.whl
-    metawards-0.11.1+7.g52b3671-cp38-cp38-macosx_10_14_x86_64.whl
-    metawards-0.11.1+7.g52b3671-cp38-cp38-manylinux1_x86_64.whl
-    metawards-0.11.1+7.g52b3671-cp38-cp38-win_amd64.whl
-    metawards-0.11.1+7.g52b3671.tar.gz
-
-Try to install the package related to you machine, just to double-check
-that it is working, e.g.
-
-.. code-block:: bash
-
-   pip install ./metawards-0.11.1+7.g52b3671-cp37-cp37m-macosx_10_14_x86_64.whl
-   cd ..
-   pytest tests
-
-Once it is working, remove these temporary packages from your ``dist`` folder,
-
-.. code-block:: bash
-
-   rm dist/*
 
 Tagging a new release
 ---------------------
@@ -132,7 +87,7 @@ the command would be;
 
 .. code-block:: bash
 
-   git tag -a 0.12.0 -m "0.12.0 release"
+   git tag -a 0.7.1 -m "0.7.1 release"
 
 Next, push your tag to GitHub;
 
@@ -148,62 +103,3 @@ that is included in the package to tag versions.
 This will also trigger a full CI/CD to test and build the new version.
 Again, it should work as this tag was taken from your fully-tested
 "main" branch.
-
-Uploading packages to pypi
---------------------------
-
-While you are waiting for the CI/CD GitHub Actions to complete, make sure
-that your version of twine is fully up to date;
-
-.. code-block:: bash
-
-   pip install --upgrade twine
-
-Once GitHub actions is complete, you will see that another build artifact
-is ready for download. Download this and unpack it into your ``dist``
-directory as before. You should now have a ``dist`` directory that
-contains six binary wheels and one source package, named according to
-the release version. For example, for the 0.11.2 release we had;
-
-.. code-block:: bash
-
-   $ ls dist
-    metawards-0.11.2-cp37-cp37m-macosx_10_14_x86_64.whl
-    metawards-0.11.2-cp37-cp37m-manylinux1_x86_64.whl
-    metawards-0.11.2-cp37-cp37m-win_amd64.whl
-    metawards-0.11.2-cp38-cp38-macosx_10_14_x86_64.whl
-    metawards-0.11.2-cp38-cp38-manylinux1_x86_64.whl
-    metawards-0.11.2-cp38-cp38-win_amd64.whl
-    metawards-0.11.2.tar.gz
-
-Now you can upload to pypi using the command;
-
-.. code-block:: bash
-
-   python3 -m twine upload dist/*
-
-.. note::
-
-    You will need a username and password for pypi and to have
-    permission to upload code to this project. Currently only
-    the release manager has permission. If you would like
-    join the release management team then please get in touch.
-
-Testing the final release
--------------------------
-
-Finally(!) test the release on a range of different machines by logging
-in and typing;
-
-.. code-block:: bash
-
-   pip install metawards=={VERSION}
-
-replacing ``{VERSION}`` with the version number, e.g. for 0.11.2
-
-.. code-block:: bash
-
-   pip install metawards==0.11.2
-
-Play with the code, run the tests and run some examples. Everything should
-work as you have performed lots of prior testing to get to this stage.

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   git_url: https://github.com/openghg/openghg.git
-  git_rev: {{ GIT_DESCRIBE_TAG }}
+  git_rev: ${{ env.GIT_DESCRIBE_TAG }}
   git_depth: 1
 
 build:

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -6,7 +6,7 @@
 
 package:
   name: "openghg"
-  version: {{ GIT_TAG }}
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   git_url: https://github.com/openghg/openghg.git

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   git_url: https://github.com/openghg/openghg.git
-  git_rev: ${{ env.GIT_DESCRIBE_TAG }}
+  git_rev: {{ GIT_TAG }}
   git_depth: 1
 
 build:

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -17,6 +17,8 @@ build:
   noarch: python
   preserve_egg_dir: True
   script: "{{ PYTHON }} -m pip install . -vv"
+  script_env:
+    GIT_TAG
 
 requirements:
   host:

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -11,7 +11,6 @@ package:
 source:
   git_url: https://github.com/openghg/openghg.git
   git_rev: {{ GIT_TAG }}
-  git_depth: 1
 
 build:
   noarch: python

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -6,7 +6,7 @@
 
 package:
   name: "openghg"
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ GIT_TAG }}
 
 source:
   git_url: https://github.com/openghg/openghg.git


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
     The value for the git tag is now fetched from the environment and passed into the conda recipe for the conda build.
     This ensures that the conda build on the master branch works as expected when the master is tagged instead of devel.


* **Please check if the PR fulfills these requirements**

- [x] Closes #946  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
- [x] Documentation and tutorials updated/added
