### PR TITLE
PR to allow optional metadata dict as tags while standardising data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to convert from an old style NetCDF object store to the new Zarr based store format - [PR #967](https://github.com/openghg/openghg/pull/967)
 - Updated `parse_edgar` function to handle processing of v8.0 Edgar datasets. [PR #965](https://github.com/openghg/openghg/pull/965)
 - Argument `time_resolved` is added as phase 1 change for `high_time_resolution`, also metadata is updated and added deprecation warning. - [PR #968](https://github.com/openghg/openghg/pull/968)
+- Added ability to pass additional `tags` as `optional metadata` through `standardising_*` and `transform_flux_data functions`. [PR #981](https://github.com/openghg/openghg/pull/981)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to convert from an old style NetCDF object store to the new Zarr based store format - [PR #967](https://github.com/openghg/openghg/pull/967)
 - Updated `parse_edgar` function to handle processing of v8.0 Edgar datasets. [PR #965](https://github.com/openghg/openghg/pull/965)
 - Argument `time_resolved` is added as phase 1 change for `high_time_resolution`, also metadata is updated and added deprecation warning. - [PR #968](https://github.com/openghg/openghg/pull/968)
-- Added ability to pass additional `tags` as `optional metadata` through `standardising_*` and `transform_flux_data functions`. [PR #981](https://github.com/openghg/openghg/pull/981)
+- Added ability to pass additional tags as optional metadata through `standardising_*` and `transform_flux_data functions`. [PR #981](https://github.com/openghg/openghg/pull/981)
 
 ### Fixed
 

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -76,7 +76,7 @@ def standardise_surface(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = None,
+    optional_metadata: Optional[Dict] = None,
 ) -> Dict:
     """Standardise surface measurements and store the data in the object store.
 
@@ -266,7 +266,7 @@ def standardise_column(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = None,
+    optional_metadata: Optional[Dict] = None,
 ) -> Dict:
     """Read column observation file
 
@@ -386,7 +386,7 @@ def standardise_bc(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = None,
+    optional_metadata: Optional[Dict] = None,
 ) -> Dict:
     """Standardise boundary condition data and store it in the object store.
 
@@ -501,7 +501,7 @@ def standardise_footprint(
     compression: bool = True,
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
-    optional_metadata: Optional[dict] = None,
+    optional_metadata: Optional[Dict] = None,
 ) -> Dict:
     """Reads footprint data files and returns the UUIDs of the Datasources
     the processed data has been assigned to
@@ -650,7 +650,7 @@ def standardise_flux(
     compression: bool = True,
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
-    optional_metadata: Optional[dict] = None,
+    optional_metadata: Optional[Dict] = None,
 ) -> Dict:
     """Process flux / emissions data
 
@@ -774,7 +774,7 @@ def standardise_eulerian(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = None,
+    optional_metadata: Optional[Dict] = None,
 ) -> Dict:
     """Read Eulerian model output
 

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -76,6 +76,7 @@ def standardise_surface(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
+    optional_metadata: Optional[dict] = {}
 ) -> Dict:
     """Standardise surface measurements and store the data in the object store.
 
@@ -241,6 +242,7 @@ def standardise_surface(
             compressor=compressor,
             filters=filters,
             chunks=chunks,
+            optional_metadata=optional_metadata
         )
 
 
@@ -264,6 +266,7 @@ def standardise_column(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
+    optional_metadata: Optional[dict] = {}
 ) -> Dict:
     """Read column observation file
 
@@ -363,6 +366,7 @@ def standardise_column(
             compressor=compressor,
             filters=filters,
             chunks=chunks,
+            optional_metadata=optional_metadata
         )
 
 
@@ -382,6 +386,7 @@ def standardise_bc(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
+    optional_metadata: Optional[dict] = {}
 ) -> Dict:
     """Standardise boundary condition data and store it in the object store.
 
@@ -463,6 +468,7 @@ def standardise_bc(
             compressor=compressor,
             filters=filters,
             chunks=chunks,
+            optional_metadata=optional_metadata
         )
 
 
@@ -495,6 +501,7 @@ def standardise_footprint(
     compression: bool = True,
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
+    optional_metadata: Optional[dict] = {}
 ) -> Dict:
     """Reads footprint data files and returns the UUIDs of the Datasources
     the processed data has been assigned to
@@ -617,6 +624,7 @@ def standardise_footprint(
             filters=filters,
             sort=sort,
             drop_duplicates=drop_duplicates,
+            optional_metadata=optional_metadata
         )
 
 
@@ -642,6 +650,7 @@ def standardise_flux(
     compression: bool = True,
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
+    optional_metadata: Optional[dict] = {}
 ) -> Dict:
     """Process flux / emissions data
 
@@ -745,6 +754,7 @@ def standardise_flux(
             compression=compression,
             compressor=compressor,
             filters=filters,
+            optional_metadata=optional_metadata
         )
 
 
@@ -764,6 +774,7 @@ def standardise_eulerian(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
+    optional_metadata: Optional[dict] = {}
 ) -> Dict:
     """Read Eulerian model output
 
@@ -821,6 +832,7 @@ def standardise_eulerian(
             compressor=compressor,
             filters=filters,
             chunks=chunks,
+            optional_metadata=optional_metadata
         )
 
 

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -126,6 +126,7 @@ def standardise_surface(
             for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
             See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
             To disable chunking pass an empty dictionary.
+        optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
     Returns:
         dict: Dictionary of result data
     """
@@ -311,6 +312,7 @@ def standardise_column(
             for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
             See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking
             To disable chunking pass an empty dictionary.
+        optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
     Returns:
         dict: Dictionary containing confirmation of standardisation process.
     """
@@ -422,6 +424,7 @@ def standardise_bc(
             for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
             See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking
             To disable chunking pass an empty dictionary.
+        optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
     returns:
         dict: Dictionary containing confirmation of standardisation process.
     """
@@ -550,6 +553,7 @@ def standardise_footprint(
             See https://zarr.readthedocs.io/en/stable/api/codecs.html for more information on compressors.
         filters: Filters to apply to the data on storage, this defaults to no filtering. See
             https://zarr.readthedocs.io/en/stable/tutorial.html#filters for more information on picking filters.
+        optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
     Returns:
         dict / None: Dictionary containing confirmation of standardisation process. None
         if file already processed.
@@ -689,6 +693,7 @@ def standardise_flux(
             See https://zarr.readthedocs.io/en/stable/api/codecs.html for more information on compressors.
         filters: Filters to apply to the data on storage, this defaults to no filtering. See
             https://zarr.readthedocs.io/en/stable/tutorial.html#filters for more information on picking filters.
+        optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
     returns:
         dict: Dictionary of Datasource UUIDs data assigned to
     """
@@ -809,6 +814,7 @@ def standardise_eulerian(
             for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
             See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
             To disable chunking pass an empty dictionary.
+        optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
     Returns:
         dict: Dictionary of result data
     """

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -76,7 +76,7 @@ def standardise_surface(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = {}
+    optional_metadata: Optional[dict] = {},
 ) -> Dict:
     """Standardise surface measurements and store the data in the object store.
 
@@ -242,7 +242,7 @@ def standardise_surface(
             compressor=compressor,
             filters=filters,
             chunks=chunks,
-            optional_metadata=optional_metadata
+            optional_metadata=optional_metadata,
         )
 
 
@@ -266,7 +266,7 @@ def standardise_column(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = {}
+    optional_metadata: Optional[dict] = {},
 ) -> Dict:
     """Read column observation file
 
@@ -366,7 +366,7 @@ def standardise_column(
             compressor=compressor,
             filters=filters,
             chunks=chunks,
-            optional_metadata=optional_metadata
+            optional_metadata=optional_metadata,
         )
 
 
@@ -386,7 +386,7 @@ def standardise_bc(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = {}
+    optional_metadata: Optional[dict] = {},
 ) -> Dict:
     """Standardise boundary condition data and store it in the object store.
 
@@ -468,7 +468,7 @@ def standardise_bc(
             compressor=compressor,
             filters=filters,
             chunks=chunks,
-            optional_metadata=optional_metadata
+            optional_metadata=optional_metadata,
         )
 
 
@@ -501,7 +501,7 @@ def standardise_footprint(
     compression: bool = True,
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
-    optional_metadata: Optional[dict] = {}
+    optional_metadata: Optional[dict] = {},
 ) -> Dict:
     """Reads footprint data files and returns the UUIDs of the Datasources
     the processed data has been assigned to
@@ -624,7 +624,7 @@ def standardise_footprint(
             filters=filters,
             sort=sort,
             drop_duplicates=drop_duplicates,
-            optional_metadata=optional_metadata
+            optional_metadata=optional_metadata,
         )
 
 
@@ -650,7 +650,7 @@ def standardise_flux(
     compression: bool = True,
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
-    optional_metadata: Optional[dict] = {}
+    optional_metadata: Optional[dict] = {},
 ) -> Dict:
     """Process flux / emissions data
 
@@ -754,7 +754,7 @@ def standardise_flux(
             compression=compression,
             compressor=compressor,
             filters=filters,
-            optional_metadata=optional_metadata
+            optional_metadata=optional_metadata,
         )
 
 
@@ -774,7 +774,7 @@ def standardise_eulerian(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = {}
+    optional_metadata: Optional[dict] = {},
 ) -> Dict:
     """Read Eulerian model output
 
@@ -832,7 +832,7 @@ def standardise_eulerian(
             compressor=compressor,
             filters=filters,
             chunks=chunks,
-            optional_metadata=optional_metadata
+            optional_metadata=optional_metadata,
         )
 
 

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -76,7 +76,7 @@ def standardise_surface(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = {},
+    optional_metadata: Optional[dict] = None,
 ) -> Dict:
     """Standardise surface measurements and store the data in the object store.
 
@@ -266,7 +266,7 @@ def standardise_column(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = {},
+    optional_metadata: Optional[dict] = None,
 ) -> Dict:
     """Read column observation file
 
@@ -386,7 +386,7 @@ def standardise_bc(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = {},
+    optional_metadata: Optional[dict] = None,
 ) -> Dict:
     """Standardise boundary condition data and store it in the object store.
 
@@ -501,7 +501,7 @@ def standardise_footprint(
     compression: bool = True,
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
-    optional_metadata: Optional[dict] = {},
+    optional_metadata: Optional[dict] = None,
 ) -> Dict:
     """Reads footprint data files and returns the UUIDs of the Datasources
     the processed data has been assigned to
@@ -650,7 +650,7 @@ def standardise_flux(
     compression: bool = True,
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
-    optional_metadata: Optional[dict] = {},
+    optional_metadata: Optional[dict] = None,
 ) -> Dict:
     """Process flux / emissions data
 
@@ -774,7 +774,7 @@ def standardise_eulerian(
     compressor: Optional[Any] = None,
     filters: Optional[Any] = None,
     chunks: Optional[Dict] = None,
-    optional_metadata: Optional[dict] = {},
+    optional_metadata: Optional[dict] = None,
 ) -> Dict:
     """Read Eulerian model output
 

--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -64,6 +64,7 @@ class BoundaryConditions(BaseStore):
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
         chunks: Optional[Dict] = None,
+        optional_metadata: Optional[Dict] = None,
     ) -> dict:
         """Read boundary conditions file
 
@@ -206,6 +207,17 @@ class BoundaryConditions(BaseStore):
             boundary_conditions_data[key]["metadata"] = metadata
 
             required_keys = ("species", "bc_input", "domain")
+
+            if optional_metadata:
+                common_keys = set(required_keys) & set(optional_metadata.keys())
+
+                if common_keys:
+                    raise ValueError(
+                        f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+                    )
+                else:
+                    for key, parsed_data in boundary_conditions_data.items():
+                        parsed_data["metadata"].update(optional_metadata)
 
             # This performs the lookup and assignment of data to new or
             # existing Datasources

--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -102,6 +102,7 @@ class BoundaryConditions(BaseStore):
                 for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
                 See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
                 To disable chunking pass in an empty dictionary.
+            optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
         Returns:
             dict: Dictionary of datasource UUIDs data assigned to
         """

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -74,6 +74,7 @@ class EulerianModel(BaseStore):
                 for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
                 See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
                 To disable chunking pass in an empty dictionary.
+            optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
         """
         # TODO: As written, this currently includes some light assumptions that we're dealing with GEOSChem SpeciesConc format.
         # May need to split out into multiple modules (like with ObsSurface) or into separate retrieve functions as needed.

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -42,6 +42,7 @@ class EulerianModel(BaseStore):
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
         chunks: Optional[Dict] = None,
+        optional_metadata: Optional[Dict] = None,
     ) -> Dict:
         """Read Eulerian model output
 
@@ -196,6 +197,17 @@ class EulerianModel(BaseStore):
             model_data[key]["metadata"] = metadata
 
             required = ("model", "species", "date")
+
+            if optional_metadata:
+                common_keys = set(required) & set(optional_metadata.keys())
+
+                if common_keys:
+                    raise ValueError(
+                        f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+                    )
+                else:
+                    for key, parsed_data in model_data.items():
+                        parsed_data["metadata"].update(optional_metadata)
 
             data_type = "eulerian_model"
             datasource_uuids = self.assign_data(

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -224,13 +224,13 @@ class Flux(BaseStore):
         if optional_metadata:
             common_keys = set(required) & set(optional_metadata.keys())
 
-        if common_keys:
-            raise ValueError(
-                f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
-            )
-        else:
-            for key, parsed_data in flux_data.items():
-                parsed_data["metadata"].update(optional_metadata)
+            if common_keys:
+                raise ValueError(
+                    f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+                )
+            else:
+                for key, parsed_data in flux_data.items():
+                    parsed_data["metadata"].update(optional_metadata)
 
         data_type = "flux"
         datasource_uuids = self.assign_data(
@@ -257,6 +257,7 @@ class Flux(BaseStore):
         overwrite: bool = False,
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
+        optional_metadata: Optional[Dict] = None,
         **kwargs: Dict,
     ) -> Dict:
         """
@@ -331,6 +332,17 @@ class Flux(BaseStore):
             Flux.validate_data(em_data)
 
         required_keys = ("species", "source", "domain")
+
+        if optional_metadata:
+            common_keys = set(required_keys) & set(optional_metadata.keys())
+
+            if common_keys:
+                raise ValueError(
+                    f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+                )
+            else:
+                for key, parsed_data in flux_data.items():
+                    parsed_data["metadata"].update(optional_metadata)
 
         data_type = "flux"
         datasource_uuids = self.assign_data(

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -118,6 +118,7 @@ class Flux(BaseStore):
                 See https://zarr.readthedocs.io/en/stable/api/codecs.html for more information on compressors.
             filters: Filters to apply to the data on storage, this defaults to no filtering. See
                 https://zarr.readthedocs.io/en/stable/tutorial.html#filters for more information on picking filters.
+            optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
         Returns:
             dict: Dictionary of datasource UUIDs data assigned to
         """

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -76,6 +76,7 @@ class Flux(BaseStore):
         force: bool = False,
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
+        optional_metadata: Optional[Dict] = None,
     ) -> dict:
         """Read flux / emissions file
 
@@ -219,6 +220,17 @@ class Flux(BaseStore):
                 min_required.append(key)
 
         required = tuple(min_required)
+
+        if optional_metadata:
+            common_keys = set(required) & set(optional_metadata.keys())
+
+        if common_keys:
+            raise ValueError(
+                f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+            )
+        else:
+            for key, parsed_data in flux_data.items():
+                parsed_data["metadata"].update(optional_metadata)
 
         data_type = "flux"
         datasource_uuids = self.assign_data(

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -451,13 +451,13 @@ class Footprints(BaseStore):
         if optional_metadata:
             common_keys = set(required) & set(optional_metadata.keys())
 
-        if common_keys:
-            raise ValueError(
-                f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
-            )
-        else:
-            for key, parsed_data in footprint_data.items():
-                parsed_data["metadata"].update(optional_metadata)
+            if common_keys:
+                raise ValueError(
+                    f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+                )
+            else:
+                for key, parsed_data in footprint_data.items():
+                    parsed_data["metadata"].update(optional_metadata)
 
         data_type = "footprints"
         # TODO - filter options

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -212,6 +212,7 @@ class Footprints(BaseStore):
         drop_duplicates: bool = False,
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
+        optional_metadata: Optional[Dict] = None,
     ) -> dict:
         """Reads footprints data files and returns the UUIDS of the Datasources
         the processed data has been assigned to
@@ -446,6 +447,17 @@ class Footprints(BaseStore):
             "species",
             "met_model",
         )
+
+        if optional_metadata:
+            common_keys = set(required) & set(optional_metadata.keys())
+
+        if common_keys:
+            raise ValueError(
+                f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+            )
+        else:
+            for key, parsed_data in footprint_data.items():
+                parsed_data["metadata"].update(optional_metadata)
 
         data_type = "footprints"
         # TODO - filter options

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -259,6 +259,7 @@ class Footprints(BaseStore):
                 See https://zarr.readthedocs.io/en/stable/api/codecs.html for more information on compressors.
             filters: Filters to apply to the data on storage, this defaults to no filtering. See
                 https://zarr.readthedocs.io/en/stable/tutorial.html#filters for more information on picking filters.
+            optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
         Returns:
             dict: UUIDs of Datasources data has been assigned to
         """

--- a/openghg/store/_obscolumn.py
+++ b/openghg/store/_obscolumn.py
@@ -168,13 +168,13 @@ class ObsColumn(BaseStore):
         if optional_metadata:
             common_keys = set(required) & set(optional_metadata.keys())
 
-        if common_keys:
-            raise ValueError(
-                f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
-            )
-        else:
-            for key, parsed_data in obs_data.items():
-                parsed_data["metadata"].update(optional_metadata)
+            if common_keys:
+                raise ValueError(
+                    f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+                )
+            else:
+                for key, parsed_data in obs_data.items():
+                    parsed_data["metadata"].update(optional_metadata)
 
         data_type = "column"
         datasource_uuids = self.assign_data(

--- a/openghg/store/_obscolumn.py
+++ b/openghg/store/_obscolumn.py
@@ -42,6 +42,7 @@ class ObsColumn(BaseStore):
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
         chunks: Optional[Dict] = None,
+        optional_metadata: Optional[Dict] = None,
     ) -> dict:
         """Read column observation file
 
@@ -163,6 +164,17 @@ class ObsColumn(BaseStore):
         # platform = list(obs_data.keys())[0]["metadata"]["platform"]
 
         required = ("satellite", "selection", "domain", "site", "species", "network")
+
+        if optional_metadata:
+            common_keys = set(required) & set(optional_metadata.keys())
+
+        if common_keys:
+            raise ValueError(
+                f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+            )
+        else:
+            for key, parsed_data in obs_data.items():
+                parsed_data["metadata"].update(optional_metadata)
 
         data_type = "column"
         datasource_uuids = self.assign_data(

--- a/openghg/store/_obscolumn.py
+++ b/openghg/store/_obscolumn.py
@@ -85,6 +85,7 @@ class ObsColumn(BaseStore):
                 for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
                 See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
                 To disable chunking pass in an empty dictionary.
+            optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
         Returns:
             dict: Dictionary of datasource UUIDs data assigned to
         """

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -124,6 +124,7 @@ class ObsSurface(BaseStore):
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
         chunks: Optional[Dict] = None,
+        optional_metadata: Optional[dict] = {},
     ) -> Dict:
         """Process files and store in the object store. This function
             utilises the process functions of the other classes in this submodule
@@ -375,6 +376,13 @@ class ObsSurface(BaseStore):
                 "icos_data_level",
                 "data_type",
             )
+
+            if optional_metadata:
+                for optional_key, optional_value in optional_metadata.items():
+                    if optional_key in required_keys:
+                        raise ValueError(f"Optional metadata key '{optional_key}' is already present in required keys.")
+                    else:
+                        data["metadata"][optional_key] = optional_value
 
             # Create Datasources, save them to the object store and get their UUIDs
             data_type = "surface"

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -124,7 +124,7 @@ class ObsSurface(BaseStore):
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
         chunks: Optional[Dict] = None,
-        optional_metadata: Optional[dict] = None,
+        optional_metadata: Optional[Dict] = None,
     ) -> Dict:
         """Process files and store in the object store. This function
             utilises the process functions of the other classes in this submodule

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -380,13 +380,13 @@ class ObsSurface(BaseStore):
             if optional_metadata:
                 common_keys = set(required_keys) & set(optional_metadata.keys())
 
-            if common_keys:
-                raise ValueError(
-                    f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
-                )
-            else:
-                for key, parsed_data in data.items():
-                    parsed_data["metadata"].update(optional_metadata)
+                if common_keys:
+                    raise ValueError(
+                        f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+                    )
+                else:
+                    for key, parsed_data in data.items():
+                        parsed_data["metadata"].update(optional_metadata)
 
             # Create Datasources, save them to the object store and get their UUIDs
             data_type = "surface"

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -124,7 +124,7 @@ class ObsSurface(BaseStore):
         compressor: Optional[Any] = None,
         filters: Optional[Any] = None,
         chunks: Optional[Dict] = None,
-        optional_metadata: Optional[dict] = {},
+        optional_metadata: Optional[dict] = None,
     ) -> Dict:
         """Process files and store in the object store. This function
             utilises the process functions of the other classes in this submodule
@@ -378,11 +378,15 @@ class ObsSurface(BaseStore):
             )
 
             if optional_metadata:
-                for optional_key, optional_value in optional_metadata.items():
-                    if optional_key in required_keys:
-                        raise ValueError(f"Optional metadata key '{optional_key}' is already present in required keys.")
-                    else:
-                        data["metadata"][optional_key] = optional_value
+                common_keys = set(required_keys) & set(optional_metadata.keys())
+
+            if common_keys:
+                raise ValueError(
+                    f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
+                )
+            else:
+                for key, parsed_data in data.items():
+                    parsed_data["metadata"].update(optional_metadata)
 
             # Create Datasources, save them to the object store and get their UUIDs
             data_type = "surface"

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -178,6 +178,7 @@ class ObsSurface(BaseStore):
                 for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
                 See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
                 To disable chunking pass in an empty dictionary.
+            optional_metadata: Allows to pass in additional tags to distinguish added data. e.g {"project":"paris", "baseline":"Intem"}
         Returns:
             dict: Dictionary of Datasource UUIDs
 

--- a/tests/store/test_boundary_conditions.py
+++ b/tests/store/test_boundary_conditions.py
@@ -235,7 +235,28 @@ def test_bc_schema():
     # TODO: Could also add checks for dims and dtypes?
 
 
-def test_optional_metadata(clear_stores):
+def test_optional_metadata_raise_error(clear_stores):
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+    test_datapath = get_bc_datapath("co2_EUROPE_201407.nc")
+
+    species = "co2"
+    bc_input = "CAMS"
+    domain = "EUROPE"
+
+    with pytest.raises(ValueError):
+        standardise_bc(
+            store="user",
+            filepath=test_datapath,
+            species=species,
+            bc_input=bc_input,
+            domain=domain,
+            optional_metadata={"purpose":"openghg_tests", "species":"co2"},
+        )
+
+
+def test_optional_metadata():
     """
     Test to verify optional metadata supplied as dictionary gets stored as metadata
     """
@@ -263,24 +284,3 @@ def test_optional_metadata(clear_stores):
 
     assert "project" in metadata
     assert "tag" in metadata
-
-
-def test_optional_metadata_raise_error(clear_stores):
-    """
-    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
-    """
-    test_datapath = get_bc_datapath("co2_EUROPE_201407.nc")
-
-    species = "co2"
-    bc_input = "CAMS"
-    domain = "EUROPE"
-
-    with pytest.raises(ValueError):
-        standardise_bc(
-            store="user",
-            filepath=test_datapath,
-            species=species,
-            bc_input=bc_input,
-            domain=domain,
-            optional_metadata={"purpose":"openghg_tests", "species":"co2"}
-        )

--- a/tests/store/test_boundary_conditions.py
+++ b/tests/store/test_boundary_conditions.py
@@ -1,16 +1,11 @@
 import numpy as np
 import pytest
-from helpers import get_bc_datapath,clear_test_stores
+from helpers import get_bc_datapath,clear_test_store
 from openghg.retrieve import search
 from openghg.standardise import standardise_bc, standardise_from_binary_data
 from openghg.store import BoundaryConditions
 from openghg.util import hash_bytes
 from xarray import open_dataset
-
-
-@pytest.fixture
-def clear_stores():
-    clear_test_stores()
 
 
 def test_read_data_monthly(mocker):
@@ -235,10 +230,12 @@ def test_bc_schema():
     # TODO: Could also add checks for dims and dtypes?
 
 
-def test_optional_metadata_raise_error(clear_stores):
+def test_optional_metadata_raise_error():
     """
     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
     """
+
+    clear_test_store("user")
     test_datapath = get_bc_datapath("co2_EUROPE_201407.nc")
 
     species = "co2"

--- a/tests/store/test_eulerian_model.py
+++ b/tests/store/test_eulerian_model.py
@@ -53,8 +53,18 @@ def test_read_file():
         assert metadata[key] == expected_value
 
 
+def test_optional_metadata_raise_error(clear_stores):
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
 
-def test_optional_metadata(clear_stores):
+    with pytest.raises(ValueError):
+        test_datapath = get_eulerian_datapath("GEOSChem.SpeciesConc.20150101_0000z_reduced.nc4")
+
+        proc_results = standardise_eulerian(store="user", filepath=test_datapath, model="GEOSChem", species="ch4", optional_metadata={"species":"ch4", "tag":"tests"})
+
+
+def test_optional_metadata():
     """
     Test to verify optional metadata supplied as dictionary gets stored as metadata
     """
@@ -71,14 +81,3 @@ def test_optional_metadata(clear_stores):
 
     assert "project" in metadata
     assert "tag" in metadata
-
-
-def test_optional_metadata_raise_error(clear_stores):
-    """
-    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
-    """
-
-    with pytest.raises(ValueError):
-        test_datapath = get_eulerian_datapath("GEOSChem.SpeciesConc.20150101_0000z_reduced.nc4")
-
-        proc_results = standardise_eulerian(store="user", filepath=test_datapath, model="GEOSChem", species="ch4", optional_metadata={"species":"ch4", "tag":"tests"})

--- a/tests/store/test_eulerian_model.py
+++ b/tests/store/test_eulerian_model.py
@@ -1,12 +1,8 @@
 import pytest
-from helpers import get_eulerian_datapath, clear_test_stores
+from helpers import get_eulerian_datapath, clear_test_store
 from openghg.retrieve import search
 from openghg.standardise import standardise_eulerian
 from xarray import open_dataset
-
-@pytest.fixture
-def clear_stores():
-    clear_test_stores()
 
 
 def test_read_file():
@@ -53,11 +49,12 @@ def test_read_file():
         assert metadata[key] == expected_value
 
 
-def test_optional_metadata_raise_error(clear_stores):
+def test_optional_metadata_raise_error():
     """
     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
     """
 
+    clear_test_store("user")
     with pytest.raises(ValueError):
         test_datapath = get_eulerian_datapath("GEOSChem.SpeciesConc.20150101_0000z_reduced.nc4")
 

--- a/tests/store/test_flux.py
+++ b/tests/store/test_flux.py
@@ -452,7 +452,21 @@ def test_flux_schema():
     # TODO: Could also add checks for dims and dtypes?
 
 
-def test_optional_metadata(clear_stores):
+def test_optional_metadata_raise_error(clear_stores):
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+    folder = "v6.0_CH4"
+    test_datapath = get_flux_datapath(f"EDGAR/yearly/{folder}")
+
+    database = "EDGAR"
+    date = "2015"
+
+    with pytest.raises(ValueError):
+        proc_results = transform_flux_data(store="user", datapath=test_datapath, database=database, date=date, optional_metadata={"domain":"openghg_tests"})
+
+
+def test_optional_metadata():
     """
     Test to verify optional metadata supplied as dictionary gets stored as metadata
     """
@@ -479,17 +493,3 @@ def test_optional_metadata(clear_stores):
 
     assert "project" in metadata
     assert "tag" in metadata
-
-
-def test_optional_metadata_raise_error(clear_stores):
-    """
-    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
-    """
-    folder = "v6.0_CH4"
-    test_datapath = get_flux_datapath(f"EDGAR/yearly/{folder}")
-
-    database = "EDGAR"
-    date = "2015"
-
-    with pytest.raises(ValueError):
-        proc_results = transform_flux_data(store="user", datapath=test_datapath, database=database, date=date, optional_metadata={"domain":"openghg_tests"})

--- a/tests/store/test_flux.py
+++ b/tests/store/test_flux.py
@@ -450,3 +450,46 @@ def test_flux_schema():
     assert "lon" in data_vars["flux"]
 
     # TODO: Could also add checks for dims and dtypes?
+
+
+def test_optional_metadata(clear_stores):
+    """
+    Test to verify optional metadata supplied as dictionary gets stored as metadata
+    """
+    folder = "v6.0_CH4"
+    test_datapath = get_flux_datapath(f"EDGAR/yearly/{folder}")
+
+    database = "EDGAR"
+    date = "2015"
+
+    proc_results = transform_flux_data(store="user", datapath=test_datapath, database=database, date=date, optional_metadata={"project":"openghg_tests", "tag":"tests"})
+
+    version = "v6.0"
+    species = "ch4"
+
+    search_results = search_flux(
+        species=species,
+        date=date,
+        database=database,  # would searching for lowercase not work?
+        database_version=version,
+    )
+
+    edgar_obs = search_results.retrieve_all()
+    metadata = edgar_obs.metadata
+
+    assert "project" in metadata
+    assert "tag" in metadata
+
+
+def test_optional_metadata_raise_error(clear_stores):
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+    folder = "v6.0_CH4"
+    test_datapath = get_flux_datapath(f"EDGAR/yearly/{folder}")
+
+    database = "EDGAR"
+    date = "2015"
+
+    with pytest.raises(ValueError):
+        proc_results = transform_flux_data(store="user", datapath=test_datapath, database=database, date=date, optional_metadata={"domain":"openghg_tests"})

--- a/tests/store/test_footprints.py
+++ b/tests/store/test_footprints.py
@@ -1,5 +1,5 @@
 import pytest
-from helpers import get_footprint_datapath, clear_test_stores
+from helpers import get_footprint_datapath, clear_test_store
 from openghg.retrieve import search
 from openghg.objectstore import get_writable_bucket
 from openghg.standardise import standardise_footprint, standardise_from_binary_data
@@ -7,11 +7,6 @@ from openghg.store import Footprints
 from openghg.util import hash_bytes
 import xarray as xr
 from pathlib import Path
-
-
-@pytest.fixture
-def clear_stores():
-    clear_test_stores()
 
 
 @pytest.mark.xfail(reason="Need to add a better way of passing in binary data to the read_file functions.")
@@ -640,7 +635,36 @@ def test_footprints_chunking_schema():
         )
 
 
-def test_optional_metadata(clear_stores):
+def test_optional_metadata_raise_error():
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+    clear_test_store("user")
+
+    datapath = get_footprint_datapath("WAO-20magl_UKV_rn_TEST_201801.nc")
+
+    site = "WAO"
+    inlet = "20m"
+    domain = "TEST"
+    model = "NAME"
+    met_model = "UKV"
+    species = "Rn"
+
+    with pytest.raises(ValueError):
+        standardise_footprint(
+            store="user",
+            filepath=datapath,
+            site=site,
+            model=model,
+            met_model=met_model,
+            inlet=inlet,
+            species=species,
+            domain=domain,
+            optional_metadata={"site":"test"},
+    )
+
+
+def test_optional_metadata():
     """
     Test to verify optional metadata supplied as dictionary gets stored as metadata
     """
@@ -673,30 +697,3 @@ def test_optional_metadata(clear_stores):
     footprint_metadata = footprint_obs.metadata
 
     assert "project" in footprint_metadata
-
-
-def test_optional_metadata_raise_error(clear_stores):
-    """
-    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
-    """
-    datapath = get_footprint_datapath("WAO-20magl_UKV_rn_TEST_201801.nc")
-
-    site = "WAO"
-    inlet = "20m"
-    domain = "TEST"
-    model = "NAME"
-    met_model = "UKV"
-    species = "Rn"
-
-    with pytest.raises(ValueError):
-        standardise_footprint(
-            store="user",
-            filepath=datapath,
-            site=site,
-            model=model,
-            met_model=met_model,
-            inlet=inlet,
-            species=species,
-            domain=domain,
-            optional_metadata={"site":"test"},
-    )

--- a/tests/store/test_footprints.py
+++ b/tests/store/test_footprints.py
@@ -1,5 +1,5 @@
 import pytest
-from helpers import get_footprint_datapath
+from helpers import get_footprint_datapath, clear_test_stores
 from openghg.retrieve import search
 from openghg.objectstore import get_writable_bucket
 from openghg.standardise import standardise_footprint, standardise_from_binary_data
@@ -7,6 +7,11 @@ from openghg.store import Footprints
 from openghg.util import hash_bytes
 import xarray as xr
 from pathlib import Path
+
+
+@pytest.fixture
+def clear_stores():
+    clear_test_stores()
 
 
 @pytest.mark.xfail(reason="Need to add a better way of passing in binary data to the read_file functions.")
@@ -633,3 +638,65 @@ def test_footprints_chunking_schema():
             time_resolved=False,
             short_lifetime=False,
         )
+
+
+def test_optional_metadata(clear_stores):
+    """
+    Test to verify optional metadata supplied as dictionary gets stored as metadata
+    """
+
+    datapath = get_footprint_datapath("WAO-20magl_UKV_rn_TEST_201801.nc")
+
+    site = "WAO"
+    inlet = "20m"
+    domain = "TEST"
+    model = "NAME"
+    met_model = "UKV"
+    species = "Rn"
+
+    standardise_footprint(
+        store="user",
+        filepath=datapath,
+        site=site,
+        model=model,
+        met_model=met_model,
+        inlet=inlet,
+        species=species,
+        domain=domain,
+        optional_metadata={"project":"test"},
+    )
+
+    # Get the footprints data
+    footprint_results = search(site=site, domain=domain, species=species, data_type="footprints",)
+
+    footprint_obs = footprint_results.retrieve_all()
+    footprint_metadata = footprint_obs.metadata
+
+    assert "project" in footprint_metadata
+
+
+def test_optional_metadata_raise_error(clear_stores):
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+    datapath = get_footprint_datapath("WAO-20magl_UKV_rn_TEST_201801.nc")
+
+    site = "WAO"
+    inlet = "20m"
+    domain = "TEST"
+    model = "NAME"
+    met_model = "UKV"
+    species = "Rn"
+
+    with pytest.raises(ValueError):
+        standardise_footprint(
+            store="user",
+            filepath=datapath,
+            site=site,
+            model=model,
+            met_model=met_model,
+            inlet=inlet,
+            species=species,
+            domain=domain,
+            optional_metadata={"site":"test"},
+    )

--- a/tests/store/test_obscolumn.py
+++ b/tests/store/test_obscolumn.py
@@ -50,7 +50,30 @@ def test_read_openghg_format():
         assert np.isclose(ch4_data["xch4"][0], 1844.2019)
 
 
-def test_optional_metadata(clear_store):
+def test_optional_metadata_raise_error(clear_store):
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+    filename = "gosat-fts_gosat_20170318_ch4-column.nc"
+    datafile = get_column_datapath(filename=filename)
+
+    satellite = "GOSAT"
+    domain = "BRAZIL"
+    species = "methane"
+
+    with pytest.raises(ValueError):
+        standardise_column(
+            store="user",
+            filepath=datafile,
+            source_format="OPENGHG",
+            satellite=satellite,
+            domain=domain,
+            species=species,
+            optional_metadata={"domain":"openghg_test"}
+     )
+
+
+def test_optional_metadata():
     """
     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
     """
@@ -74,26 +97,3 @@ def test_optional_metadata(clear_store):
     metadata = col_data.metadata
 
     assert "project" in metadata
-
-
-def test_optional_metadata_raise_error(clear_store):
-    """
-    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
-    """
-    filename = "gosat-fts_gosat_20170318_ch4-column.nc"
-    datafile = get_column_datapath(filename=filename)
-
-    satellite = "GOSAT"
-    domain = "BRAZIL"
-    species = "methane"
-
-    with pytest.raises(ValueError):
-        standardise_column(
-            store="user",
-            filepath=datafile,
-            source_format="OPENGHG",
-            satellite=satellite,
-            domain=domain,
-            species=species,
-            optional_metadata={"domain":"openghg_test"}
-     )

--- a/tests/store/test_obscolumn.py
+++ b/tests/store/test_obscolumn.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 from helpers import get_column_datapath
 from openghg.objectstore import get_bucket
+from openghg.retrieve import search_column
 from openghg.standardise import standardise_column
 from openghg.store.base import Datasource
 from pandas import Timestamp
@@ -43,3 +45,51 @@ def test_read_openghg_format():
     with d.get_data(version="latest") as ch4_data:
         assert ch4_data.time[0] == Timestamp("2017-03-18T15:32:54")
         assert np.isclose(ch4_data["xch4"][0], 1844.2019)
+
+# def test_optional_metadata():
+#     """
+#     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+#     """
+#     filename = "gosat-fts_gosat_20170318_ch4-column.nc"
+#     datafile = get_column_datapath(filename=filename)
+
+#     satellite = "GOSAT"
+#     domain = "BRAZIL"
+#     species = "methane"
+
+#     standardise_column(
+#         store="user",
+#         filepath=datafile,
+#         source_format="OPENGHG",
+#         satellite=satellite,
+#         domain=domain,
+#         species=species,
+#         optional_metadata={"project":"openghg_test"}
+#     )
+#     col_data = search_column(species="ch4").retrieve_all()
+#     metadata = col_data.metadata
+
+#     assert "project" in metadata
+
+
+# def test_optional_metadata_raise_error():
+#     """
+#     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+#     """
+#     filename = "gosat-fts_gosat_20170318_ch4-column.nc"
+#     datafile = get_column_datapath(filename=filename)
+
+#     satellite = "GOSAT"
+#     domain = "BRAZIL"
+#     species = "methane"
+
+#     with pytest.raises(ValueError):
+#         standardise_column(
+#             store="user",
+#             filepath=datafile,
+#             source_format="OPENGHG",
+#             satellite=satellite,
+#             domain=domain,
+#             species=species,
+#             optional_metadata={"domain":"openghg_test"}
+#      )

--- a/tests/store/test_obscolumn.py
+++ b/tests/store/test_obscolumn.py
@@ -1,15 +1,12 @@
 import numpy as np
 import pytest
-from helpers import get_column_datapath, clear_test_stores
+from helpers import get_column_datapath, clear_test_store
 from openghg.objectstore import get_bucket
 from openghg.retrieve import search_column
 from openghg.standardise import standardise_column
 from openghg.store.base import Datasource
 from pandas import Timestamp
 
-@pytest.fixture
-def clear_store():
-    clear_test_stores()
 
 def test_read_openghg_format():
     """
@@ -50,10 +47,12 @@ def test_read_openghg_format():
         assert np.isclose(ch4_data["xch4"][0], 1844.2019)
 
 
-def test_optional_metadata_raise_error(clear_store):
+def test_optional_metadata_raise_error():
     """
     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
     """
+
+    clear_test_store("user")
     filename = "gosat-fts_gosat_20170318_ch4-column.nc"
     datafile = get_column_datapath(filename=filename)
 

--- a/tests/store/test_obscolumn.py
+++ b/tests/store/test_obscolumn.py
@@ -1,12 +1,15 @@
 import numpy as np
 import pytest
-from helpers import get_column_datapath
+from helpers import get_column_datapath, clear_test_stores
 from openghg.objectstore import get_bucket
 from openghg.retrieve import search_column
 from openghg.standardise import standardise_column
 from openghg.store.base import Datasource
 from pandas import Timestamp
 
+@pytest.fixture
+def clear_store():
+    clear_test_stores()
 
 def test_read_openghg_format():
     """
@@ -46,50 +49,51 @@ def test_read_openghg_format():
         assert ch4_data.time[0] == Timestamp("2017-03-18T15:32:54")
         assert np.isclose(ch4_data["xch4"][0], 1844.2019)
 
-# def test_optional_metadata():
-#     """
-#     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
-#     """
-#     filename = "gosat-fts_gosat_20170318_ch4-column.nc"
-#     datafile = get_column_datapath(filename=filename)
 
-#     satellite = "GOSAT"
-#     domain = "BRAZIL"
-#     species = "methane"
+def test_optional_metadata(clear_store):
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+    filename = "gosat-fts_gosat_20170318_ch4-column.nc"
+    datafile = get_column_datapath(filename=filename)
 
-#     standardise_column(
-#         store="user",
-#         filepath=datafile,
-#         source_format="OPENGHG",
-#         satellite=satellite,
-#         domain=domain,
-#         species=species,
-#         optional_metadata={"project":"openghg_test"}
-#     )
-#     col_data = search_column(species="ch4").retrieve_all()
-#     metadata = col_data.metadata
+    satellite = "GOSAT"
+    domain = "BRAZIL"
+    species = "methane"
 
-#     assert "project" in metadata
+    standardise_column(
+        store="user",
+        filepath=datafile,
+        source_format="OPENGHG",
+        satellite=satellite,
+        domain=domain,
+        species=species,
+        optional_metadata={"project":"openghg_test"}
+    )
+    col_data = search_column(species="ch4").retrieve_all()
+    metadata = col_data.metadata
+
+    assert "project" in metadata
 
 
-# def test_optional_metadata_raise_error():
-#     """
-#     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
-#     """
-#     filename = "gosat-fts_gosat_20170318_ch4-column.nc"
-#     datafile = get_column_datapath(filename=filename)
+def test_optional_metadata_raise_error(clear_store):
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+    filename = "gosat-fts_gosat_20170318_ch4-column.nc"
+    datafile = get_column_datapath(filename=filename)
 
-#     satellite = "GOSAT"
-#     domain = "BRAZIL"
-#     species = "methane"
+    satellite = "GOSAT"
+    domain = "BRAZIL"
+    species = "methane"
 
-#     with pytest.raises(ValueError):
-#         standardise_column(
-#             store="user",
-#             filepath=datafile,
-#             source_format="OPENGHG",
-#             satellite=satellite,
-#             domain=domain,
-#             species=species,
-#             optional_metadata={"domain":"openghg_test"}
-#      )
+    with pytest.raises(ValueError):
+        standardise_column(
+            store="user",
+            filepath=datafile,
+            source_format="OPENGHG",
+            satellite=satellite,
+            domain=domain,
+            species=species,
+            optional_metadata={"domain":"openghg_test"}
+     )

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -942,6 +942,20 @@ def test_optional_parameters():
                         store="group" )
 
 
+def test_optional_metadata_raise_error():
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+
+    clear_test_stores()
+    rgl_filepath = get_surface_datapath(filename="rgl.picarro.1minute.90m.minimum.dat", source_format="CRDS")
+
+    with pytest.raises(ValueError):
+        standardise_surface(
+            filepath=rgl_filepath, source_format="CRDS", network="DECC", site="RGL", store="group", optional_metadata={"species":"openghg_tests"}
+        )
+
+
 def test_optional_metadata():
     """
     Test to verify optional metadata supplied as dictionary gets stored as metadata
@@ -960,17 +974,3 @@ def test_optional_metadata():
     rgl_ch4_metadata = rgl_ch4.metadata
 
     assert "project" in rgl_ch4_metadata
-
-
-def test_optional_metadata_raise_error():
-    """
-    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
-    """
-
-    clear_test_stores()
-    rgl_filepath = get_surface_datapath(filename="rgl.picarro.1minute.90m.minimum.dat", source_format="CRDS")
-
-    with pytest.raises(ValueError):
-        standardise_surface(
-            filepath=rgl_filepath, source_format="CRDS", network="DECC", site="RGL", store="group", optional_metadata={"species":"openghg_tests"}
-        )

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -961,14 +961,11 @@ def test_optional_metadata():
     Test to verify optional metadata supplied as dictionary gets stored as metadata
     """
 
-    clear_test_stores()
     rgl_filepath = get_surface_datapath(filename="rgl.picarro.1minute.90m.minimum.dat", source_format="CRDS")
 
     standardise_surface(
         filepath=rgl_filepath, source_format="CRDS", network="DECC", site="RGL", store="group", optional_metadata={"project":"openghg_tests"}
     )
-
-    # Compare output to GCWerks - there should be a valid CH4 data point at 2014-06-16 03:34
 
     rgl_ch4 = get_obs_surface(site="rgl", species="ch4", inlet="90m")
     rgl_ch4_metadata = rgl_ch4.metadata

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -926,17 +926,51 @@ def test_drop_only_correct_nan():
     assert len(rgl_co2_data["time"]) == 1
     assert np.isclose(rgl_co2_data.sel(time=time_str2)["mf"].values, 405.30)
 
+
 def test_optional_parameters():
     """Test if ValueError is raised for invalid input value to calibration_scale."""
 
     data_filepath = get_surface_datapath(filename="tac_co2_openghg.nc",source_format="OPENGHG")
 
     with pytest.raises(ValueError, match="Input for 'calibration_scale': unknown does not match value in file attributes: WMO-X2007"):
-        standardise_surface(filepath=data_filepath, 
-                        source_format="OPENGHG", 
-                        site="TAC", 
+        standardise_surface(filepath=data_filepath,
+                        source_format="OPENGHG",
+                        site="TAC",
                         network="DECC",
                         calibration_scale="unknown",
                         instrument='picarro',
                         store="group" )
-        
+
+
+def test_optional_metadata():
+    """
+    Test to verify optional metadata supplied as dictionary gets stored as metadata
+    """
+
+    clear_test_stores()
+    rgl_filepath = get_surface_datapath(filename="rgl.picarro.1minute.90m.minimum.dat", source_format="CRDS")
+
+    standardise_surface(
+        filepath=rgl_filepath, source_format="CRDS", network="DECC", site="RGL", store="group", optional_metadata={"project":"openghg_tests"}
+    )
+
+    # Compare output to GCWerks - there should be a valid CH4 data point at 2014-06-16 03:34
+
+    rgl_ch4 = get_obs_surface(site="rgl", species="ch4", inlet="90m")
+    rgl_ch4_metadata = rgl_ch4.metadata
+
+    assert "project" in rgl_ch4_metadata
+
+
+def test_optional_metadata_raise_error():
+    """
+    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    """
+
+    clear_test_stores()
+    rgl_filepath = get_surface_datapath(filename="rgl.picarro.1minute.90m.minimum.dat", source_format="CRDS")
+
+    with pytest.raises(ValueError):
+        standardise_surface(
+            filepath=rgl_filepath, source_format="CRDS", network="DECC", site="RGL", store="group", optional_metadata={"species":"openghg_tests"}
+        )


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Allowed the standardising functions to accept optional_metadata
Added raise value error if optional_metadata contains keys similar to required_keys
Added tests for both scenarios.

* **Please check if the PR fulfills these requirements**

- [x] Closes #493 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
