### PR TITLE
Fix to be able to retrieve non-sequential data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Problem where the zarr store check raised an error for empty stores, preventing new zarr stores from being created - [#PR 993](https://github.com/openghg/openghg/pull/993) 
-
 - Retrieval of level 1 data from the ICOS Carbon Portal now no longer tries to retrieve a large number of CSV files - [#PR 868](https://github.com/openghg/openghg/pull/868)
 - Added check for duplicate object store path being added under different store name, if detected raises `ValueError`. - [PR #742](https://github.com/openghg/openghg/pull/904)
 - Added check to verify if `obs` and `footprint` have overlapping time coordinates when creating a `ModelScenario` object, if not then raise `ValueError` - [PR #954](https://github.com/openghg/openghg/pull/954)
+- Added fix to make sure data could be returned within a date range when the data had been added non-sequentially to an object store - [PR #997](https://github.com/openghg/openghg/pull/997)
 
 ## [0.8.0] - 2024-03-19
 

--- a/openghg/dataobjects/_basedata.py
+++ b/openghg/dataobjects/_basedata.py
@@ -88,7 +88,8 @@ class _BaseData:
 
                 if self.data.time.size > 1:
                     start_date = start_date - Timedelta("1s")
-                    end_date = end_date - Timedelta("1s")  # TODO: May want to remove this as end_date is already calculated as time period - 1s, slice is also right exclusive
+                    # TODO: May want to consider this extra 1s subtraction as end_date on data has already has -1s applied.
+                    end_date = end_date - Timedelta("1s")
 
                     # TODO - I feel we should do this in a tider way
                     start_date = start_date.tz_localize(None)

--- a/tests/retrieve/conftest.py
+++ b/tests/retrieve/conftest.py
@@ -100,8 +100,9 @@ def data_read():
 
     # Emissions data - added consecutive data for 2012-2013
     # This will be seen as "yearly" data and each file only contains one time point.
-    test_datapath1 = get_flux_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
-    test_datapath2 = get_flux_datapath("co2-gpp-cardamom_EUROPE_2013.nc")
+    # Note: added out of order to check this can still be retrieved
+    test_datapath1 = get_flux_datapath("co2-gpp-cardamom_EUROPE_2013.nc")
+    test_datapath2 = get_flux_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
 
     species = "co2"
     source = "gpp-cardamom"

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -334,6 +334,18 @@ def test_get_flux():
     assert time[-1] == Timestamp("2013-01-01T00:00:00")
 
 
+def test_get_flux_range():
+    """Test data can be retrieved with a start and end date range when data is added non-sequentially (check conftest.py)"""
+    flux_data = get_flux(species="co2", source="gpp-cardamom", domain="europe", start_date="2012-01-01", end_date="2012-05-01")
+
+    flux = flux_data.data
+
+    # Check a single time value has been retrieved
+    time = flux["time"]
+    assert len(time) == 1
+    assert time[0] == Timestamp("2012-01-01T00:00:00")
+
+
 def test_get_flux_no_result():
     """Test sensible error message is being returned when no results are found
     with input keywords for get_flux function"""


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

If data is added non-sequentially, there is a bug where this cannot be retrieved when passing a time range as the data is not in time order by this point. This PR is a simple fix for this to always sort the data before slicing.

* **Please check if the PR fulfills these requirements**

- [x] Closes #996
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
