### PR TITLE
Tidy up: Update NOAA keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated parse_* functions for surface data type to accept `filepath` rather than `data_filepath`. This maps better to the `standardise_surface` input and makes this consistent with the other data types. [PR #1101](https://github.com/openghg/openghg/pull/1101)
 - Separated data variable formatting from assign attributes function into dataset_formatter function.- [PR #1102](https://github.com/openghg/openghg/pull/1102)
 - Required and optional keys for "column" data type were updated to reflect the two sources of this data (site, satellite) [PR #1104](https://github.com/openghg/openghg/pull/1104)
+- Ensure metadata keywords for NOAA obspack are consistent with wider definitions including renaming data_source to dataset_source (data_source would be "internal"). [PR #1110](https://github.com/openghg/openghg/pull/1110)
 
 ### Fixed
 

--- a/openghg/standardise/surface/_noaa.py
+++ b/openghg/standardise/surface/_noaa.py
@@ -1,7 +1,6 @@
 import logging
 from pathlib import Path
 from typing import Any, Dict, Hashable, Optional, Union, cast
-
 import xarray as xr
 
 from openghg.standardise.meta import dataset_formatter
@@ -362,7 +361,7 @@ def _read_obspack(
     metadata["species"] = species
     metadata["units"] = units
     metadata["sampling_period"] = sampling_period
-    metadata["data_source"] = "noaa_obspack"
+    metadata["dataset_source"] = "noaa_obspack"
     metadata["data_type"] = "surface"
 
     # Add additional sampling_period_estimate if sampling_period is not set

--- a/openghg/standardise/surface/_noaa.py
+++ b/openghg/standardise/surface/_noaa.py
@@ -4,7 +4,9 @@ from typing import Any, Dict, Hashable, Optional, Union, cast
 import xarray as xr
 
 from openghg.standardise.meta import dataset_formatter
+from openghg.store.spec import null_metadata_values
 from openghg.types import optionalPathType
+from openghg.util import check_and_set_null_variable
 
 logger = logging.getLogger("openghg.standardise.surface")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -44,7 +46,7 @@ def parse_noaa(
         dict: Dictionary of data and metadata
     """
     if sampling_period is None:
-        sampling_period = "NOT_SET"
+        sampling_period = check_and_set_null_variable(sampling_period)
 
     sampling_period = str(sampling_period)
 
@@ -339,7 +341,8 @@ def _read_obspack(
     processed_ds = processed_ds.set_coords(["time"])
 
     # Estimate sampling period using metadata and midpoint time
-    if sampling_period == "NOT_SET":
+    not_set_values = null_metadata_values()
+    if sampling_period in not_set_values:
         sampling_period_estimate = _estimate_sampling_period(obspack_ds)
     else:
         sampling_period_estimate = -1.0
@@ -370,18 +373,21 @@ def _read_obspack(
             sampling_period_estimate
         )  # convert to string to keep consistent with "sampling_period"
 
+    # Define not_set value to use as a default
+    not_set_value = not_set_values[0]
+
     # Add instrument if present
     if instrument is not None:
         metadata["instrument"] = instrument
     else:
-        metadata["instrument"] = orig_attrs.get("instrument", "NOT_SET")
+        metadata["instrument"] = orig_attrs.get("instrument", not_set_value)
 
     # Add data owner details, station position and calibration scale, if present
-    metadata["data_owner"] = orig_attrs.get("provider_1_name", "NOT_SET")
-    metadata["data_owner_email"] = orig_attrs.get("provider_1_email", "NOT_SET")
-    metadata["station_longitude"] = orig_attrs.get("site_longitude", "NOT_SET")
-    metadata["station_latitude"] = orig_attrs.get("site_latitude", "NOT_SET")
-    metadata["calibration_scale"] = orig_attrs.get("dataset_calibration_scale", "NOT_SET")
+    metadata["data_owner"] = orig_attrs.get("provider_1_name", not_set_value)
+    metadata["data_owner_email"] = orig_attrs.get("provider_1_email", not_set_value)
+    metadata["station_longitude"] = orig_attrs.get("site_longitude", not_set_value)
+    metadata["station_latitude"] = orig_attrs.get("site_latitude", not_set_value)
+    metadata["calibration_scale"] = orig_attrs.get("dataset_calibration_scale", not_set_value)
 
     # Create attributes with copy of metadata values
     attributes = cast(Dict[Hashable, Any], metadata.copy())  # Cast to match xarray attributes type

--- a/tests/standardise/surface/test_noaa.py
+++ b/tests/standardise/surface/test_noaa.py
@@ -55,7 +55,6 @@ def test_read_obspack_2020():
     attributes = ch4_data.attrs
 
     assert "sampling_period" in attributes
-    assert attributes["sampling_period"] == "NOT_SET"
     assert "sampling_period_estimate" in attributes
 
     ch4_metadata = data["ch4"]["metadata"]
@@ -93,7 +92,7 @@ def test_read_obspack_flask_2021():
     attributes = ch4_data.attrs
 
     assert "sampling_period" in attributes
-    assert attributes["sampling_period"] == "NOT_SET"
+    assert attributes["sampling_period"] == "not_set"
     assert "sampling_period_estimate" in attributes
     assert float(attributes["sampling_period_estimate"]) > 0.0
     assert attributes["units"] == "nanomol mol-1"


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Updating keywords to NOAA obspack to ensure these are consistent with current definitions. This includes:
 - `data_source` --> `dataset_source`
 - Updating keywords which are not set (e.g. sampling_period and potentially other keys) to use central definition for the not_set keyword

This assists with making definitions consistent for PR #1069 .

* **Please check if the PR fulfills these requirements**

- [x] Updates related to #1071 but does not close this
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
