### PR TITLE
Tidy up required keys around data_source and dataset_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code to combine multiple data objects - [PR #1063](https://github.com/openghg/openghg/pull/1063)
 - A new object store config file to allow customisation of metadata keys used to store data in unique Datasources - [PR #983](https://github.com/openghg/openghg/pull/983)
 - New keywords `data_level` and `data_sublevel` as additional keys which can be used to distinguish observation surface data - [PR #1051](https://github.com/openghg/openghg/pull/1051)
+- The `dataset_source` keyword previously used for retrieved data is now available when using `standardise_surface`. This allow an origin key for the dataset to be included e.g. "InGOS", "European ObsPack". [PR #1083](https://github.com/openghg/openghg/pull/1083)
 - Footprint parser for "paris" footprint format which includes the new format used for both the NAME and FLEXPART LPDM models - [PR #1070](https://github.com/openghg/openghg/pull/1070)
 
 ### Updated
 
 - Updated `base` to `offset` in `resample` due to xarray deprecation. [PR #1073](https://github.com/openghg/openghg/pull/1073)
 - Updated `get_obs_column` to output mole fraction details. This involves using the apriori level data above a maximum level and applying a correction to the column data (aligned with this process within [acrg code](https://github.com/ACRG-Bristol/acrg)). [PR #1050](https://github.com/openghg/openghg/pull/1050)
-
+- The `data_source` keyword is now included as "internal" when using `standardise_surface` to distinguish this from data retrieved from external sources (e.g. "icos", "noaa_obspack"). [PR #1083](https://github.com/openghg/openghg/pull/1083)
+ 
 ## [0.8.2] - 2024-06-06
 
 ### Fixed

--- a/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
+++ b/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
@@ -49,7 +49,9 @@ including data from the AGAGE, DECC, NOAA, LondonGHG, BEAC2ON networks.
 The process of adding data to the object store is called *standardisation*.
 
 To standardise a new data file, you must specify the *source format* and
-other details about the data.
+other keywords for the data. Which keywords need to be specified may be dependent
+on the source format itself as some details can be inferred from the data or may
+not be relevant.
 For the full list of accepted observation inputs and source formats, call
 the function ``summary_source_formats``:
 
@@ -107,8 +109,8 @@ following arguments:
 
 * ``filepaths``: list of paths to ``.dat`` files
 * ``site``:  ``"TAC"``, the site code for Tacolneston
-* ``source_format``: ``"CRDS"``, the type of data we want to process
 * ``network``: ``"DECC"``
+* ``source_format``: ``"CRDS"``, the type of data we want to process
 
 .. ipython::
 
@@ -125,7 +127,8 @@ following arguments:
 
 
 This extracts the data and metadata from the files,
-standardises them, and adds them to our object store.
+standardises them, and adds them to our object store. The keywords of ``site`` and ``network``,
+along with details extracted from the data itself allow us to uniquely store the data.
 
 The returned ``decc_results`` dictionary shows how the data
 has been stored: each file has been split into several entries, each with a unique ID (UUID).
@@ -135,6 +138,20 @@ The ``decc_results`` output includes details of the processed data and tells
 us that the data has been stored correctly. This will also tell us if
 any errors have been encountered when trying to access and standardise
 this data.
+
+Other keywords
+~~~~~~~~~~~~~~
+
+When adding data in this way there are other keywords which can be used to 
+distinguish between different data sets as required including:
+
+* ``instrument``: Name of the instrument
+* ``sampling_period``: The time taken for each measurement to be sampled
+* ``data_level``: The level of quality control which has been applied to the data.
+* ``data_sublevel``:  Optional level to include between data levels. Typically for level 1 data where multiple steps of initial QA may have been applied.
+* ``dataset_source``: Name of the dataset if data is taken from a larger source e.g. from an ObsPack
+
+See the `standardise_surface` documentation for a full list of inputs.
 
 Multiple stores
 ~~~~~~~~~~~~~~~
@@ -188,9 +205,9 @@ data by including the right arguments:
 
 * ``filepaths``: tuple (or list of tuples) with paths to data and precision files
 * ``site`` (site code): ``"CGO"``
-* ``source_format`` (data type): ``"GCWERKS"``
 * ``network``: ``"AGAGE"``
 * ``instrument``: ``"medusa"``
+* ``source_format`` (data type): ``"GCWERKS"``
 
 .. code:: ipython3
 
@@ -222,6 +239,10 @@ file
 
 
 .. _note-on-datasources:
+
+
+
+
 
 Note on Datasources
 ^^^^^^^^^^^^^^^^^^^

--- a/openghg/data/config/objectstore/defaults.json
+++ b/openghg/data/config/objectstore/defaults.json
@@ -239,22 +239,27 @@
                     "str"
                 ]
             },
-            "data_source": {
-                "type": [
-                    "str"
-                ]
-            },
-            "icos_data_level": {
-                "type": [
-                    "str"
-                ]
-            },
             "data_level": {
                 "type": [
                     "str"
                 ]
             },
             "data_sublevel": {
+                "type": [
+                    "str"
+                ]
+            },
+            "dataset_source": {
+                "type": [
+                    "str"
+                ]                
+            },
+            "data_source": {
+                "type": [
+                    "str"
+                ]
+            },
+            "icos_data_level": {
                 "type": [
                     "str"
                 ]

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -263,15 +263,15 @@ def search_surface(
     instrument: Union[str, list[str], None] = None,
     data_level: Union[str, list[str], None] = None,
     data_sublevel: Union[str, list[str], None] = None,
+    dataset_source: Optional[str] = None,
+    data_source: Optional[str] = None,
     measurement_type: Union[str, list[str], None] = None,
     source_format: Union[str, list[str], None] = None,
     network: Union[str, list[str], None] = None,
     start_date: Union[str, list[str], None] = None,
     end_date: Union[str, list[str], None] = None,
-    data_source: Optional[str] = None,
     sampling_height: Optional[str] = None,
     icos_data_level: Optional[int] = None,
-    dataset_source: Optional[str] = None,
     **kwargs: Any,
 ) -> SearchResults:
     """Cloud object store search.
@@ -285,16 +285,18 @@ def search_surface(
         data_level: Data quality assurance level (0-3)
         data_sublevel: Typically used for "L1" data depending on different QA
             performed before data is finalised.
+        data_source: Where data was retrieved from (used especially when retrieved from external archives)
+            e.g. "internal", "noaa_obspack", "icoscp", "ceda_archive". This
+            argument only needs to be used to narrow the search to data solely from retrieval methods.
+        dataset_source: External name applied to source of the dataset,
+            for example "ICOS", "InGOS", "European ObsPack", "CEDA 2023.06"
         measurement_type: Measurement type
         data_type: Data type e.g. "surface", "column", "flux"
             See openghg.store.spec.define_data_types() for full details.
         start_date: Start date
         end_date: End date
-        data_source: Source of data, e.g. noaa_obspack, icoscp, ceda_archive. This
-        argument only needs to be used to narrow the search to data solely from these sources.
         sampling_height: Sampling height of measurements
         icos_data_level: ICOS data level, see ICOS documentation
-        dataset_source: For ICOS data only: dataset source name, for example ICOS, InGOS, European ObsPack
         kwargs: Additional search terms
     Returns:
         SearchResults: SearchResults object
@@ -325,16 +327,16 @@ def search_surface(
         instrument=instrument,
         data_level=data_level,
         data_sublevel=data_sublevel,
+        data_source=data_source,
+        dataset_source=dataset_source,
         measurement_type=measurement_type,
         data_type="surface",
         source_format=source_format,
         start_date=start_date,
         end_date=end_date,
-        data_source=data_source,
         network=network,
         sampling_height=sampling_height,
         icos_data_level=icos_data_level,
-        dataset_source=dataset_source,
         **kwargs,
     )
 

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -63,6 +63,7 @@ def standardise_surface(
     instrument: Optional[str] = None,
     data_level: Optional[str] = None,
     data_sublevel: Optional[str] = None,
+    dataset_source: Optional[str] = None,
     sampling_period: Optional[Union[Timedelta, str]] = None,
     calibration_scale: Optional[str] = None,
     measurement_type: str = "insitu",
@@ -100,6 +101,7 @@ def standardise_surface(
                 - "3": elaborated data products using the data
         data_sublevel: Typically used for "L1" data depending on different QA performed
             before data is finalised.
+        dataset_source: Dataset source name, for example "ICOS", "InGOS", "European ObsPack", "CEDA 2023.06".
         sampling_period: Sampling period as pandas time code, e.g. 1m for 1 minute, 1h for 1 hour
         calibration_scale: Calibration scale for data
         measurement_type: Type of measurement e.g. insitu, flask
@@ -241,6 +243,7 @@ def standardise_surface(
             instrument=instrument,
             data_level=data_level,
             data_sublevel=data_sublevel,
+            dataset_source=dataset_source,
             sampling_period=sampling_period,
             calibration_scale=calibration_scale,
             measurement_type=measurement_type,

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -113,6 +113,7 @@ class ObsSurface(BaseStore):
         instrument: Optional[str] = None,
         data_level: Optional[str] = None,
         data_sublevel: Optional[str] = None,
+        dataset_source: Optional[str] = None,
         sampling_period: Optional[Union[Timedelta, str]] = None,
         calibration_scale: Optional[str] = None,
         measurement_type: str = "insitu",
@@ -152,6 +153,7 @@ class ObsSurface(BaseStore):
                 - "3": elaborated data products using the data
         data_sublevel: Can be used to sub-categorise data (typically "L1") depending on different QA performed
             before data is finalised.
+        dataset_source: Dataset source name, for example "ICOS", "InGOS", "European ObsPack", "CEDA 2023.06"
         sampling_period: Sampling period in pandas style (e.g. 2H for 2 hour period, 2m for 2 minute period).
             measurement_type: Type of measurement e.g. insitu, flask
             verify_site_code: Verify the site code
@@ -237,14 +239,18 @@ class ObsSurface(BaseStore):
 
         data_level = check_and_set_null_variable(data_level)
         data_sublevel = check_and_set_null_variable(data_sublevel)
+        dataset_source = check_and_set_null_variable(dataset_source)
 
         data_level = clean_string(data_level)
         data_sublevel = clean_string(data_sublevel)
+        dataset_source = clean_string(dataset_source)
 
         # Define additional metadata which we aren't passing (are never passing?) to the parse functions
         # TODO: May actually want to include more dynamic checks of this - whatever is needed but not passed to parse?
         # - how are we determining "whatever is needed" at the moment? Presumably set by the config file - may even be the get_lookup_keys (or need some variant on this)?
-        additional_metadata = {"data_level": data_level, "data_sublevel": data_sublevel}
+        additional_metadata = {"data_level": data_level,
+                               "data_sublevel": data_sublevel,
+                               "dataset_source": dataset_source}
 
         # Check if alias `height` is included instead of `inlet`
         if inlet is None and height is not None:

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -245,12 +245,17 @@ class ObsSurface(BaseStore):
         data_sublevel = clean_string(data_sublevel)
         dataset_source = clean_string(dataset_source)
 
+        # Would like to rename `data_source` to `retrieved_from` but
+        # currently trying to match with keys added from retrieve_atmospheric (ICOS) - Issue #654
+        data_source = "internal"  
+
         # Define additional metadata which we aren't passing (are never passing?) to the parse functions
         # TODO: May actually want to include more dynamic checks of this - whatever is needed but not passed to parse?
         # - how are we determining "whatever is needed" at the moment? Presumably set by the config file - may even be the get_lookup_keys (or need some variant on this)?
         additional_metadata = {"data_level": data_level,
                                "data_sublevel": data_sublevel,
-                               "dataset_source": dataset_source}
+                               "dataset_source": dataset_source,
+                               "data_source": data_source}
 
         # Check if alias `height` is included instead of `inlet`
         if inlet is None and height is not None:

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -247,15 +247,17 @@ class ObsSurface(BaseStore):
 
         # Would like to rename `data_source` to `retrieved_from` but
         # currently trying to match with keys added from retrieve_atmospheric (ICOS) - Issue #654
-        data_source = "internal"  
+        data_source = "internal"
 
         # Define additional metadata which we aren't passing (are never passing?) to the parse functions
         # TODO: May actually want to include more dynamic checks of this - whatever is needed but not passed to parse?
         # - how are we determining "whatever is needed" at the moment? Presumably set by the config file - may even be the get_lookup_keys (or need some variant on this)?
-        additional_metadata = {"data_level": data_level,
-                               "data_sublevel": data_sublevel,
-                               "dataset_source": dataset_source,
-                               "data_source": data_source}
+        additional_metadata = {
+            "data_level": data_level,
+            "data_sublevel": data_sublevel,
+            "dataset_source": dataset_source,
+            "data_source": data_source,
+        }
 
         # Check if alias `height` is included instead of `inlet`
         if inlet is None and height is not None:

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -103,6 +103,26 @@ def test_search_surface_range():
 
     assert res.metadata[key].items() >= partial_metdata.items()
 
+@pytest.mark.parametrize(
+    "keyword,value", [
+        ("data_type", "surface"),
+        ("data_source", "internal"),
+    ],
+)
+def test_search_internal_key_present(keyword, value):
+    """
+    Check keys which weren't specified in standardise function have been
+    added correctly to the metadata.
+    Currently testing for search_surface but could expand to other data_types.
+    """
+
+    res = search_surface(site="hfd", inlet="50m", species="co2")
+    key = next(iter(res.metadata))
+    metadata = res.metadata[key]
+
+    assert keyword in metadata
+    assert metadata[keyword] == value
+
 
 def test_search_site():
     res = search(site="bsd", species="co2", inlet="42m")

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -18,7 +18,7 @@ from openghg.retrieve import get_obs_surface, search_surface
 from openghg.standardise import standardise_from_binary_data, standardise_surface
 from openghg.store import ObsSurface
 from openghg.store.base import Datasource
-from openghg.util import create_daterange_str
+from openghg.util import create_daterange_str, clean_string
 from pandas import Timestamp
 
 
@@ -932,6 +932,7 @@ def test_drop_only_correct_nan():
     [
         ("data_level", "1", "2"),
         ("data_sublevel", "1.1", "1.2"),
+        ("dataset_source", "InGOS", "European ObsPack"),
     ],
 )
 def test_obs_data_param_split(data_keyword, data_value_1, data_value_2):
@@ -963,8 +964,10 @@ def test_obs_data_param_split(data_keyword, data_value_1, data_value_2):
     tac_1 = get_obs_surface(site="tac", species="co2", **data_labels_1)
     tac_2 = get_obs_surface(site="tac", species="co2", **data_labels_2)
 
-    assert tac_1.metadata[data_keyword] == data_value_1.lower()
-    assert tac_2.metadata[data_keyword] == data_value_2.lower()
+    # assert tac_1.metadata[data_keyword] == data_value_1.lower()
+    # assert tac_2.metadata[data_keyword] == data_value_2.lower()
+    assert tac_1.metadata[data_keyword] == clean_string(data_value_1)
+    assert tac_2.metadata[data_keyword] == clean_string(data_value_2)
 
     # All values within "tac_co2_openghg_dummy-ones.nc" have been set to a value of 1, so check
     # this data has been retrieved.


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

We want to ensure that obs surface data being added can be distinguished by the source of the data. Within retrieved data (which follows a different path to standardise) there are additional keywords including: `data_source` (e.g. "icos", "ceda") and `dataset_source` ("InGOS", "European ObsPack") which it would be useful to have available more generally.

This PR formalises this to allow `dataset_source` to be specified by the user and `data_source` to be set to "internal" when using the `standardise_surface` interface. These keys are part of the set used to distinguish between different stored Datasources.

*Note: Would like `data_source` to be renamed to `retrieved_from` but kept this the same as ICOS (retrieve_atmospheric) for the moment - happy to change this if we can make sure this is backwards compatible.*

* **Please check if the PR fulfills these requirements**

- [x] Closes #654 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Documentation and tutorials updated/added

Not needed:
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
