### PR TITLE
Changed how "inlet" is parsed by search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Formatting of `inlet` in search, so that float values of inlet can be retrieved - [PR #1057](https://github.com/openghg/openghg/pull/1057)
+- Formatting of `inlet` (and related keys) in search, so that float values of inlet can be retrieved - [PR #1057](https://github.com/openghg/openghg/pull/1057)
 
 - Test for zarr compression `test_bytes_stored_compression` that was failing due to a slight mismatch between actual and expected values. The test now uses a bound on relative error - [PR #1065](https://github.com/openghg/openghg/pull/1065)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Formatting of `inlet` in search, so that float values of inlet can be retrieved - [PR #1057](https://github.com/openghg/openghg/pull/1057)
+
 - Typo and possible performance issue in `analysis._scenario.combine_datasets` - [PR #1047](https://github.com/openghg/openghg/pull/1047)
 
 - Pinned numpy to < 2.0 and netcdf4 to <= 1.6.5. Numpy 2.0 release caused some minor bugs in OpenGHG, and netCDF4's updates to numpy 2.0 were also causing tests to fail - [PR #1043](https://github.com/openghg/openghg/pull/1043)

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -474,6 +474,7 @@ def _base_search(**kwargs: Any) -> SearchResults:
     from openghg.util import (
         clean_string,
         dates_overlap,
+        format_inlet,
         synonyms,
         timestamp_epoch,
         timestamp_now,
@@ -491,7 +492,9 @@ def _base_search(**kwargs: Any) -> SearchResults:
     # - clean search terms directly or within data structures
     search_kwargs = {}
     for k, v in kwargs.items():
-        if isinstance(v, (list, tuple)):
+        if k.lower() in ["inlet", "height"]:
+            v = format_inlet(v)
+        elif isinstance(v, (list, tuple)):
             v = [clean_string(value) for value in v if value is not None]
             if not v:  # Check empty list
                 v = None

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -492,7 +492,7 @@ def _base_search(**kwargs: Any) -> SearchResults:
     # - clean search terms directly or within data structures
     search_kwargs = {}
     for k, v in kwargs.items():
-        if k.lower() in ["inlet", "height"]:
+        if k.lower() in ["inlet", "height", "inlet_height_magl", "station_height_masl"]:
             v = format_inlet(v)
         elif isinstance(v, (list, tuple)):
             v = [clean_string(value) for value in v if value is not None]

--- a/openghg/util/_inlet.py
+++ b/openghg/util/_inlet.py
@@ -75,6 +75,8 @@ def format_inlet(
             "10m"
         >>> format_inlet("10.111")
             "10.1m"
+        >>> format_inlet(["10", 100])
+            ["10m", "100m"]
         >>> format_inlet("multiple")
             "multiple"
         >>> format_inlet("10m", key_name="inlet")

--- a/openghg/util/_inlet.py
+++ b/openghg/util/_inlet.py
@@ -26,12 +26,21 @@ def format_inlet(
 ) -> None: ...
 
 
+@overload
 def format_inlet(
-    inlet: Optional[str],
+    inlet: list[Optional[str]],
     units: str = "m",
     key_name: Optional[str] = None,
     special_keywords: Optional[list] = None,
-) -> Optional[str]:
+) -> list[Optional[str]]: ...
+
+
+def format_inlet(
+    inlet: Union[Optional[str], list[Optional[str]]],
+    units: str = "m",
+    key_name: Optional[str] = None,
+    special_keywords: Optional[list] = None,
+) -> Union[Optional[str], list[Optional[str]]]:
     """
     Make sure inlet / height name conforms to standard. The standard
     imposed can depend on the associated key_name itself (can
@@ -75,6 +84,9 @@ def format_inlet(
         >>> format_inlet("10m", key_name="station_height_masl")
             "10"
     """
+    if isinstance(inlet, list):
+        return [format_inlet(x) for x in inlet]
+
     if inlet is None:
         return None
 

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -13,8 +13,6 @@ from openghg.retrieve import (
 from openghg.dataobjects import data_manager
 from pandas import Timestamp
 
-from tests.helpers.helpers import clear_test_stores
-
 
 @pytest.mark.parametrize(
     "inlet_keyword,inlet_value",


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

- "inlet" and "height" now go through "format_inlet", but not "clean_string" when passed to `search`
- modified `format_inlet` to accept a list

* **Please check if the PR fulfills these requirements**

- [x] Closes #1056 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature  -- existing tests pass, new tests should be added to PR #912 
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
