### PR TITLE
Streamlining keywords within surface required config definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code to combine multiple data objects - [PR #1063](https://github.com/openghg/openghg/pull/1063)
 - A new object store config file to allow customisation of metadata keys used to store data in unique Datasources - [PR #983](https://github.com/openghg/openghg/pull/983)
 - New keywords `data_level` and `data_sublevel` as additional keys which can be used to distinguish observation surface data - [PR #1051](https://github.com/openghg/openghg/pull/1051)
-- The `dataset_source` keyword previously used for retrieved data is now available when using `standardise_surface`. This allow an origin key for the dataset to be included e.g. "InGOS", "European ObsPack". [PR #1083](https://github.com/openghg/openghg/pull/1083)
+- The `dataset_source` keyword previously only used for retrieved data is now available when using `standardise_surface` as well. This allows an origin key for the dataset to be included e.g. "InGOS", "European ObsPack". [PR #1083](https://github.com/openghg/openghg/pull/1083)
 - Footprint parser for "paris" footprint format which includes the new format used for both the NAME and FLEXPART LPDM models - [PR #1070](https://github.com/openghg/openghg/pull/1070)
 
 ### Updated
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `get_obs_column` to output mole fraction details. This involves using the apriori level data above a maximum level and applying a correction to the column data (aligned with this process within [acrg code](https://github.com/ACRG-Bristol/acrg)). [PR #1050](https://github.com/openghg/openghg/pull/1050)
 - The `data_source` keyword is now included as "internal" when using `standardise_surface` to distinguish this from data retrieved from external sources (e.g. "icos", "noaa_obspack"). [PR #1083](https://github.com/openghg/openghg/pull/1083)
 - Added interactive timeseries plots in Search and Plotting tutorial. - [PR #953](https://github.com/openghg/openghg/pull/953) 
+- Removing 'station_long_name' and 'data_type' as required keys from the metadata config file as these do not need to be used as keys to distinguish datasources when adding new data. [PR #1088](https://github.com/openghg/openghg/pull/1088)
 
 ## [0.8.2] - 2024-06-06
 

--- a/openghg/data/config/objectstore/defaults.json
+++ b/openghg/data/config/objectstore/defaults.json
@@ -214,11 +214,6 @@
                     "str"
                 ]
             },
-            "station_long_name": {
-                "type": [
-                    "str"
-                ]
-            },
             "inlet": {
                 "type": [
                     "str"
@@ -260,11 +255,6 @@
                 ]
             },
             "icos_data_level": {
-                "type": [
-                    "str"
-                ]
-            },
-            "data_type": {
                 "type": [
                     "str"
                 ]


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The required keys within the config file should be a mapping onto keys which are used to distinguish datasources within the object store. This is used as part of the data lookup steps when adding new data so we know whether to add data to an existing datasource or to create a new datasource.

This PR removes some additional keywords from the config file which do not need to be used as these distinguishing keys. The keywords removed are:
 - `station_long_name` - the `site` code should cover the same purpose and, in general, the same site code should have the same `station_long_name`
 - `data_type` - the datasources are already split by `data_type` as part of the structure of the object store so this does not need to be used as a distinguishing key. This is also not included as a required key for any of the other data types than surface.
 
Within Issue #1035 we have started to outline the plans for how metadata is used when adding new data. This PR is also a step towards being able to apply the changes within PR #1069 which relies on the above logic to start to generalise this workflow.

* **Please check if the PR fulfills these requirements**

- [x] Related to #1071 but does not close this
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
