### PR TITLE
Empty stores are now treated as zarr stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Problem where the zarr store check raised an error for empty stores, preventing new zarr stores from being created - [#PR 993](https://github.com/openghg/openghg/pull/993) 
+
 - Retrieval of level 1 data from the ICOS Carbon Portal now no longer tries to retrieve a large number of CSV files - [#PR 868](https://github.com/openghg/openghg/pull/868)
 - Added check for duplicate object store path being added under different store name, if detected raises `ValueError`. - [PR #742](https://github.com/openghg/openghg/pull/904)
 - Added check to verify if `obs` and `footprint` have overlapping time coordinates when creating a `ModelScenario` object, if not then raise `ValueError` - [PR #954](https://github.com/openghg/openghg/pull/954)

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -379,7 +379,8 @@ def _check_valid_store(store_path: Path) -> bool:
     store_dirs = list(data_dir.glob("*"))
     # Let's take the first data directory and see if there's a zarr folder in it
     if not store_dirs:
-        raise ObjectStoreError("No data found in the object store, please check the path and try again.")
+        logger.info(f"No data found in the object store {store_path}, so we are treating this empty store as a zarr store.")
+        return True
 
     store_data_dir = store_dirs[0]
 

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 import uuid
 import toml
 import shutil
-from openghg.types import ConfigFileError, ObjectStoreError
+from openghg.types import ConfigFileError
 
 logger = logging.getLogger("openghg.util")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -379,8 +379,10 @@ def _check_valid_store(store_path: Path) -> bool:
     store_dirs = list(data_dir.glob("*"))
     # Let's take the first data directory and see if there's a zarr folder in it
     if not store_dirs:
-        logger.info(f"No data found in the object store {store_path}, "
-                    "so we are treating this empty store as a zarr store.")
+        logger.info(
+            f"No data found in the object store {store_path}, "
+            "so we are treating this empty store as a zarr store."
+        )
         return True
 
     store_data_dir = store_dirs[0]

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -379,7 +379,8 @@ def _check_valid_store(store_path: Path) -> bool:
     store_dirs = list(data_dir.glob("*"))
     # Let's take the first data directory and see if there's a zarr folder in it
     if not store_dirs:
-        logger.info(f"No data found in the object store {store_path}, so we are treating this empty store as a zarr store.")
+        logger.info(f"No data found in the object store {store_path}, "
+                    "so we are treating this empty store as a zarr store.")
         return True
 
     store_data_dir = store_dirs[0]


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Previous if a store was empty, the code that checks if it is a zarr store raised an error because no data was found.

This update changes this to log an info item stating that the store is empty and we are treating it as a zarr store.

This fixes a bug that prevented a zarr store from being initialised.

* **Please check if the PR fulfills these requirements**

- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

