### PR TITLE
Tidy up: Split out sampling period check

### DIFF
--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -203,6 +203,7 @@ class ObsSurface(BaseStore):
             clean_string,
             format_inlet,
             format_data_level,
+            evaluate_sampling_period,
             check_and_set_null_variable,
             hash_file,
             load_standardise_parser,
@@ -232,6 +233,8 @@ class ObsSurface(BaseStore):
 
         network = clean_string(network)
         instrument = clean_string(instrument)
+
+        sampling_period = evaluate_sampling_period(sampling_period)
 
         # Ensure we have a clear missing value for data_level, data_sublevel
         data_level = format_data_level(data_level)
@@ -281,39 +284,6 @@ class ObsSurface(BaseStore):
 
         new_version = check_if_need_new_version(if_exists, save_current)
 
-        sampling_period_seconds: Union[str, None] = None
-        # If we have a sampling period passed we want the number of seconds
-        if sampling_period is not None:
-            # Check value passed is not just a number with no units
-            try:
-                float(sampling_period)
-            except (ValueError, TypeError):
-                # If this cannot be evaluated to a float assume this is correct form.
-                pass
-            else:
-                raise ValueError(
-                    f"Invalid sampling period: '{sampling_period}'. Must be specified as a string with unit (e.g. 1m for 1 minute)."
-                )
-
-            # Check string passed can be evaluated as a Timedelta object
-            # and extract this in seconds.
-            try:
-                sampling_period_td = Timedelta(sampling_period)
-            except ValueError:
-                raise ValueError(
-                    f"Could not evaluate sampling period: '{sampling_period}'. Must be specified as a string with valid unit (e.g. 1m for 1 minute)."
-                )
-
-            sampling_period_seconds = str(float(sampling_period_td.total_seconds()))
-
-            # Check if sampling period has resolved to 0 seconds.
-            if sampling_period_seconds == "0.0":
-                raise ValueError(
-                    f"Sampling period resolves to <= 0.0 seconds. Please check input: '{sampling_period}'"
-                )
-
-            # TODO: May want to add check for NaT or NaN
-
         # Load the data retrieve object
         parser_fn = load_standardise_parser(data_type=self._data_type, source_format=source_format)
 
@@ -353,7 +323,7 @@ class ObsSurface(BaseStore):
                 "network": network,
                 "inlet": inlet,
                 "instrument": instrument,
-                "sampling_period": sampling_period_seconds,
+                "sampling_period": sampling_period,
                 "measurement_type": measurement_type,
                 "site_filepath": site_filepath,
             }

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -66,6 +66,7 @@ from ._time import (
     daterange_overlap,
     dates_overlap,
     daterange_to_str,
+    evaluate_sampling_period,
     find_daterange_gaps,
     find_duplicate_timestamps,
     first_last_dates,

--- a/openghg/util/_time.py
+++ b/openghg/util/_time.py
@@ -945,10 +945,10 @@ def evaluate_sampling_period(sampling_period: Optional[Union[Timedelta, str]]) -
         # Check string passed can be evaluated as a Timedelta object and extract this in seconds.
         try:
             sampling_period_td = Timedelta(sampling_period)
-        except ValueError:
+        except ValueError as e:
             raise ValueError(
                 f"Could not evaluate sampling period: '{sampling_period}'. Must be specified as a string with valid unit (e.g. 1m for 1 minute)."
-            )
+            ) from e
 
         sampling_period = str(float(sampling_period_td.total_seconds()))
 

--- a/openghg/util/_time.py
+++ b/openghg/util/_time.py
@@ -1,9 +1,10 @@
 from datetime import date
 from typing import Dict, List, Optional, Tuple, Union
-from openghg.types import TimePeriod
-
 from pandas import DataFrame, DateOffset, DatetimeIndex, Timedelta, Timestamp
 from xarray import Dataset
+import re
+
+from openghg.types import TimePeriod
 
 __all__ = [
     "timestamp_tzaware",
@@ -931,13 +932,13 @@ def evaluate_sampling_period(sampling_period: Optional[Union[Timedelta, str]]) -
     # If we have a sampling period passed we want the number of seconds
     if sampling_period is not None:
 
-        # Check value passed is not just a number with no units
-        try:
-            float(sampling_period)
-        except (ValueError, TypeError):
-            # If this cannot be evaluated to a float assume this is correct form.
-            pass
-        else:
+        # Check format of input string matches expected
+        sampling_period = str(sampling_period)
+        re_sampling_period = re.compile(r"\d+[.]?\d*\s*[a-zA-Z]+")
+        check_format = re_sampling_period.search(sampling_period)
+
+        # If pattern is not matched this returns a None - indicating string is in incorrect form
+        if check_format is None:
             raise ValueError(
                 f"Invalid sampling period: '{sampling_period}'. Must be specified as a string with unit (e.g. 1m for 1 minute)."
             )

--- a/tests/retrieve/conftest.py
+++ b/tests/retrieve/conftest.py
@@ -91,7 +91,7 @@ def data_read():
         site="tac",
         network="DECC",
         instrument="picarro",
-        sampling_period="1H",
+        sampling_period="1h",
     )
 
     # Obs Column data

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -102,7 +102,7 @@ def test_standardise_obs_openghg():
         inlet=185,
         instrument="picarro",
         source_format="openghg",
-        sampling_period="1H",
+        sampling_period="1h",
         force=True,
         store="user",
     )
@@ -141,7 +141,7 @@ def test_standardise_obs_metadata_mismatch():
         inlet="999m",
         instrument="picarro",
         source_format="openghg",
-        sampling_period="1H",
+        sampling_period="1h",
         update_mismatch=update_mismatch,
         overwrite=True,
         store="user",
@@ -200,7 +200,7 @@ def test_local_obs_metadata_mismatch_meta():
         inlet="998m",
         instrument="picarro",
         source_format="openghg",
-        sampling_period="1H",
+        sampling_period="1h",
         update_mismatch=update_mismatch,
         store="user",
     )
@@ -251,7 +251,7 @@ def test_local_obs_metadata_mismatch_fail():
             inlet="999m",
             instrument="picarro",
             source_format="openghg",
-            sampling_period="1H",
+            sampling_period="1h",
             update_mismatch="never",
             force=True,
             store="user",
@@ -606,7 +606,7 @@ def test_standardise_sorting_true(caplog):
         site="tac",
         network="DECC",
         instrument="picarro",
-        sampling_period="1H",
+        sampling_period="1h",
         update_mismatch="attributes",
         if_exists="new",
         sort_files=True
@@ -632,7 +632,7 @@ def test_standardise_sorting_false(caplog):
         site="tac",
         network="DECC",
         instrument="picarro",
-        sampling_period="1H",
+        sampling_period="1h",
         update_mismatch="attributes",
         if_exists="new",
         sort_files=False

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -866,7 +866,7 @@ def test_check_obssurface_multi_file_same_skip():
         site="tac",
         network="DECC",
         instrument="picarro",
-        sampling_period="1H",
+        sampling_period="1h",
         if_exists="new",
     )
 
@@ -881,7 +881,7 @@ def test_check_obssurface_multi_file_same_skip():
         site="tac",
         network="DECC",
         instrument="picarro",
-        sampling_period="1H",
+        sampling_period="1h",
         if_exists="new",
     )
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Move check for sampling_period into the util._time.py module. This is to continue to simplify the checks within `ObsSurface.read_file()` and feeds into PR #1069 to make sure inputs to the read_file function call matches as closely as we can to what is accepted by the `parse` functions. Previously `sampling_period` input was converted to `sampling_period_seconds` which is what was passed to the `parse` functions.

Related to this, sampling_period of "1H" was changed to "1h" as this was causing a warning in the tests.

* **Please check if the PR fulfills these requirements**

- [x] Related to #1071 but does not close this
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature - small internal change - needed?

Not needed
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
