### PR TITLE
added satellite processing steps to get_obs_column

### DIFF
--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -3,6 +3,9 @@ import logging
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Union
 from openghg.types import SearchError
+import logging
+
+logger = logging.getLogger("openghg.retrieve.access")
 
 from openghg.dataobjects import (
     BoundaryConditionsData,
@@ -511,7 +514,7 @@ def get_obs_column(
     )
 
     if max_level > max(obs_data.data.lev.values) + 1:
-        print(
+        logger.warning(
             f"passed max level is above max level in data ({max(obs_data.data.lev.values)+1}). Defaulting to highest level"
         )
         max_level = max(obs_data.data.lev.values) + 1
@@ -569,9 +572,11 @@ def get_obs_column(
         obs_data.data.mf.attrs["units"] = "1e-6"
         obs_data.data.attrs["species"] = "CO2"
 
-    obs_data.data.attrs["scale"] = "GOSAT"
+    # obs_data.data.attrs["scale"] = "GOSAT"
 
-    obs_data.metadata["transforms"] = "Applied mf transforms"
+    obs_data.metadata["transforms"] = (
+        f"For creating mole fraction, used apriori data for levels above max_level={max_level}"
+    )
 
     return ObsColumnData(data=obs_data.data, metadata=obs_data.metadata)
 

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -510,6 +510,12 @@ def get_obs_column(
         **kwargs,
     )
 
+    if max_level > max(obs_data.data.lev.values) + 1:
+        print(
+            f"passed max level is above max level in data ({max(obs_data.data.lev.values)+1}). Defaulting to highest level"
+        )
+        max_level = max(obs_data.data.lev.values) + 1
+
     ## processing taken from acrg/acrg/obs/read.py get_gosat()
     lower_levels = list(range(0, max_level))
 

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -468,6 +468,7 @@ def get_obs_surface_local(
 
 def get_obs_column(
     species: str,
+    max_level: int,
     satellite: Optional[str] = None,
     domain: Optional[str] = None,
     selection: Optional[str] = None,
@@ -508,6 +509,63 @@ def get_obs_column(
         data_type="column",
         **kwargs,
     )
+
+    ## processing taken from acrg/acrg/obs/read.py get_gosat()
+    lower_levels = list(range(0, max_level))
+
+    prior_factor = (
+        obs_data.data.pressure_weights[dict(lev=list(lower_levels))]
+        * (1.0 - obs_data.data.xch4_averaging_kernel[dict(lev=list(lower_levels))])
+        * obs_data.data.ch4_profile_apriori[dict(lev=list(lower_levels))]
+    ).sum(dim="lev")
+
+    upper_levels = list(range(max_level, len(obs_data.data.lev.values)))
+    prior_upper_level_factor = (
+        obs_data.data.pressure_weights[dict(lev=list(upper_levels))]
+        * obs_data.data.ch4_profile_apriori[dict(lev=list(upper_levels))]
+    ).sum(dim="lev")
+
+    obs_data.data["mf_prior_factor"] = prior_factor
+    obs_data.data["mf_prior_upper_level_factor"] = prior_upper_level_factor
+    obs_data.data["mf"] = (
+        obs_data.data.xch4 - obs_data.data.mf_prior_factor - obs_data.data.mf_prior_upper_level_factor
+    )
+    obs_data.data["mf_repeatability"] = obs_data.data.xch4_uncertainty
+
+    # rt17603: 06/04/2018 Added drop variables to ensure lev and id dimensions are also dropped, Causing problems in footprints_data_merge() function
+    drop_data_vars = [
+        "xch4",
+        "xch4_uncertainty",
+        "lon",
+        "lat",
+        "ch4_profile_apriori",
+        "xch4_averaging_kernel",
+        "pressure_levels",
+        "pressure_weights",
+        "exposure_id",
+    ]
+    drop_coords = ["lev", "id"]
+
+    for dv in drop_data_vars:
+        if dv in obs_data.data.data_vars:
+            obs_data.data = obs_data.data.drop(dv)
+    for coord in drop_coords:
+        if coord in obs_data.data.coords:
+            obs_data.data = obs_data.data.drop(coord)
+
+    obs_data.data = obs_data.data.sortby("time")
+
+    obs_data.data.attrs["max_level"] = max_level
+    if species.upper() == "CH4":
+        obs_data.data.mf.attrs["units"] = "1e-9"
+        obs_data.data.attrs["species"] = "CH4"
+    if species.upper() == "CO2":
+        obs_data.data.mf.attrs["units"] = "1e-6"
+        obs_data.data.attrs["species"] = "CO2"
+
+    obs_data.data.attrs["scale"] = "GOSAT"
+
+    obs_data.metadata["transforms"] = "Applied mf transforms"
 
     return ObsColumnData(data=obs_data.data, metadata=obs_data.metadata)
 

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -554,10 +554,10 @@ def get_obs_column(
 
     for dv in drop_data_vars:
         if dv in obs_data.data.data_vars:
-            obs_data.data = obs_data.data.drop(dv)
+            obs_data.data = obs_data.data.drop_vars(dv)
     for coord in drop_coords:
         if coord in obs_data.data.coords:
-            obs_data.data = obs_data.data.drop(coord)
+            obs_data.data = obs_data.data.drop_vars(coord)
 
     obs_data.data = obs_data.data.sortby("time")
 

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -566,10 +566,10 @@ def get_obs_column(
 
     obs_data.data.attrs["max_level"] = max_level
     if species.upper() == "CH4":
-        obs_data.data.mf.attrs["units"] = "1e-9"
+        # obs_data.data.mf.attrs["units"] = "1e-9"
         obs_data.data.attrs["species"] = "CH4"
     if species.upper() == "CO2":
-        obs_data.data.mf.attrs["units"] = "1e-6"
+        # obs_data.data.mf.attrs["units"] = "1e-6"
         obs_data.data.attrs["species"] = "CO2"
 
     # obs_data.data.attrs["scale"] = "GOSAT"

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -307,14 +307,23 @@ def test_get_obs_surface_cloud(mocker, monkeypatch):
 
 
 def test_get_obs_column():
-    column_data = get_obs_column(species="ch4", satellite="gosat")
+    column_data = get_obs_column(species="ch4", satellite="gosat", max_level=10)
 
     obscolumn = column_data.data
 
-    assert "xch4" in obscolumn
+    assert "mf" in obscolumn
+    assert "mf_prior_factor" in obscolumn
+    assert "mf_prior_upper_level_factor" in obscolumn
+    assert "mf_repeatability" in obscolumn
+
     assert obscolumn.time[0] == Timestamp("2017-03-18T15:32:54")
-    assert np.isclose(obscolumn["xch4"][0], 1844.2019)
-    assert obscolumn.attrs["species"] == "ch4"
+    assert np.isclose(obscolumn["mf"][0], 1238.2743)
+    assert obscolumn.attrs["species"] == "CH4"
+
+
+    # test max level defaults to highest if out of range
+    column_data = get_obs_column(species="ch4", satellite="gosat", max_level=100)
+
 
 
 def test_get_flux():

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -320,9 +320,12 @@ def test_get_obs_column():
     assert np.isclose(obscolumn["mf"][0], 1238.2743)
     assert obscolumn.attrs["species"] == "CH4"
 
-
-    # test max level defaults to highest if out of range
+def test_get_obs_column_max_level():
+    # test max level defaults to highest available if out of range
     column_data = get_obs_column(species="ch4", satellite="gosat", max_level=100)
+    obscolumn = column_data.data
+    assert np.isclose(obscolumn["mf"][0], 1818.2135)
+
 
 
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Added logic from acrg get_gosat code, implemented within the get_obs_function. get_obs_function now retrieves standardised satellite data from a store and processes it to obtain mf_prior_factor, mf_prior_upper_level_factor, mf and mf_repeatability, based on required parameter max_level. If passed max_level is above available max level, it reverts to available max level

* **Please check if the PR fulfills these requirements**

- [x] Solves one of the checkboxes on #987 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed] Updated test_get_obs_column test
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
