### PR TITLE
Iss1031 missing footprint data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated incorrect import for data_manager within tutorial. This now shows the import from `openghg.dataobjects` not `openghg.store` - [PR #1007](https://github.com/openghg/openghg/pull/1007)
 
+- Issue causing missing data when standardising multiple files in a loop - [PR #1032](https://github.com/openghg/openghg/pull/1032)
+
 ### Added
 
 - Added ability to process CRF data as `flux_timeseries` datatype (one dimensional data) - [PR #870](https://github.com/openghg/openghg/pull/870)

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -160,7 +160,12 @@ class LocalZarrStore(Store):
                 dataset = dataset.chunk(chunking)
 
             dataset.to_zarr(
-                store=self._stores[version], mode="a", consolidated=True, append_dim=append_dim, compute=True
+                store=self._stores[version],
+                mode="a",
+                consolidated=True,
+                append_dim=append_dim,
+                compute=True,
+                synchronizer=zarr.ThreadSynchronizer(),
             )
         # Otherwise we create a new zarr Store for the version
         else:
@@ -170,7 +175,12 @@ class LocalZarrStore(Store):
             self._stores[version] = zarr.storage.DirectoryStore(self.store_path(version=version))
             encoding = get_zarr_encoding(data_vars=dataset.data_vars, filters=filters, compressor=compressor)
             dataset.to_zarr(
-                store=self._stores[version], mode="w", encoding=encoding, consolidated=True, compute=True
+                store=self._stores[version],
+                mode="w",
+                encoding=encoding,
+                consolidated=True,
+                compute=True,
+                synchronizer=zarr.ThreadSynchronizer(),
             )
 
     def get(self, version: str) -> xr.Dataset:

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -160,12 +160,7 @@ class LocalZarrStore(Store):
                 dataset = dataset.chunk(chunking)
 
             dataset.to_zarr(
-                store=self._stores[version],
-                mode="a",
-                consolidated=True,
-                append_dim=append_dim,
-                compute=True,
-                synchronizer=zarr.ThreadSynchronizer(),  # avoid race on multiple writes to same zarr chunk
+                store=self._stores[version], mode="a", consolidated=True, append_dim=append_dim, compute=True
             )
         # Otherwise we create a new zarr Store for the version
         else:
@@ -175,12 +170,7 @@ class LocalZarrStore(Store):
             self._stores[version] = zarr.storage.DirectoryStore(self.store_path(version=version))
             encoding = get_zarr_encoding(data_vars=dataset.data_vars, filters=filters, compressor=compressor)
             dataset.to_zarr(
-                store=self._stores[version],
-                mode="w",
-                encoding=encoding,
-                consolidated=True,
-                compute=True,
-                synchronizer=zarr.ThreadSynchronizer(),  # avoid race on multiple writes to same zarr chunk
+                store=self._stores[version], mode="w", encoding=encoding, consolidated=True, compute=True
             )
 
     def get(self, version: str) -> xr.Dataset:

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -160,7 +160,12 @@ class LocalZarrStore(Store):
                 dataset = dataset.chunk(chunking)
 
             dataset.to_zarr(
-                store=self._stores[version], mode="a", consolidated=True, append_dim=append_dim, compute=True
+                store=self._stores[version],
+                mode="a",
+                consolidated=True,
+                append_dim=append_dim,
+                compute=True,
+                synchronizer=zarr.ThreadSynchronizer(),  # avoid race on multiple writes to same zarr chunk
             )
         # Otherwise we create a new zarr Store for the version
         else:
@@ -170,7 +175,12 @@ class LocalZarrStore(Store):
             self._stores[version] = zarr.storage.DirectoryStore(self.store_path(version=version))
             encoding = get_zarr_encoding(data_vars=dataset.data_vars, filters=filters, compressor=compressor)
             dataset.to_zarr(
-                store=self._stores[version], mode="w", encoding=encoding, consolidated=True, compute=True
+                store=self._stores[version],
+                mode="w",
+                encoding=encoding,
+                consolidated=True,
+                compute=True,
+                synchronizer=zarr.ThreadSynchronizer(),  # avoid race on multiple writes to same zarr chunk
             )
 
     def get(self, version: str) -> xr.Dataset:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Added "synchronizer" to `to_zarr` calls to fix race condition, which was causing missing data to appear when standardising multiple files from a loop.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1031
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
