### PR TITLE
Temporary check for old object stores when using `0.8.0`

### DIFF
--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -82,7 +82,7 @@ def get_writable_bucket(name: Optional[str] = None) -> str:
     if not writable_buckets:
         raise ObjectStoreError("No writable object stores found. Check configuration file.")
 
-    if len(writable_buckets) == 1:
+    if name is None and len(writable_buckets) == 1:
         return next(iter(writable_buckets.values()))
     elif name is not None:
         try:

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 import uuid
 import toml
 import shutil
-from openghg.types import ConfigFileError
+from openghg.types import ConfigFileError, ObjectStoreError
 
 logger = logging.getLogger("openghg.util")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -355,7 +355,7 @@ def _check_valid_store(store_path: Path) -> bool:
     TODO - remove this when users have all moved to the new object store format.
 
     Args:
-        store: Object store name
+        store_path: Object store path
     Returns:
         bool: True if valid, False if not
     """
@@ -364,7 +364,7 @@ def _check_valid_store(store_path: Path) -> bool:
     store_dirs = list(data_dir.glob("*"))
     # Let's take the first data directory and see if there's a zarr folder in it
     if not store_dirs:
-        return False
+        raise ObjectStoreError("No data found in the object store, please check the path and try again.")
 
     store_data_dir = store_dirs[0]
 

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -259,6 +259,30 @@ def read_local_config() -> Dict:
                 or run openghg --quickstart"
         )
 
+    # Check see is the store uses the new zarr storage format
+    # for OpenGHG >= 0.8.0
+    valid_stores = {}
+    for name, store_data in config["object_store"].items():
+        store_path = Path(store_data["path"])
+        # If it doesn't exist or its empty then we expect it to be created / populated
+        if not store_path.exists() or not any(store_path.iterdir()):
+            valid_stores[name] = store_data
+        # Otherwise we check an existing store to see if it's the correct format
+        else:
+            if _check_valid_store(store_path):
+                valid_stores[name] = store_data
+            else:
+                logger.warning(
+                    f"Object store {name} does not use the new Zarr storage format and will be ignored."
+                )
+
+    if not valid_stores:
+        raise ConfigFileError(
+            "We've only detected old (non-Zarr) object stores. Please update your configuration to add a new path."
+        )
+
+    config["object_store"] = valid_stores
+
     return config
 
 
@@ -322,3 +346,26 @@ def _migrate_config() -> None:
         shutil.rmtree(old_config_path.parent)  # remove "openghg" dir from ~/.config
     else:
         raise FileNotFoundError("Configuration file not found.")
+
+
+def _check_valid_store(store_path: Path) -> bool:
+    """Checks if the store is a valid object store using the new Zarr storage
+    format. If it is return True, otherwise False.
+
+    TODO - remove this when users have all moved to the new object store format.
+
+    Args:
+        store: Object store name
+    Returns:
+        bool: True if valid, False if not
+    """
+    data_dir = Path(store_path).joinpath("data")
+    # Now check if there's a zarr folder in the data directory
+    store_dirs = list(data_dir.glob("*"))
+    # Let's take the first data directory and see if there's a zarr folder in it
+    if not store_dirs:
+        return False
+
+    store_data_dir = store_dirs[0]
+
+    return store_data_dir.joinpath("zarr").exists()

--- a/tests/util/test_user.py
+++ b/tests/util/test_user.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-
 import pytest
 import toml
 from openghg.types import ConfigFileError
@@ -7,21 +6,75 @@ from openghg.util import check_config, create_config, read_local_config
 
 
 @pytest.fixture
-def mock_conf_path(tmpdir, monkeypatch, mocker):
-    monkeypatch.setenv("HOME", str(tmpdir))
-    mock_path = Path(tmpdir).joinpath("mock_config.conf")
-    mocker.patch("openghg.util._user.get_user_config_path", return_value=mock_path)
+def tmp_config_path(tmpdir):
+    return Path(tmpdir).joinpath("config_folder").joinpath("mock_config.conf")
 
 
 @pytest.fixture
-def mock_contents():
+def tmp_home_path(tmpdir):
+    return Path(tmpdir).joinpath("tmp_home_path")
+
+
+@pytest.fixture
+def mock_get_user_config_path(tmp_config_path, mocker):
+    tmp_config_path.parent.mkdir(parents=True)
+    mocker.patch("openghg.util._user.get_user_config_path", return_value=tmp_config_path)
+
+
+@pytest.fixture
+def write_mock_config(tmpdir, tmp_config_path):
     mock_uuid = "179dcd5f-d5bb-439d-a3c2-9f690ac6d3b8"
-    mock_path = "/tmp/mock_store"
-    return {"object_store": {"user": {"path": mock_path, "permissions": "rw"}, "user_id": mock_uuid}}
+    mock_path = Path(tmpdir).joinpath("mock_store")
+    mock_shared_path = Path(tmpdir).joinpath("mock_shared_store")
+    mock_conf = {
+        "object_store": {
+            "user": {"path": mock_path, "permissions": "rw"},
+            "shared": {"path": mock_shared_path, "permission": "rw"},
+        },
+        "user_id": mock_uuid,
+    }
+
+    tmp_config_path.write_text(toml.dumps(mock_conf))
 
 
-def check_read_local_config():
-    # Make sure we can't read an empty config
+def test_read_config_check_old_stores(
+    mock_get_user_config_path, write_mock_config, caplog
+):
+    """This tests the read_local_config function when the user has an old store in their config file.
+    This test and the _check_valid_store function may be removed once the move to the new store setup is complete.
+    """
+    config = read_local_config()
+
+    user_store_path = Path(config["object_store"]["user"]["path"])
+
+    # Let's mock some data having been written to the object store
+    zarr_store_folderpath = user_store_path.joinpath("data/test-uuid-123/zarr")
+    zarr_store_folderpath.mkdir(parents=True)
+
+    config = read_local_config()
+
+    assert "Zarr storage format and will be ignored" not in caplog.text
+
+    zarr_store_folderpath.rmdir()
+
+    config = read_local_config()
+
+    assert len(config["object_store"]) == 1
+    assert "Zarr storage format and will be ignored" in caplog.text
+
+    # Let's now make a zarr folder and make sure this object store is still valid
+    shared_store_path = Path(config["object_store"]["shared"]["path"])
+    zarr_store_folderpath = shared_store_path.joinpath("data/test-uuid-123/zarr")
+    zarr_store_folderpath.mkdir(parents=True)
+
+    config = read_local_config()
+    assert len(config["object_store"]) == 1
+
+    # Now we remove the zarr store and check the config again
+    # As there's now a folder structure there a ConfigFileError should be raised
+    # as the store is no longer valid and OpenGHG can't find a valid store
+    zarr_store_folderpath.rmdir()
+
     with pytest.raises(ConfigFileError):
         read_local_config()
 


### PR DESCRIPTION
* **Summary of changes** 

This adds some functionality to the `read_local_config` function to check for old non-Zarr object stores and remove them from the config dictionary that OpenGHG will use internally when doing lookups etc. This does **not** remove them from the config file on disk. 

It could be some useful temporary functionality to allow users to have multiple virtual environments and versions of OpenGHG in use whilst populating their new store / new shared stores are populated.

This also means they can have new and old stores in their config file whilst the changeover happens. 
