### PR TITLE
Ensure backwards compatability of new time_resolved key with previous stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to convert from an old style NetCDF object store to the new Zarr based store format - [PR #967](https://github.com/openghg/openghg/pull/967)
 - Updated `parse_edgar` function to handle processing of v8.0 Edgar datasets. [PR #965](https://github.com/openghg/openghg/pull/965)
 - Argument `time_resolved` is added as phase 1 change for `high_time_resolution`, also metadata is updated and added deprecation warning. - [PR #968](https://github.com/openghg/openghg/pull/968)
+- Added explicit backwards compatability when searching previous object stores containing the `high_time_resolution` keyword rather than `time_resolved` - [PR #990](https://github.com/openghg/openghg/pull/990)
 - Added ability to pass additional tags as optional metadata through `standardising_*` and `transform_flux_data functions`. [PR #981](https://github.com/openghg/openghg/pull/981)
 
 ### Fixed

--- a/doc/source/tutorials/local/Exploring_data/Searching_and_plotting.rst
+++ b/doc/source/tutorials/local/Exploring_data/Searching_and_plotting.rst
@@ -25,7 +25,7 @@ Now we'll add some data to the tutorial store.
     populate_surface_data()
 
 1. Searching
--------------
+------------
 
 Let's search for all the methane data from Tacolneston.
 To do this we need to know the site code ("TAC").
@@ -85,11 +85,33 @@ to extract, for example, just the methane data:
     tac_surface_search = search_surface(site="TAC", species="ch4")
     tac_surface_search.results
 
+Keyword options when searching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When searching it is also possible to specify multiple options for keywords.
+If this is done using a list, then datasources which have any of the
+specified values will be found. For example if we wanted to search for methane
+at two specific inlets we could write:
+
+.. code:: ipython3
+
+    from openghg.retrieve import search_surface
+
+    tac_surface_search = search_surface(site="TAC", species="ch4", inlet=["100m", "185m"])
+    tac_surface_search.results    
+
+This will return results from both the 100m and 185m inlets (but not the 54m inlet).
+
+Note: it is also possible to specify a dictionary to provide an option between 
+different keywords but this would most often be for backwards compatability
+(e.g. if a new keyword is introduced and a previous one retired but still
+present for some data sources) and so will not be demonstrated in this tutorial.
+
 There are also equivalent search functions for other data types
 including ``search_footprints``, ``search_flux`` and ``search_bc``.
 
 2. Plotting
------------------
+-----------
 
 If we want to take a look at the data from the 185m inlet we can first
 retrieve the data from the object store and then create a quick
@@ -139,7 +161,7 @@ and and responsive, even with relatively large amounts of data.
     plot_timeseries(data=all_ch4_tac, units="ppb")
 
 3. Comparing different sites
------------------------------
+----------------------------
 
 We can easily compare data for the same species from different sites by
 doing a quick search to see what's available

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -376,6 +376,15 @@ def search(**kwargs: Any) -> SearchResults:
     the function and these keywords will be used to search the metadata associated
     with each Datasource.
 
+    Though any types can be passed as keyword arguments, these will be interpreted in the following ways:
+     - None - argument will be ignored.
+     - list/tuple - an OR search will be created for the argument and each of the values.
+     - dict - an OR search will be created for the key, value pairs.
+       - Note: in this case the name of argument itself will be ignored.
+     - str/other - argument used directly.
+
+    All input search values are formatted (openghg.utils.clean_string).
+
     This function detects the running environment and routes the call
     to either the cloud or local search function.
 
@@ -423,6 +432,15 @@ def _base_search(**kwargs: Any) -> SearchResults:
     """Search for observations data. Any keyword arguments may be passed to the
     the function and these keywords will be used to search metadata.
 
+    Though any types can be passed as keyword arguments, these will be interpreted in the following ways:
+     - None - argument will be ignored.
+     - list/tuple - an OR search will be created for the argument and each of the values.
+     - dict - an OR search will be created for the key, value pairs.
+       - Note: in this case the name of argument itself will be ignored.
+     - str/other - argument used directly.
+
+    All input search values are formatted (openghg.utils.clean_string).
+
     This function will only perform a "local" search. It may be used either by a cloud function
     or when using OpenGHG locally, it does no environment detection.
     We suggest using the search function that takes care of everything for you.
@@ -459,8 +477,21 @@ def _base_search(**kwargs: Any) -> SearchResults:
             "This function can't be used on the OpenGHG Hub, please use openghg.retrieve.search instead."
         )
 
-    # As we might have kwargs that are None we want to get rid of those
-    search_kwargs = {k: clean_string(v) for k, v in kwargs.items() if v is not None}
+    # Select and format the search terms
+    # - ignore any kwargs which are None
+    # - clean search terms directly or within data structures
+    search_kwargs = {}
+    for k, v in kwargs.items():
+        if v is None:
+            continue
+        elif isinstance(v, (list, tuple)):
+            v = [clean_string(value) for value in v if value is not None]
+        elif isinstance(v, dict):
+            v = {key: clean_string(value) for key, value in v.items() if value is not None}
+        else:
+            v = clean_string(v)
+
+        search_kwargs[k] = v
 
     # Species translation
     species = search_kwargs.get("species")
@@ -521,27 +552,33 @@ def _base_search(**kwargs: Any) -> SearchResults:
     else:
         del search_kwargs["end_date"]
 
-    # Here we process the kwargs and flatten out the lists so
-    # we create the combinations of search queries correctly
-    a_list = {}
-    not_a_list = {}
+    # Here we process the kwargs, allowing us to create the correct combinations of search queries.
+    # To set this up for keywords with multiple options, lists of the (key, value) pair terms are created
+    # - e.g. for species = ["ch4", "methane"], time_resolution = {"time_resolved": "true", "high_time_resolution: "true"}
+    # - multiple_options is [[("species", "ch4"), ("species", "methane")], [("time_resolved": "true"), ("high_time_resolution": "true")]]
+    # - we then expect searches for all permutations across both lists.
+    multiple_options = []
+    single_options = {}
     for k, v in search_kwargs.items():
         if isinstance(v, (list, tuple)):
-            a_list[k] = v
+            expand_key_values = [(k, value) for value in v]
+            multiple_options.append(expand_key_values)
+        elif isinstance(v, dict):
+            expand_key_values = v.items()
+            multiple_options.append(expand_key_values)
         else:
-            not_a_list[k] = v
+            single_options[k] = v
 
-    # If we have lists of values to find we need to flatten them out
     expanded_search = []
-    if a_list:
-        keys, values = zip(*a_list.items())
-        for v in itertools.product(*values):
-            d = dict(zip(keys, v))
-            if not_a_list:
-                d.update(not_a_list)
+    if multiple_options:
+        # Ensure that all permutations of the search options are created.
+        for kv_pair in itertools.product(*multiple_options):
+            d = dict(kv_pair)
+            if single_options:
+                d.update(single_options)
             expanded_search.append(d)
     else:
-        expanded_search.append(not_a_list)
+        expanded_search.append(single_options)
 
     general_metadata = {}
 

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -205,7 +205,7 @@ def search_footprints(
     """
     from openghg.util import format_inlet
 
-    args = {
+    args: Dict[str, Any] = {
         "site": site,
         "inlet": inlet,
         "height": height,
@@ -232,14 +232,17 @@ def search_footprints(
     # - ensure passing time_resolved=True gives back all relevant footprints.
     if high_time_resolution is not None:
         warnings.warn(
-        "The 'high_time_resolution' argument is deprecated and will be replaced in future versions with 'time_resolved'.",
-        DeprecationWarning,
+            "The 'high_time_resolution' argument is deprecated and will be replaced in future versions with 'time_resolved'.",
+            DeprecationWarning,
         )
         if time_resolved is None:
             time_resolved = high_time_resolution
 
     high_time_resolution = time_resolved  # Includes at the moment for backwards compatability
-    args["option_time_resolved"] = {"time_resolved": time_resolved, "high_time_resolution": high_time_resolution}
+    args["option_time_resolved"] = {
+        "time_resolved": time_resolved,
+        "high_time_resolution": high_time_resolution,
+    }
 
     # Either (or both) of 'inlet' and 'height' may be in the metastore, so
     # both are allowed for search.
@@ -573,7 +576,7 @@ def _base_search(**kwargs: Any) -> SearchResults:
             expand_key_values = [(k, value) for value in v]
             multiple_options.append(expand_key_values)
         elif isinstance(v, dict):
-            expand_key_values = v.items()
+            expand_key_values = list(v.items())
             multiple_options.append(expand_key_values)
         else:
             single_options[k] = v

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -202,6 +202,7 @@ def test_multi_type_search():
 
 
 def test_many_term_search():
+    """Test search using list inputs. This should create an OR search between the terms in the arguments with lists."""
     res = search(site=["bsd", "tac"], species=["co2", "ch4"], inlet=["42m", "100m"])
 
     assert len(res.metadata) == 4
@@ -215,6 +216,18 @@ def test_many_term_search():
 
     inlets = set([x["inlet"] for x in res.metadata.values()])
     assert inlets == {"100m", "42m"}
+
+
+def test_optional_term_search():
+    """Test search using dict inputs. This should create an OR search between the key, value pairs in the dictionaries"""
+    # Note: had to be careful to not create duplicates as this currently raises an error.
+    res = search(site="bsd", inlet_option={"inlet": "42m", "height": "42m"}, name_option={"station_long_name": "bilsdale, uk", "long_name": "bilsdale"})
+
+    assert len(res.metadata) == 3
+    assert res.metadata
+
+    inlets = set([x["inlet"] for x in res.metadata.values()])
+    assert inlets == {"42m"}
 
 
 def test_nonsense_terms():
@@ -369,9 +382,6 @@ def test_search_footprints_time_resolved():
     # check attributes
     metadata = res.retrieve().metadata
     assert metadata["time_resolved"] == "true"
-
-
-# def test_search
 
 
 def test_search_flux():

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -62,7 +62,9 @@ def test_search_surface_selects_dates():
     assert data.time[0] == Timestamp("2013-11-23T12:28:30")
     assert data.time[-1] == Timestamp("2020-06-24T09:41:30")
 
-    res = search_surface(site="hfd", species="co2", inlet="50m", start_date="2014-01-01", end_date="2014-12-31")
+    res = search_surface(
+        site="hfd", species="co2", inlet="50m", start_date="2014-01-01", end_date="2014-12-31"
+    )
 
     data_sliced = res.retrieve_all().data
 
@@ -222,7 +224,11 @@ def test_many_term_search():
 def test_optional_term_search():
     """Test search using dict inputs. This should create an OR search between the key, value pairs in the dictionaries"""
     # Note: had to be careful to not create duplicates as this currently raises an error.
-    res = search(site="bsd", inlet_option={"inlet": "42m", "height": "42m"}, name_option={"station_long_name": "bilsdale, uk", "long_name": "bilsdale"})
+    res = search(
+        site="bsd",
+        inlet_option={"inlet": "42m", "height": "42m"},
+        name_option={"station_long_name": "bilsdale, uk", "long_name": "bilsdale"},
+    )
 
     assert len(res.metadata) == 3
     assert res.metadata
@@ -297,12 +303,7 @@ def test_search_footprints_multiple():
         - 2016-08-01 (3 time points)
     """
     res = search_footprints(
-        site="TAC",
-        network="DECC",
-        height="100m",
-        domain="TEST",
-        model="NAME",
-        time_resolved=False
+        site="TAC", network="DECC", height="100m", domain="TEST", model="NAME", time_resolved=False
     )
 
     key = next(iter(res.metadata))
@@ -365,7 +366,7 @@ def test_search_footprints_time_resolved():
     # Check search for footprints returns multiple entries
     res_all = search_footprints(
         site="TAC",
-    )    
+    )
 
     # Based on loaded data in conftest.py,
     # more than one footprint for TAC should be found (standard, time_resolved)
@@ -412,12 +413,12 @@ def previous_htr_footprint_setup():
     # Find this footprint and update the metadata
     dm = data_manager(data_type="footprints", site="TAC", inlet="185m", time_resolved=True, store="user")
     uuid = next(iter(dm.metadata))
-    
+
     # Removed time_resolved key
     to_delete = "time_resolved"
     value = dm.metadata[uuid][to_delete]
     dm.update_metadata(uuid=uuid, to_delete=to_delete)
-    
+
     # Add high_time_resolution key
     to_add = {"high_time_resolution": value}
     dm.update_metadata(uuid=uuid, to_update=to_add)
@@ -435,7 +436,7 @@ def test_search_high_time_resolution(previous_htr_footprint_setup):
         site="TAC",
         inlet="185m",
         high_time_resolution=True,
-    )    
+    )
 
     # results dataframes find the footprint labeled as high_time_resolution
     assert res.results.shape[0] == 1
@@ -445,7 +446,9 @@ def test_search_high_time_resolution(previous_htr_footprint_setup):
     assert metadata["high_time_resolution"] == "true"
 
     # Remove temporary datasource from the object store
-    dm = data_manager(data_type="footprints", site="TAC", inlet="185m", high_time_resolution=True, store="user")
+    dm = data_manager(
+        data_type="footprints", site="TAC", inlet="185m", high_time_resolution=True, store="user"
+    )
     uuid = next(iter(dm.metadata))
     dm.delete_datasource(uuid=uuid)
 

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -341,29 +341,37 @@ def test_search_footprints_select():
 
 
 def test_search_footprints_time_resolved():
-    """Test search for high time resolution footprints
+    """Test search for time resolved footprints
 
     Expected behaviour: searching for footprints with
     keyword argument `time_resolved = True` should only
-    return results for high time resolution footprints.
+    return results for time resolved footprints.
     """
+
+    # Check search for footprints returns multiple entries
+    res_all = search_footprints(
+        site="TAC",
+    )    
+
+    # Based on loaded data in conftest.py,
+    # more than one footprint for TAC should be found (standard, time_resolved)
+    assert res_all.results.shape[0] > 1
+
+    # Check searching using the time_resolved keyword, finds only the time resolved footprint.
     res = search_footprints(
         site="TAC",
-        network="DECC",
-        height="100m",
-        domain="TEST",
-        model="NAME",
-        start_date="2014-07-01",
-        end_date="2014-08-01",
         time_resolved=True,
     )
 
-    # results dataframes should have exactly one row
+    # results dataframes should have exactly one row (only time resolved footprint)
     assert res.results.shape[0] == 1
 
     # check attributes
     metadata = res.retrieve().metadata
     assert metadata["time_resolved"] == "true"
+
+
+# def test_search
 
 
 def test_search_flux():

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -8,6 +8,7 @@ from openghg.retrieve import (
     search_footprints,
     search_surface,
 )
+from openghg.dataobjects import data_manager
 from pandas import Timestamp
 
 
@@ -382,6 +383,71 @@ def test_search_footprints_time_resolved():
     # check attributes
     metadata = res.retrieve().metadata
     assert metadata["time_resolved"] == "true"
+
+
+@pytest.fixture()
+def previous_htr_footprint_setup():
+    """
+    Mimic the previous setup when adding "high_time_resolution" (now
+    termed "time_resolved") footprints so this has the previous
+    high_time_resolution="true" key rather than the new time_resolved="true".
+    """
+    from helpers import get_footprint_datapath
+    from openghg.standardise import standardise_footprint
+
+    # Add high time resolution footprint
+    hitres_fp_datapath = get_footprint_datapath("TAC-185magl_UKV_co2_EUROPE_TEST_201405.nc")
+    standardise_footprint(
+        store="user",
+        filepath=hitres_fp_datapath,
+        site="TAC",
+        model="NAME",
+        network="DECC",
+        height="185m",
+        domain="TEST",
+        met_model="UKV",
+        time_resolved=True,
+    )
+
+    # Find this footprint and update the metadata
+    dm = data_manager(data_type="footprints", site="TAC", inlet="185m", time_resolved=True, store="user")
+    uuid = next(iter(dm.metadata))
+    
+    # Removed time_resolved key
+    to_delete = "time_resolved"
+    value = dm.metadata[uuid][to_delete]
+    dm.update_metadata(uuid=uuid, to_delete=to_delete)
+    
+    # Add high_time_resolution key
+    to_add = {"high_time_resolution": value}
+    dm.update_metadata(uuid=uuid, to_update=to_add)
+
+
+def test_search_high_time_resolution(previous_htr_footprint_setup):
+    """
+    Check backwards comptability for footprints added to an object store
+    prior to the use of time_resolved keyword in preference to
+    high_time_resolution.
+    """
+
+    # Check search for footprints returns multiple entries
+    res = search_footprints(
+        site="TAC",
+        inlet="185m",
+        high_time_resolution=True,
+    )    
+
+    # results dataframes find the footprint labeled as high_time_resolution
+    assert res.results.shape[0] == 1
+
+    # check attributes
+    metadata = res.retrieve().metadata
+    assert metadata["high_time_resolution"] == "true"
+
+    # Remove temporary datasource from the object store
+    dm = data_manager(data_type="footprints", site="TAC", inlet="185m", high_time_resolution=True, store="user")
+    uuid = next(iter(dm.metadata))
+    dm.delete_datasource(uuid=uuid)
 
 
 def test_search_flux():


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Updates to search to ensure backwards compatibility with object stores created prior to changes to keywords in PR #968 when retrieving time resolved footprints. Previous PR #968 was to improve the interface by introducing the new, and more accurate, `time_resolved` keyword in favour of `high_time_resolution` but for now we still need to be able retrieve appropriate footprints which are only labelled with `high_time_resolution` and NOT `time_resolved`.

These updates include:
 - Update to `openghg.retrieve.search` (actually `_base_search`) to allow dictionary inputs to be passed so that multiple options for keywords can be used (expands on current ability to do this with lists). This performs an OR search with the other keywords.
 - Update to `openghg.retrieve.search_footprints` to create an appropriate input for this with the two possible keywords
 - Tests to check both keywords and to mimic previous setup to ensure the footprint with the previous labeling can be retrieved

*Note: solution here is pretty rough and ready and test is a bit scrappy - happy for alternative suggestions for how to approach this but do want to get a fix in asap. See #989 for alternative considered to update in search interface (use a dataclass rather than a dict).*

* **Please check if the PR fulfills these requirements**

- [x] Closes #989
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
