### PR TITLE
Fixes for combine datasets (ported from openghg inversions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Typo and possible performance issue in `analysis._scenario.combine_datasets` - [PR #1047](https://github.com/openghg/openghg/pull/1047)
+
 - Pinned numpy to < 2.0 and netcdf4 to <= 1.6.5. Numpy 2.0 release caused some minor bugs in OpenGHG, and netCDF4's updates to numpy 2.0 were also causing tests to fail - [PR #1043](https://github.com/openghg/openghg/pull/1043)
 
 - Updated incorrect import for data_manager within tutorial. This now shows the import from `openghg.dataobjects` not `openghg.store` - [PR #1007](https://github.com/openghg/openghg/pull/1007)

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -1750,7 +1750,8 @@ def combine_datasets(
     if _indexes_match(dataset_A, dataset_B):
         dataset_B_temp = dataset_B
     else:
-        dataset_B_temp = dataset_B.reindex_like(dataset_A, method=method, tolerance=tolerance)
+        # load dataset_B to avoid performance issue (see xarray issue #8945)
+        dataset_B_temp = dataset_B.load().reindex_like(dataset_A, method=method, tolerance=tolerance)
 
     merged_ds = dataset_A.merge(dataset_B_temp)
 

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -1755,7 +1755,7 @@ def combine_datasets(
     merged_ds = dataset_A.merge(dataset_B_temp)
 
     if "fp" in merged_ds:
-        if all(k in merged_ds.fp.dims for k in ("lat", "long")):
+        if all(k in merged_ds.fp.dims for k in ("lat", "lon")):
             flag = np.where(np.isfinite(merged_ds.fp.mean(dim=["lat", "lon"]).values))
             merged_ds = merged_ds[dict(time=flag[0])]
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Two changes to `combine_datasets` in `analyse._scenario`:
1. fixed a typo: "long" changed to "lon"
2. loaded the second (usually smaller) dataset into memory before reindexing. This avoids a weird slow down noticed on inversions. This is documented in [xarray issue #8945](https://github.com/pydata/xarray/issues/8945).

* **Please check if the PR fulfills these requirements**

- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
