### PR TITLE
Removing repeated 'optional' key from eulerian_model input config file

### DIFF
--- a/openghg/data/config/objectstore/defaults.json
+++ b/openghg/data/config/objectstore/defaults.json
@@ -20,7 +20,6 @@
         "optional": {}
     },
     "eulerian_model": {
-        "optional": {},
         "required": {
             "model": {
                 "type": [


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Small update to defaults.json file to remove repeated "optional" key from the eulerian_model option.

* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

Probably not needed
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed:
- ~Closes #xxxx (Replace xxxx with the Github issue number)~
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~