### PR TITLE
Fix for mypy against latest version of rapidfuzz

### DIFF
--- a/openghg/util/_util.py
+++ b/openghg/util/_util.py
@@ -100,7 +100,8 @@ def site_code_finder(site_name: str) -> Optional[str]:
 
     inverted = _create_site_lookup_dict()
 
-    matches = process.extract(query=site_name, choices=inverted.keys())
+    # rapidfuzz 3.9.0 seemed to stop giving type details - ignoring for now.
+    matches = process.extract(query=site_name, choices=inverted.keys())  # type:ignore
     highest_score = matches[0][1]
 
     if highest_score < 90:
@@ -132,7 +133,8 @@ def find_matching_site(site_name: str, possible_sites: Dict) -> str:
 
     site_list = possible_sites.keys()
 
-    matches = process.extract(site_name, site_list)
+    # rapidfuzz 3.9.0 seemed to stop giving type details - ignoring for now.
+    matches = process.extract(site_name, site_list)  # type:ignore
 
     scores = [s for m, s, _ in matches]
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

With current version of the `rapidfuzz` external package (3.9.0) this has started failing the mypy type checking, causing  `openghg.util`to fail the checks. This change updates this to ignore the type coming from this package for now.

* **Please check if the PR fulfills these requirements**

- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

Checks not needed:
- ~Closes #xxxx (Replace xxxx with the Github issue number)~
- ~[Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature~
- ~Documentation and tutorials updated/added~
- ~Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
