### PR TITLE
Move to use tmp_path instead of tmpdir

### DIFF
--- a/tests/util/test_user.py
+++ b/tests/util/test_user.py
@@ -8,14 +8,8 @@ from openghg.util import check_config, create_config, read_local_config
 
 
 @pytest.fixture
-def tmp_config_path(tmpdir):
-    return Path(tmpdir).joinpath("config_folder").joinpath("mock_config.conf")
-
-
-@pytest.fixture
-def tmp_home_path(tmpdir):
-    return Path(tmpdir).joinpath("tmp_home_path")
-
+def tmp_config_path(tmp_path):
+    return tmp_path.joinpath("config_folder").joinpath("mock_config.conf")
 
 @pytest.fixture
 def mock_get_user_config_path(tmp_config_path, mocker):
@@ -24,14 +18,14 @@ def mock_get_user_config_path(tmp_config_path, mocker):
 
 
 @pytest.fixture
-def write_mock_config(tmpdir, tmp_config_path):
+def write_mock_config(tmp_path, tmp_config_path):
     mock_uuid = "179dcd5f-d5bb-439d-a3c2-9f690ac6d3b8"
-    mock_path = Path(tmpdir).joinpath("mock_store")
-    mock_shared_path = Path(tmpdir).joinpath("mock_shared_store")
+    mock_path = tmp_path.joinpath("mock_store")
+    mock_shared_path = tmp_path.joinpath("mock_shared_store")
     mock_conf = {
         "object_store": {
-            "user": {"path": mock_path, "permissions": "rw"},
-            "shared": {"path": mock_shared_path, "permission": "rw"},
+            "user": {"path": str(mock_path), "permissions": "rw"},
+            "shared": {"path": str(mock_shared_path), "permission": "rw"},
         },
         "user_id": mock_uuid,
     }
@@ -81,9 +75,9 @@ def test_read_config_check_old_stores(
         read_local_config()
 
 
-def test_create_config(monkeypatch, mocker, tmpdir):
-    monkeypatch.setenv("HOME", str(tmpdir))
-    mock_config_path = Path(tmpdir).joinpath("mock_config.conf")
+def test_create_config(monkeypatch, mocker, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mock_config_path = tmp_path.joinpath("mock_config.conf")
 
     mocker.patch("openghg.util._user.get_user_config_path", return_value=mock_config_path)
     mock_uuids = [f"test-uuid-{x}" for x in range(100, 110)]
@@ -120,9 +114,9 @@ def test_create_config_migrate(mocker, monkeypatch, tmp_path, caplog):
     assert mock_new_config_path.read_text() == mock_config_content
 
 
-def test_check_config(mocker, caplog, monkeypatch, tmpdir):
-    monkeypatch.setenv("HOME", str(tmpdir))
-    mock_config_path = Path(tmpdir).joinpath("mock_config.conf")
+def test_check_config(mocker, caplog, monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mock_config_path = tmp_path.joinpath("mock_config.conf")
 
     mocker.patch("openghg.util._user.get_user_config_path", return_value=mock_config_path)
 
@@ -145,13 +139,13 @@ def test_check_config(mocker, caplog, monkeypatch, tmpdir):
     assert " /tmp/mock_store does not exist but will be created." in caplog.text
 
 
-def test_create_config_duplicates(monkeypatch, mocker, tmpdir, capsys):
+def test_create_config_duplicates(monkeypatch, mocker, tmp_path, capsys):
     """
     Test simulates input values submitted after invoking the create_config method. It verifies if the value error is raised for duplicate store names and store paths.
     """
 
-    monkeypatch.setenv("HOME", str(tmpdir))
-    mock_config_path = Path(tmpdir).joinpath("mock_config.conf")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mock_config_path = tmp_path.joinpath("mock_config.conf")
 
     mocker.patch("openghg.util._user.get_user_config_path", return_value=mock_config_path)
     mock_uuids = [f"test-uuid-{x}" for x in range(100, 110)]


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

I've noticed files being leftover by the tests using the `tmp_path` fixture. This was due to a `Path` being passed to the mock config instead of a string. This fixes that and moves the other tests in the file to use `tmp_path` instead of `tmppdir` to save some conversion to `Path` throughout the code.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1018
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

