### PR TITLE
Add code to convert old store to zarr store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.8.0...HEAD)
 
+### Added
+
+- Ability to convert from an old style NetCDF object store to the new Zarr based store format - [PR #967](https://github.com/openghg/openghg/pull/967)
+
 ## [0.8.0] - 2024-03-19
 
 This version brings a breaking change with the move to use the [Zarr](https://zarr.dev/) file format for data storage. This means that object stores created with previous versions of OpenGHG will need to be repopulated to use this version. You should notice improvements in time taken for standardisation, memory consumption and disk usage. With the use of Zarr comes the ability for the user to control the way which data is processed and stored. Please see [the documentation](https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking) for more on this.

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -80,3 +80,8 @@ delete or modify already existing data.
    :maxdepth: 1
 
    local/Managing_object_store/Changing_object_store
+
+.. toctree::
+   :maxdepth: 1
+
+   local/Managing_object_store/Converting_a_store

--- a/doc/source/tutorials/local/Managing_object_store/Converting_a_store.rst
+++ b/doc/source/tutorials/local/Managing_object_store/Converting_a_store.rst
@@ -16,8 +16,8 @@ Let's first add a new object store to our ``openghg.conf`` using ``openghg --qui
     OpenGHG configuration
     ---------------------
 
-    [03/26/24 14:25:17] INFO     INFO:openghg.util:User config exists at /home/gareth/.openghg/openghg.conf, checking...             _user.py:91
-                        INFO     INFO:openghg.util:Current user object store path: /home/gareth/openghg_store                       _user.py:102
+    INFO:openghg.util:User config exists at /home/gareth/.openghg/openghg.conf, checking...             _user.py:91
+    INFO:openghg.util:Current user object store path: /home/gareth/openghg_store                       _user.py:102
     Would you like to update the path? (y/n): n
     Would you like to add another object store? (y/n): y
     Enter the name of the store: openghg_store_zarr
@@ -28,7 +28,7 @@ Let's first add a new object store to our ``openghg.conf`` using ``openghg --qui
 
     Enter object store permissions: rw
     Would you like to add another object store? (y/n): n
-    [03/26/24 14:25:40] INFO     INFO:openghg.util:Configuration written to /home/gareth/.openghg/openghg.conf
+    INFO:openghg.util:Configuration written to /home/gareth/.openghg/openghg.conf
 
 
 Now we have a new object store called ``openghg_store_zarr`` in our configuration file and the path of that object
@@ -71,6 +71,6 @@ To do this we can pass a chunks dictionary and the name of the data type that wa
     old_store = "/home/gareth/openghg_store"
     new_store = "openghg_store_zarr"
 
-    convert_store(path_in=old_store, store_out=new_store, to_convert=["footprnts"], chunks={"time": 24})
+    convert_store(path_in=old_store, store_out=new_store, to_convert=["footprints"], chunks={"time": 24})
 
 You may need to experiment with the chunk sizes to find the optimal size for the data being converted.

--- a/doc/source/tutorials/local/Managing_object_store/Converting_a_store.rst
+++ b/doc/source/tutorials/local/Managing_object_store/Converting_a_store.rst
@@ -1,0 +1,76 @@
+Converting an object store
+==========================
+
+In this tutorial we'll convert an object store from the old-style NetCDF format
+to the new Zarr based object store format.
+
+In this example we have an old-style object store at ``/home/gareth/openghg_store`` and we want to convert it to the new Zarr format.
+To perform the conversion we need the path of the old old-style store and the name of the new store to write to.
+
+Let's first add a new object store to our ``openghg.conf`` using ``openghg --quickstart``.
+
+.. code-block:: bash
+
+    $ openghg --quickstart
+
+    OpenGHG configuration
+    ---------------------
+
+    [03/26/24 14:25:17] INFO     INFO:openghg.util:User config exists at /home/gareth/.openghg/openghg.conf, checking...             _user.py:91
+                        INFO     INFO:openghg.util:Current user object store path: /home/gareth/openghg_store                       _user.py:102
+    Would you like to update the path? (y/n): n
+    Would you like to add another object store? (y/n): y
+    Enter the name of the store: openghg_store_zarr
+    Enter the object store path: /home/gareth/openghg_store_zarr
+
+    You will now be asked for read/write permissions for the store.
+    For read only enter r, for read and write enter rw.
+
+    Enter object store permissions: rw
+    Would you like to add another object store? (y/n): n
+    [03/26/24 14:25:40] INFO     INFO:openghg.util:Configuration written to /home/gareth/.openghg/openghg.conf
+
+
+Now we have a new object store called ``openghg_store_zarr`` in our configuration file and the path of that object
+store is ``/home/gareth/openghg_store_zarr``. We're now ready perform the conversion.
+
+.. code-block:: python
+
+    from openghg.store.storage import convert_store
+
+    old_store = "/home/gareth/openghg_store"
+    new_store = "openghg_store_zarr"
+
+    convert_store(path_in=old_store, store_out=new_store)
+
+The ``convert_store`` function iterates over each of the data storage classes (``Footprints``, ``ObsSurface`` etc) and adds the data to the new object store.
+It does this by reading the metadata from the the metadata store and passing the data stored as NetCDF files to the
+appropriate ``standardise_*`` functions.
+
+The conversion process can take some time depending on the size of the object store. The conversion process is not
+atomic and if the process is interrupted the new object store may be broken. If the conversion
+process is interrupted it is recommended to delete the new object store and start the conversion process again.
+
+.. NOTE::
+
+    We recommend that object stores are populated using the original data, this will result in a more
+    consistent store. We recommend using the conversion process only when necessary.
+
+The conversion function will attempt to catch errors are they are raised during the conversion process.
+You may see lines such as ``Error standardising record <uuid>: Codec does not support buffers of > 2147483647 bytes``
+in the log output. These errors mean that the chunks being written to the object store are too large and need
+to be reduced through the use of chunking.
+
+To do this we can pass a chunks dictionary and the name of the data type that was being converted during conversion to the ``convert_store`` function.
+
+.. code-block:: python
+
+
+    from openghg.store.storage import convert_store
+
+    old_store = "/home/gareth/openghg_store"
+    new_store = "openghg_store_zarr"
+
+    convert_store(path_in=old_store, store_out=new_store, to_convert=["footprnts"], chunks={"time": 24})
+
+You may need to experiment with the chunk sizes to find the optimal size for the data being converted.

--- a/openghg/objectstore/metastore/_classic_metastore.py
+++ b/openghg/objectstore/metastore/_classic_metastore.py
@@ -31,20 +31,11 @@ from typing import Any, cast, Literal, Optional, Type
 from filelock import FileLock
 from openghg.objectstore import exists, get_object, set_object_from_json, get_object_lock_path
 from openghg.objectstore.metastore import TinyDBMetaStore
+from openghg.store import storage_class_info
 from openghg.types import MetastoreError
 from openghg.util import hash_string
 import tinydb
 from tinydb.middlewares import Middleware
-
-
-object_store_data_classes = {  # TODO: move this to central location after ObjectStore PR
-    "surface": {"_root": "ObsSurface", "_uuid": "da0b8b44-6f85-4d3c-b6a3-3dde34f6dea1"},
-    "column": {"_root": "ObsColumn", "_uuid": "5c567168-0287-11ed-9d0f-e77f5194a415"},
-    "flux": {"_root": "Flux", "_uuid": "c5c88168-0498-40ac-9ad3-949e91a30872"},
-    "footprints": {"_root": "Footprints", "_uuid": "62db5bdf-c88d-4e56-97f4-40336d37f18c"},
-    "boundary_conditions": {"_root": "BoundaryConditions", "_uuid": "4e787366-be91-4fc5-ad1b-4adcb213d478"},
-    "eulerian_model": {"_root": "EulerianModel", "_uuid": "63ff2365-3ba2-452a-a53d-110140805d06"},
-}
 
 
 def get_metakey(data_type: str) -> str:
@@ -57,6 +48,7 @@ def get_metakey(data_type: str) -> str:
         Metakey string for given data type, if found, or "default"
             if data type not found.
     """
+    object_store_data_classes = storage_class_info()
     try:
         result = object_store_data_classes[data_type]
     except KeyError:

--- a/openghg/objectstore/metastore/_classic_metastore.py
+++ b/openghg/objectstore/metastore/_classic_metastore.py
@@ -31,7 +31,6 @@ from typing import Any, cast, Literal, Optional, Type
 from filelock import FileLock
 from openghg.objectstore import exists, get_object, set_object_from_json, get_object_lock_path
 from openghg.objectstore.metastore import TinyDBMetaStore
-from openghg.store import storage_class_info
 from openghg.types import MetastoreError
 from openghg.util import hash_string
 import tinydb
@@ -48,7 +47,9 @@ def get_metakey(data_type: str) -> str:
         Metakey string for given data type, if found, or "default"
             if data type not found.
     """
-    object_store_data_classes = storage_class_info()
+    from openghg.store import data_class_info
+
+    object_store_data_classes = data_class_info()
     try:
         result = object_store_data_classes[data_type]
     except KeyError:

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional, Union, Any
 from pandas import Timedelta
 import warnings
 
-from openghg.store.base import get_data_class
 from openghg.cloud import create_file_package, create_post_dict
 from openghg.objectstore import get_writable_bucket
 from openghg.util import running_on_hub
@@ -26,6 +25,8 @@ def standardise(data_type: str, filepath: multiPathType, store: Optional[str] = 
     Returns:
         dict: Dictionary of result data.
     """
+    from openghg.store import get_data_class
+
     dclass = get_data_class(data_type)
     bucket = get_writable_bucket(name=store)
 
@@ -828,6 +829,8 @@ def standardise_from_binary_data(
     returns:
         Dictionary of result data.
     """
+    from openghg.store import get_data_class
+
     dclass = get_data_class(data_type)
     bucket = get_writable_bucket(name=store)
 

--- a/openghg/standardise/surface/_openghg.py
+++ b/openghg/standardise/surface/_openghg.py
@@ -89,7 +89,6 @@ def parse_openghg(
     # Run some checks on the
     data_attrs = {k.lower().replace(" ", "_"): v for k, v in data.attrs.items()}
 
-    print(metadata_initial)
     # Populate metadata with values from attributes if inputs have not been passed
     for key, value in metadata_initial.items():
         if value is None:

--- a/openghg/standardise/surface/_openghg.py
+++ b/openghg/standardise/surface/_openghg.py
@@ -89,6 +89,7 @@ def parse_openghg(
     # Run some checks on the
     data_attrs = {k.lower().replace(" ", "_"): v for k, v in data.attrs.items()}
 
+    print(metadata_initial)
     # Populate metadata with values from attributes if inputs have not been passed
     for key, value in metadata_initial.items():
         if value is None:
@@ -101,10 +102,16 @@ def parse_openghg(
             if key in attributes:
                 attributes_value = attributes[key]
                 if str(value).lower() != str(attributes_value).lower():
-                    # If inputs do not match attribute values, raise a ValueError
-                    raise ValueError(
-                        f"Input for '{key}': {value} does not match value in file attributes: {attributes_value}"
-                    )
+                    try:
+                        # As we may have things like 1200 != 1200.0
+                        # we'll check if the floats are equal
+                        if float(value) == float(attributes_value):
+                            continue
+                    except ValueError:
+                        # If inputs do not match attribute values, raise a ValueError
+                        raise ValueError(
+                            f"Input for '{key}': {value} does not match value in file attributes: {attributes_value}"
+                        )
 
     # Read the inlet
     if inlet is None:

--- a/openghg/store/__init__.py
+++ b/openghg/store/__init__.py
@@ -9,3 +9,4 @@ from ._obscolumn import ObsColumn
 from ._obssurface import ObsSurface
 from ._populate import add_noaa_obspack
 from ._metstore import METStore
+from ._meta import storage_class_info

--- a/openghg/store/__init__.py
+++ b/openghg/store/__init__.py
@@ -9,4 +9,4 @@ from ._obscolumn import ObsColumn
 from ._obssurface import ObsSurface
 from ._populate import add_noaa_obspack
 from ._metstore import METStore
-from ._meta import storage_class_info
+from ._meta import data_class_info, get_data_class

--- a/openghg/store/_meta.py
+++ b/openghg/store/_meta.py
@@ -1,8 +1,9 @@
 # This holds store metadata for now
 from typing import Dict
+from openghg.store.base import BaseStore
 
 
-def storage_class_info() -> Dict:
+def data_class_info() -> Dict:
     """Return storage class information for each data type.
 
     Returns:
@@ -21,3 +22,22 @@ def storage_class_info() -> Dict:
         },
         "eulerian_model": {"_root": "EulerianModel", "_uuid": "63ff2365-3ba2-452a-a53d-110140805d06"},
     }
+
+
+def get_data_class(data_type: str) -> type[BaseStore]:
+    """Return data class corresponding to given data type.
+
+    Args:
+        data_type: one of "surface", "column", "flux", "footprints",
+    "boundary_conditions", or "eulerian_model"
+
+    Returns:
+        Data class, one of `ObsSurface`, `ObsColumn`, `Flux`, `EulerianModel`,
+    `Footprints`, `BoundaryConditions`.
+    """
+    try:
+        data_class = BaseStore._registry[data_type]
+    except KeyError:
+        raise ValueError(f"No data class for data type {data_type}.")
+    else:
+        return data_class

--- a/openghg/store/_meta.py
+++ b/openghg/store/_meta.py
@@ -1,0 +1,23 @@
+# This holds store metadata for now
+from typing import Dict
+
+
+def storage_class_info() -> Dict:
+    """Return storage class information for each data type.
+
+    Returns:
+        dict: Dictionary of storage class names and UUIDs
+    """
+    # TODO - move this to read from object store config file?
+
+    return {
+        "surface": {"_root": "ObsSurface", "_uuid": "da0b8b44-6f85-4d3c-b6a3-3dde34f6dea1"},
+        "column": {"_root": "ObsColumn", "_uuid": "5c567168-0287-11ed-9d0f-e77f5194a415"},
+        "flux": {"_root": "Flux", "_uuid": "c5c88168-0498-40ac-9ad3-949e91a30872"},
+        "footprints": {"_root": "Footprints", "_uuid": "62db5bdf-c88d-4e56-97f4-40336d37f18c"},
+        "boundary_conditions": {
+            "_root": "BoundaryConditions",
+            "_uuid": "4e787366-be91-4fc5-ad1b-4adcb213d478",
+        },
+        "eulerian_model": {"_root": "EulerianModel", "_uuid": "63ff2365-3ba2-452a-a53d-110140805d06"},
+    }

--- a/openghg/store/base/__init__.py
+++ b/openghg/store/base/__init__.py
@@ -1,2 +1,2 @@
-from ._base import BaseStore, get_data_class
+from ._base import BaseStore
 from ._datasource import Datasource

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -617,22 +617,3 @@ class BaseStore:
         #     if chunks[k] < dim_sizes[k]:
         #         rechunk[k] = chunks.pop(k)
         return chunks
-
-
-def get_data_class(data_type: str) -> type[BaseStore]:
-    """Return data class corresponding to given data type.
-
-    Args:
-        data_type: one of "surface", "column", "flux", "footprints",
-    "boundary_conditions", or "eulerian_model"
-
-    Returns:
-        Data class, one of `ObsSurface`, `ObsColumn`, `Flux`, `EulerianModel`,
-    `Footprints`, `BoundaryConditions`.
-    """
-    try:
-        data_class = BaseStore._registry[data_type]
-    except KeyError:
-        raise ValueError(f"No data class for data type {data_type}.")
-    else:
-        return data_class

--- a/openghg/store/storage/__init__.py
+++ b/openghg/store/storage/__init__.py
@@ -3,3 +3,4 @@ from ._store import Store
 from ._localzarrstore import LocalZarrStore
 from ._encoding import get_zarr_encoding
 from ._compression import compare_compression
+from ._convert import convert_store

--- a/openghg/store/storage/_convert.py
+++ b/openghg/store/storage/_convert.py
@@ -1,0 +1,99 @@
+# This is a simple way to convert an old style NetCDF based object store
+# to a new Zarr based object store
+
+# First we want to get the path to the old style object store
+import logging
+import inspect
+from pathlib import Path
+from typing import Dict, List, Union
+import tinydb
+
+import openghg.standardise
+
+
+from openghg.objectstore.metastore import open_metastore
+from openghg.objectstore.metastore._classic_metastore import BucketKeyStorage
+from openghg.objectstore.metastore._metastore import TinyDBMetaStore
+from openghg.store import storage_class_info
+from openghg.types import ObjectStoreError
+
+logger = logging.getLogger("openghg.store")
+logger.setLevel(logging.DEBUG)
+
+
+def convert_store(path_in: Union[str, Path], path_out: Union[str, Path]) -> None:
+    """Convert object store
+
+    Args:
+        path: Path to object store
+    """
+    # First we need to read the data in the object store
+    # Iterating over each data type and then each data file
+    # to convert to Zarr
+    old_store_path = Path(path_in)
+
+    # Let's now check if it's a valid object store
+    if not old_store_path.exists():
+        raise ObjectStoreError(f"Path {old_store_path} does not exist")
+
+    dirs = [x.name for x in old_store_path.iterdir()]
+    if "datasource" not in dirs:
+        raise ObjectStoreError("Cannot find datasource folder, please check this is a valid object store")
+
+    # Let's first get each of the storage classes
+    storage_classes = storage_class_info()
+    # These are the functions we can use to standardise the data
+    standardise_args = _get_standardise_args()
+
+    for data_type in storage_classes:
+        # Let's load the metadata store
+        # As we renamed Emissions -> Flux in 0.8.0 we need to check for this
+        if data_type.lower() == "flux":
+            key = "Emissions/uuid/c5c88168-0498-40ac-9ad3-949e91a30872/metastore"
+            with tinydb.TinyDB(old_store_path, key, "r", storage=BucketKeyStorage) as db:
+                records = db.all()
+        else:
+            with open_metastore(bucket=str(old_store_path), data_type=data_type, mode="r") as db:
+                records = db._db.all()
+
+        if not records:
+            logger.info(f"No metadata records found for {data_type}, skipping...")
+            continue
+
+        # Now let's iterate over the records
+        for record in records:
+            datasource = Datasource()
+
+def convert():
+    # could we just iterate over the data for each Datasource, read the data in and then save it to a Datasource
+    # in the new object store?
+    # That would get around needing to call the standardise functions
+
+
+def _get_standardise_args() -> Dict[str, List[str]]:
+    """Get dictionary mapping OpenGHG storage classes to a list of the arguments for the standardise
+    function of that data class.
+
+    Returns:
+        dict:
+    """
+    standardise_members = inspect.getmembers(openghg.standardise)
+
+    # Get function objects for standardise_* functions
+    func_dict = {mem[0]: mem[1] for mem in standardise_members if mem[0].startswith("standardise_")}
+
+    # Make dict with args
+    arg_dict = {
+        k.split("_")[1]: list(inspect.signature(v).parameters.keys())
+        for k, v in func_dict.items()
+        if "binary" not in k
+    }
+
+    # rename some types
+    arg_dict["boundary_conditions"] = arg_dict["bc"]
+    del arg_dict["bc"]
+
+    arg_dict["footprints"] = arg_dict["footprint"]
+    del arg_dict["footprint"]
+
+    return arg_dict

--- a/openghg/store/storage/_convert.py
+++ b/openghg/store/storage/_convert.py
@@ -117,7 +117,7 @@ def convert_store(
                 except (ValueError, AttributeError):
                     # .iterdir gives empty sequence or some version name doesn't match r"v\d+" (e.g. "v10", etc.)
                     logger.warning(
-                        f"Unable to find a data sversion for {data_type} data with UUID {uuid}, skipping..."
+                        f"Unable to find a data version for {data_type} data with UUID {uuid}, skipping..."
                     )
                     continue
 

--- a/openghg/store/storage/_convert.py
+++ b/openghg/store/storage/_convert.py
@@ -5,27 +5,30 @@
 import logging
 import inspect
 from pathlib import Path
+import re
 from typing import Dict, List, Union
 import tinydb
+import xarray as xr
 
-import openghg.standardise
-
-
+# import openghg.standardise
+from openghg.store.base import Datasource
+from openghg.standardise import standardise
 from openghg.objectstore.metastore import open_metastore
 from openghg.objectstore.metastore._classic_metastore import BucketKeyStorage
 from openghg.objectstore.metastore._metastore import TinyDBMetaStore
 from openghg.store import storage_class_info
-from openghg.types import ObjectStoreError
+from openghg.types import ObjectStoreError, DataOverlapError
 
 logger = logging.getLogger("openghg.store")
 logger.setLevel(logging.DEBUG)
 
 
-def convert_store(path_in: Union[str, Path], path_out: Union[str, Path]) -> None:
-    """Convert object store
+def convert_store(path_in: Union[str, Path], store_out: str) -> None:
+    """Convert object store to new style Zarr based object store.
 
     Args:
-        path: Path to object store
+        path_in: Path to current old style object store
+        store_out: Name of new object store. The store must exist in your OpenGHG config file.
     """
     # First we need to read the data in the object store
     # Iterating over each data type and then each data file
@@ -46,6 +49,7 @@ def convert_store(path_in: Union[str, Path], path_out: Union[str, Path]) -> None
     standardise_args = _get_standardise_args()
 
     for data_type in storage_classes:
+        logger.info(f"Converting {data_type} data...")
         # Let's load the metadata store
         # As we renamed Emissions -> Flux in 0.8.0 we need to check for this
         if data_type.lower() == "flux":
@@ -59,10 +63,89 @@ def convert_store(path_in: Union[str, Path], path_out: Union[str, Path]) -> None
         if not records:
             logger.info(f"No metadata records found for {data_type}, skipping...")
             continue
-
+        
+        valid_args = standardise_args[data_type]
         # Now let's iterate over the records
         for record in records:
-            datasource = Datasource()
+            # Open the dataset for this record
+            # First get the paths
+            uuid = record["uuid"]            
+            data_folderpath = Path(old_store_path).joinpath("data", uuid)
+        
+            if "latest_version" in record:
+                version = record["latest_version"]
+            else:
+                try:
+                    version = max([v.name for v in data_folderpath.iterdir()], key=lambda x: int(x[1:]))
+                except (ValueError, AttributeError):
+                    # .iterdir gives empty sequence or some version name doesn't match r"v\d+" (e.g. "v10", etc.)
+                    raise ValueError("No data versions found for this search result.")   
+
+            # Now get the files to restandardise
+            version_folderpath = data_folderpath.joinpath(version)
+            data_filepaths = sorted(list(version_folderpath.glob("*._data")))
+
+            # Now we handle the metadata for the args we want to pass into the standardise functions
+            standardise_kwargs = {k: v for k, v in record.items() if k in valid_args}
+            # Parse some values to the format required for standardising
+            tf_none = {"true": True, "false": False, "none": None}
+            for k, v in standardise_kwargs.items():
+                if v.lower() in tf_none:
+                    standardise_kwargs[k] = tf_none[v.lower()]
+                if k == "sampling_period":
+                    if m := re.search(r"(\d+\.?\d*)", v):
+                        standardise_kwargs[k] = str(int(float(m.group(1))) // 60) + "m"
+                    else:
+                        standardise_kwargs[k] = None
+
+            chunks = {}
+            if data_type == "surface":
+                try:
+                    standardise(
+                        data_type=data_type,
+                        store=store_out,
+                        filepath=data_filepaths,
+                        source_format="openghg",
+                        chunks=chunks,
+                        **standardise_kwargs,
+                    )
+                except DataOverlapError:
+                    logger.warning(f"Data overlap error for record {uuid}")
+
+            elif data_type == "footprints":
+                if standardise_kwargs["high_time_resolution"]:
+                    chunks = {"time": 24}
+                else:
+                    chunks = {"time": 480}
+
+                try:
+                    standardise(
+                        data_type=data_type,
+                        store=store_out,
+                        filepath=data_filepaths,
+                        chunks=chunks,
+                        **standardise_kwargs,
+                    )
+                except DataOverlapError:
+                    logger.warning(f"Data overlap error for record {uuid}")
+            else:
+                for data_file in data_filepaths:
+                    try:
+                        standardise(
+                            data_type=data_type,
+                            store=store_out,
+                            filepath=data_file,
+                            chunks=chunks,
+                            **standardise_kwargs,
+                        )
+                    except DataOverlapError:
+                        logger.warning(f"Data overlap error for record {uuid}")
+
+        logger.info(f"Finished converting {data_type} data.")
+
+
+
+        # TODO - remember to copy the file hashes and data storage class members over!
 
 def convert():
     # could we just iterate over the data for each Datasource, read the data in and then save it to a Datasource

--- a/openghg/transform/_transform.py
+++ b/openghg/transform/_transform.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Optional, Union, Any
 
 from openghg.objectstore import get_writable_bucket
-from openghg.store.base import get_data_class
+from openghg.store import get_data_class
 
 
 def transform_flux_data(

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -69,7 +69,14 @@ from ._time import (
     trim_daterange,
     valid_daterange,
 )
-from ._user import create_config, get_user_id, get_user_config_path, read_local_config, check_config
+from ._user import (
+    create_config,
+    get_user_id,
+    get_user_config_path,
+    read_local_config,
+    check_config,
+    check_valid_store,
+)
 from ._util import (
     find_matching_site,
     multiple_inlets,

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -75,7 +75,6 @@ from ._user import (
     get_user_config_path,
     read_local_config,
     check_config,
-    check_valid_store,
 )
 from ._util import (
     find_matching_site,

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -269,7 +269,7 @@ def read_local_config() -> Dict:
             valid_stores[name] = store_data
         # Otherwise we check an existing store to see if it's the correct format
         else:
-            if _check_valid_store(store_path):
+            if check_valid_store(store_path):
                 valid_stores[name] = store_data
             else:
                 logger.warning(
@@ -348,7 +348,7 @@ def _migrate_config() -> None:
         raise FileNotFoundError("Configuration file not found.")
 
 
-def _check_valid_store(store_path: Path) -> bool:
+def check_valid_store(store_path: Path) -> bool:
     """Checks if the store is a valid object store using the new Zarr storage
     format. If it is return True, otherwise False.
 

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -269,7 +269,7 @@ def read_local_config() -> Dict:
             valid_stores[name] = store_data
         # Otherwise we check an existing store to see if it's the correct format
         else:
-            if check_valid_store(store_path):
+            if _check_valid_store(store_path):
                 valid_stores[name] = store_data
             else:
                 logger.warning(
@@ -348,7 +348,7 @@ def _migrate_config() -> None:
         raise FileNotFoundError("Configuration file not found.")
 
 
-def check_valid_store(store_path: Path) -> bool:
+def _check_valid_store(store_path: Path) -> bool:
     """Checks if the store is a valid object store using the new Zarr storage
     format. If it is return True, otherwise False.
 


### PR DESCRIPTION
* **Summary of changes** 

This adds in some functionality to convert an old style object store to the new Zarr format. This uses some of Brendan's code for the lookup of arguments etc but I've modified it so it just takes everything in an object store and converts it.
It may be a bit temperamental and I've added some log warnings to tell people it's better to just repopulate using the original data. I've also added a short tutorial to cover how to use the new function.


* **Please check if the PR fulfills these requirements**

- [x] Closes #964
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

