### PR TITLE
Fix for failing footprint chunk test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `data_source` keyword is now included as "internal" when using `standardise_surface` to distinguish this from data retrieved from external sources (e.g. "icos", "noaa_obspack"). [PR #1083](https://github.com/openghg/openghg/pull/1083)
 - Added interactive timeseries plots in Search and Plotting tutorial. - [PR #953](https://github.com/openghg/openghg/pull/953) 
 - Pinned the `icoscp` version within requirements to 0.1.17 based on new authentication requirements. [PR #1084](https://github.com/openghg/openghg/pull/1084)
+- The sort flag can now be passed via the SearchResults.retrieve interfaces to choose whether the data is returned sorted along the time axis. [PR #1090](https://github.com/openghg/openghg/pull/1090)
+
+### Fixed
+
+- Bug in test when checking customised chunks were stored correctly in the zarr store. dask v2024.8 now changed the chunk shape after this was sorted was test was updated to ensure this didn't sort when retrieving the data. [PR #1090](https://github.com/openghg/openghg/pull/1090)
 
 ## [0.8.2] - 2024-06-06
 

--- a/openghg/dataobjects/_basedata.py
+++ b/openghg/dataobjects/_basedata.py
@@ -37,7 +37,7 @@ class _BaseData:
             version: Version of data requested from Datasource
             start_date: Start date of data to retrieve
             end_date: End date of data to retrieve
-            sort: Sort the resulting Dataset by the time dimension, defaults to False
+            sort: Sort the resulting Dataset by the time dimension, defaults to True
             elevate_inlet: Force the elevation of the inlet attribute
             attrs_to_check: Attributes to check for duplicates. If duplicates are present
                 a new data variable will be created containing the values from each dataset
@@ -83,6 +83,11 @@ class _BaseData:
             self.data = self._zarrstore.get(version=version)
             if slice_time:
                 # If slicing by time, this must be sorted along the time dimension
+                if sort is False:
+                    logger.warning(
+                        "Ignoring sort={sort} input as it is necessary to sort the data when extracting a start and end date range."
+                    )
+
                 self.data = self.data.sortby("time")
                 sorted = True
 

--- a/openghg/dataobjects/_basedata.py
+++ b/openghg/dataobjects/_basedata.py
@@ -85,7 +85,7 @@ class _BaseData:
                 # If slicing by time, this must be sorted along the time dimension
                 if sort is False:
                     logger.warning(
-                        "Ignoring sort={sort} input as it is necessary to sort the data when extracting a start and end date range."
+                        f"Ignoring sort={sort} input as it is necessary to sort the data when extracting a start and end date range."
                     )
 
                 self.data = self.data.sortby("time")

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -399,7 +399,10 @@ def test_standardise_footprints_chunk(caplog):
     )
 
     search_results = search_footprints(model="UKV-chunked", store="user")
-    fp_data = search_results.retrieve_all()
+
+    # Note: have to pass sort=False here for dask>=2024.8 as this returns different
+    # chunks for time (1, 1, 1) rather than original chunks we're trying to check.
+    fp_data = search_results.retrieve_all(sort=False)
 
     assert dict(fp_data.data.chunks) == {"time": (2, 1), "lat": (12,), "lon": (12,), "height": (20,)}
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

With the recent upgrade of dask to version 2024.8, the chunks returned when retrieving the data from an object store do not match to what we previously expected. This is due to a sort operation which is carried out when all data is retrieved. The sort operation is partially controlled by a `sort` input flag but is performed by default.

The fact that the chunks returned don't exactly match to the stored chunks is not necessarily a problem in itself but it is necessary to test that we are able to add our own custom chunks and this is stored correctly. To fix this test and allow this check to be made the following updates were made:
 - Exposed the `sort` keyword when creating BaseData through retrieve interface. This allows the sortby operation to be avoided.
    - Note: added warning that `sort=False` is not applied if there is a start_date and end_date range supplied.
 - Update the `tests/standardise/test_standardise.py::test_standardise_footprints_chunk` test to make sure the data isn't sorted when being retrieved so the chunks can be checked.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1085  
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
