### PR TITLE
Add manual CI trigger for tests

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,7 +11,7 @@ on:
     branches: [master, devel]
     paths-ignore:
       - 'CHANGELOG.md'
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,6 +11,7 @@ on:
     branches: [master, devel]
     paths-ignore:
       - 'CHANGELOG.md'
+  workflow_dispatch
 
 jobs:
   test:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Adding a manual trigger for running the tests in the CI through GitHub Actions. When merged into the default branch this should provide an option on the Actions tab to run the tests on command rather than needing a push / PR action to do this.

*Note: it may not be this simple but until this is merged into the default branch we won't be able to check the Actions tab to see if this produces the correct behaviour. At the least though, this should be a small add on and doesn't impact other functionality making it a safe update.*

* **Please check if the PR fulfills these requirements**

- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

Not needed:
- ~Closes #xxxx (Replace xxxx with the Github issue number)~
- ~[Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature~
- ~Documentation and tutorials updated/added~
- ~Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
