### PR TITLE
Iss1103: Updating required key logic for ObsColumn data class to allow for better flexibility between site/satellite split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.9.0...HEAD)
 
+### Updated
+
+- Required and optional keys for "column" data type were updated to reflect the two sources of this data (site, satellite) [PR #1104](https://github.com/openghg/openghg/pull/1104)
+
 ### Fixed
 
 - Bug where an input filepath list to standardise_surface was only storing the last file hash. This allowed for some files to bypass the check for the same files depending on where they were in the original filepath list. [PR #1100](https://github.com/openghg/openghg/pull/1100)

--- a/openghg/data/config/objectstore/defaults.json
+++ b/openghg/data/config/objectstore/defaults.json
@@ -41,6 +41,18 @@
     },
     "column": {
         "required": {
+            "species": {
+                "type": [
+                    "species"
+                ]
+            },
+            "platform": {
+                "type": [
+                    "platform"
+                ]                
+            }
+        },
+        "optional": {
             "satellite": {
                 "type": [
                     "str"
@@ -61,18 +73,12 @@
                     "str"
                 ]
             },
-            "species": {
-                "type": [
-                    "species"
-                ]
-            },
             "network": {
                 "type": [
                     "str"
                 ]
             }
-        },
-        "optional": {}
+        }
     },
     "footprints": {
         "required": {

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -261,14 +261,14 @@ def standardise_surface(
 
 def standardise_column(
     filepath: Union[str, Path],
+    species: str,
+    platform: str = "satellite",
+    site: Optional[str] = None,
     satellite: Optional[str] = None,
     domain: Optional[str] = None,
     selection: Optional[str] = None,
-    site: Optional[str] = None,
-    species: Optional[str] = None,
     network: Optional[str] = None,
     instrument: Optional[str] = None,
-    platform: str = "satellite",
     source_format: str = "openghg",
     store: Optional[str] = None,
     if_exists: str = "auto",
@@ -285,7 +285,11 @@ def standardise_column(
 
     Args:
         filepath: Path of observation file
-        satellite: Name of satellite (if relevant)
+        species: Species name or synonym e.g. "ch4"
+        platform: Type of platform. Should be one of:
+            - "satellite"
+            - "site"
+        satellite: Name of satellite (if relevant). Should include satellite OR site.
         domain: For satellite only. If data has been selected on an area include the
             identifier name for domain covered. This can map to previously defined domains
             (see openghg_defs "domain_info.json" file) or a newly defined domain.
@@ -293,14 +297,9 @@ def standardise_column(
             performed on satellite data. This can be based on any form of filtering, binning etc.
             but should be unique compared to other selections made e.g. "land", "glint", "upperlimit".
             If not specified, domain will be used.
-        site : Site code/name (if relevant). Can include satellite OR site.
-        species: Species name or synonym e.g. "ch4"
+        site : Site code/name (if relevant). Should include satellite OR site.
         instrument: Instrument name e.g. "TANSO-FTS"
-        network: Name of in-situ or satellite network e.g. "TCCON", "GOSAT"
-        platform: Type of platform. Should be one of:
-            - "satellite"
-            - "site"
-        source_format : Type of data being input e.g. openghg (internal format)
+        network: Name of in-situ or satellite network e.g. "TCCON", "GOSAT"        source_format : Type of data being input e.g. openghg (internal format)
         store: Name of store to write to
         if_exists: What to do if existing data is present.
             - "auto" - checks new and current data for timeseries overlap
@@ -336,15 +335,15 @@ def standardise_column(
         compressed_data, file_metadata = create_file_package(filepath=filepath, obs_type="footprints")
 
         metadata = {
+            "species": species,
+            "platform": platform,
             "site": site,
             "satellite": satellite,
             "domain": domain,
             "selection": selection,
             "site": site,
-            "species": species,
             "network": network,
             "instrument": instrument,
-            "platform": platform,
             "source_format": source_format,
             "overwrite": overwrite,
         }
@@ -363,14 +362,14 @@ def standardise_column(
             store=store,
             data_type="column",
             filepath=filepath,
+            species=species,
+            platform=platform,
             satellite=satellite,
             domain=domain,
             selection=selection,
             site=site,
-            species=species,
             network=network,
             instrument=instrument,
-            platform=platform,
             source_format=source_format,
             overwrite=overwrite,
             if_exists=if_exists,

--- a/openghg/store/_obscolumn.py
+++ b/openghg/store/_obscolumn.py
@@ -26,14 +26,14 @@ class ObsColumn(BaseStore):
     def read_file(
         self,
         filepath: Union[str, Path],
+        species: str,
+        platform: str = "satellite",
         satellite: Optional[str] = None,
         domain: Optional[str] = None,
         selection: Optional[str] = None,
         site: Optional[str] = None,
-        species: Optional[str] = None,
         network: Optional[str] = None,
         instrument: Optional[str] = None,
-        platform: str = "satellite",
         source_format: str = "openghg",
         if_exists: str = "auto",
         save_current: str = "auto",
@@ -48,7 +48,11 @@ class ObsColumn(BaseStore):
 
         Args:
             filepath: Path of observation file
-            satellite: Name of satellite (if relevant)
+            species: Species name or synonym e.g. "ch4"
+            platform: Type of platform. Should be one of:
+                - "satellite"
+                - "site"
+            satellite: Name of satellite (if relevant). Should include satellite OR site.
             domain: For satellite only. If data has been selected on an area include the
                 identifier name for domain covered. This can map to previously defined domains
                 (see openghg_defs "domain_info.json" file) or a newly defined domain.
@@ -56,13 +60,9 @@ class ObsColumn(BaseStore):
                 performed on satellite data. This can be based on any form of filtering, binning etc.
                 but should be unique compared to other selections made e.g. "land", "glint", "upperlimit".
                 If not specified, domain will be used.
-            site : Site code/name (if relevant). Can include satellite OR site.
-            species: Species name or synonym e.g. "ch4"
+            site : Site code/name (if relevant). Should include satellite OR site.
             instrument: Instrument name e.g. "TANSO-FTS"
             network: Name of in-situ or satellite network e.g. "TCCON", "GOSAT"
-            platform: Type of platform. Should be one of:
-                - "satellite"
-                - "site"
             source_format : Type of data being input e.g. openghg (internal format)
             if_exists: What to do if existing data is present.
                 - "auto" - checks new and current data for timeseries overlap
@@ -93,15 +93,20 @@ class ObsColumn(BaseStore):
         from openghg.util import clean_string, load_standardise_parser, check_if_need_new_version, synonyms
 
         # TODO: Evaluate which inputs need cleaning (if any)
-        satellite = clean_string(satellite)
-        site = clean_string(site)
         species = clean_string(species)
-        if species is not None:
-            species = synonyms(species)
+        species = synonyms(species)
+        platform = clean_string(platform)
+
+        if site is None and satellite is None:
+            raise ValueError("One of 'site' or 'satellite' must be specified")
+        elif site is not None and satellite is not None:
+            raise ValueError("Only one of 'site' or 'satellite' should be specified")
+
+        site = clean_string(site)
+        satellite = clean_string(satellite)
         domain = clean_string(domain)
         network = clean_string(network)
         instrument = clean_string(instrument)
-        platform = clean_string(platform)
 
         if overwrite and if_exists == "auto":
             logger.warning(
@@ -177,7 +182,6 @@ class ObsColumn(BaseStore):
             new_version=new_version,
             data_type=data_type,
             required_keys=lookup_keys,
-            min_keys=3,
             compressor=compressor,
             filters=filters,
         )

--- a/tests/store/test_obscolumn.py
+++ b/tests/store/test_obscolumn.py
@@ -68,13 +68,14 @@ def test_optional_metadata_raise_error():
             satellite=satellite,
             domain=domain,
             species=species,
-            optional_metadata={"domain": "openghg_test"},
+            optional_metadata={"species": "ch4"},
         )
 
 
 def test_optional_metadata():
     """
-    Test to verify required keys present in optional metadata supplied as dictionary raise ValueError
+    Test to verify required keys present in optional metadata supplied as dictionary is
+    added to metadata
     """
     filename = "gosat-fts_gosat_20170318_ch4-column.nc"
     datafile = get_column_datapath(filename=filename)


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Updated required and optional keys for "column" data type (`ObsColumn` data class). This includes all the same keys as previous but rearranged into required and optional definitions to better to match to how we expect this to be used for satellite OR site column data. Also added `platform` as a required key (should be set to "site" or "satellite" though this isn't imposed much at the moment) - this was already a key that could be added through the `standardise_*` framework but was not included within the config.

The defaults.json config now includes:
 - required: species, platform [added]
 - optional: satellite, selection, domain, site, network

Includes:
 - Added in check within `ObsColumn.read_file` for `satellite` OR `site` but not `satellite` AND `site`
 - Removed `min_keys=3` when performing `self.assign_data()` step so this just uses the number of keys passed.
 - Updated `optional_metadata` test so this uses one of the new required keys (was using `site` which is now optional)

* **Please check if the PR fulfills these requirements**

  - [x] Closes #1103 and feeds into #1071 (which needs to assume expected required key logic is correct)
  - [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
  - [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
  - [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

- Not needed for this PR
  - Documentation and tutorials NOT updated/added - No docs on the "column" data_type yet but should add in a separate PR.
  - ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
