### PR TITLE
Ensuring filepath values within BaseStore.check_hashes are set to Path type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bug where an input filepath list to standardise_surface was only storing the last file hash. This allowed for some files to bypass the check for the same files depending on where they were in the original filepath list. [PR #1100](https://github.com/openghg/openghg/pull/1100)
+- Bug where filepath needed to be a Path object when storing the file hash values. [PR #1108](https://github.com/openghg/openghg/pull/1108)
 
 ## [0.9.0] - 2024-08-14
 

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -130,6 +130,8 @@ class BaseStore:
         """
         if not isinstance(filepaths, list):
             filepaths = [filepaths]
+        
+        filepaths = [Path(filepath) for filepath in filepaths]
 
         unseen: Dict[str, Path] = {}
         seen: Dict[str, Path] = {}

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -130,7 +130,7 @@ class BaseStore:
         """
         if not isinstance(filepaths, list):
             filepaths = [filepaths]
-        
+
         filepaths = [Path(filepath) for filepath in filepaths]
 
         unseen: Dict[str, Path] = {}


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

When storing the file hashes the code was assuming the filepath values were `Path` not `str` type and so was raising an error. This PR updates the `BaseStore.check_hashes` function which creates the file hash details to make sure the filepath (the value in the dictionary) is already a `Path`.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1107  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
