### PR TITLE
Pinned numpy to < 2.0

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,7 +41,6 @@ jobs:
           flake8 openghg/ --count --statistics
       - name: Install openghg
         run: |
-          pip install -r requirements.txt
           pip install -r requirements-dev.txt
           pip install .
       - name: Run mypy

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,6 +41,7 @@ jobs:
           flake8 openghg/ --count --statistics
       - name: Install openghg
         run: |
+          pip install -r requirements.txt
           pip install -r requirements-dev.txt
           pip install .
       - name: Run mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pinned numpy to < 2.0 and netcdf4 to <= 1.6.5. Numpy 2.0 release caused some minor bugs in OpenGHG, and netCDF4's updates to numpy 2.0 were also causing tests to fail - [PR #1043](https://github.com/openghg/openghg/pull/1043)
+
 - Updated incorrect import for data_manager within tutorial. This now shows the import from `openghg.dataobjects` not `openghg.store` - [PR #1007](https://github.com/openghg/openghg/pull/1007)
 
 - Issue causing missing data when standardising multiple files in a loop - [PR #1032](https://github.com/openghg/openghg/pull/1032)

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -13,10 +13,10 @@ dependencies:
   - filelock
   - matplotlib
   - msgpack-python
-  - netcdf4
+  - netcdf4<=1.6.5
   - nbformat
   - numexpr
-  - numpy
+  - numpy<2.0
   - nc-time-axis
   - openghg_defs
   - openpyxl

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
   - netcdf4
   - nbformat
   - numexpr
-  - numpy
+  - numpy<2.0
   - nc-time-axis
   - openghg_defs
   - openpyxl

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
   - filelock
   - matplotlib
   - msgpack-python
-  - netcdf4
+  - netcdf4<=1.6.5
   - nbformat
   - numexpr
   - numpy<2.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,7 +8,6 @@ dependencies:
   - python>=3.9
   - addict
   - dask
-  - h5py<3.11
   - h5netcdf
   - filelock
   - matplotlib

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,6 +8,7 @@ dependencies:
   - python>=3.9
   - addict
   - dask
+  - h5py<3.11
   - h5netcdf
   - filelock
   - matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ addict
 dask
 filelock
 h5netcdf
-h5py < 3.11
 icoscp
 ipywidgets
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ addict
 dask
 filelock
 h5netcdf
+h5py < 3.11
 icoscp
 ipywidgets
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ msgpack
 nbformat
 numcodecs
 nc-time-axis
-netcdf4
+netcdf4 <= 1.6.5
 numexpr
 numpy < 2.0
 openghg_defs

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ numcodecs
 nc-time-axis
 netcdf4
 numexpr
-numpy
+numpy < 2.0
 openghg_defs
 openpyxl
 pandas >= 2.0


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Numpy had a major release whle this PR was
in progress. We need to make changes to be
compatible with numpy 2.0.

We also need backwards compatibility with numpy 1.26 for a while because pymc/pytensor hasn't upgraded to numpy 2.0 yet, and openghg_inversions depends on openghg and pymc.

We have also pinned netCDF4 to versions <=1.6.5, since they seem to be having problems moving to numpy 2.0 (and our tests were failing with netCDF4 version 1.7.1).

* **Please check if the PR fulfills these requirements**

- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
