### PR TITLE
Adding CHANGELOG.md update for PR #1050 on updates to get_obs_column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A new object store config file to allow customisation of metadata keys used to store data in unique Datasources - [PR #983](https://github.com/openghg/openghg/pull/983)
 
+### Updated
+
+- Updated `get_obs_column` to output mole fraction details. This involves using the apriori level data above a maximum level and applying a correction to the column data (aligned with this process within [acrg code](https://github.com/ACRG-Bristol/acrg)) [PR #1050](https://github.com/openghg/openghg/pull/1050)
+
 ## [0.8.2] - 2024-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
-- Updated `get_obs_column` to output mole fraction details. This involves using the apriori level data above a maximum level and applying a correction to the column data (aligned with this process within [acrg code](https://github.com/ACRG-Bristol/acrg)) [PR #1050](https://github.com/openghg/openghg/pull/1050)
+- Updated `get_obs_column` to output mole fraction details. This involves using the apriori level data above a maximum level and applying a correction to the column data (aligned with this process within [acrg code](https://github.com/ACRG-Bristol/acrg)). [PR #1050](https://github.com/openghg/openghg/pull/1050)
 
 ## [0.8.2] - 2024-06-06
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This adds a quick CHANGELOG.md entry for the changes made in PR #1050. This updated the `get_obs_column` function to include previous changes from the acrg repository (see PR details).

* **Please check if the PR fulfills these requirements**

- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature