### PR TITLE
Updated compressed bytes test to use rel error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Test for zarr compression `test_bytes_stored_compression` that was failing due to a slightly mismatched between actual and expected values. The test now uses a bound on relative error - [PR #1065](https://github.com/openghg/openghg/pull/1065)
+
 - Typo and possible performance issue in `analysis._scenario.combine_datasets` - [PR #1047](https://github.com/openghg/openghg/pull/1047)
 
 - Pinned numpy to < 2.0 and netcdf4 to <= 1.6.5. Numpy 2.0 release caused some minor bugs in OpenGHG, and netCDF4's updates to numpy 2.0 were also causing tests to fail - [PR #1043](https://github.com/openghg/openghg/pull/1043)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Test for zarr compression `test_bytes_stored_compression` that was failing due to a slightly mismatched between actual and expected values. The test now uses a bound on relative error - [PR #1065](https://github.com/openghg/openghg/pull/1065)
+- Test for zarr compression `test_bytes_stored_compression` that was failing due to a slight mismatch between actual and expected values. The test now uses a bound on relative error - [PR #1065](https://github.com/openghg/openghg/pull/1065)
 
 - Typo and possible performance issue in `analysis._scenario.combine_datasets` - [PR #1047](https://github.com/openghg/openghg/pull/1047)
 

--- a/tests/store/storage/test_localzarrstore.py
+++ b/tests/store/storage/test_localzarrstore.py
@@ -131,7 +131,7 @@ def test_bytes_stored_compression(store):
     with xr.open_dataset(datapath) as ds:
         store.add(version="v1", dataset=ds, compressor=compressor)
         compressed_bytes = store.bytes_stored()
-        assert compressed_bytes == 292896
+        assert np.abs((compressed_bytes - 292896) / 292896) < 0.01
         assert compressed_bytes < original_size
         assert compressed_bytes < uncompressed_bytes
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)**

Updated compressed bytes test to use relative error instead of checking that the compressed bytes exactly equals the expected value.

The number of compressed bytes seems to vary slightly sometimes (possibly due to changes in dependencies).




* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
