### PR TITLE
Updating and formalising merge logic when combining updating metadata from parse functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure metadata keywords for NOAA obspack are consistent with wider definitions including renaming data_source to dataset_source (data_source would be "internal"). [PR #1110](https://github.com/openghg/openghg/pull/1110)
 - Updated data type classes to dynamically select inputs to pass to parse function and to include any required/optional keys not passed to the parse function within the metadata. [PR #1111](https://github.com/openghg/openghg/pull/1111)
 - When adding new data sources, updated how lookup keys add optional keys. This used to only extract these from the optional_metadata input but this now allows keys to be added through any metadata. [PR #1112](https://github.com/openghg/openghg/pull/1112)
+- Formalising metadata data merging logic within new util.metadata_util functions. [PR #1113](https://github.com/openghg/openghg/pull/1113)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Separated data variable formatting from assign attributes function into dataset_formatter function.- [PR #1102](https://github.com/openghg/openghg/pull/1102)
 - Required and optional keys for "column" data type were updated to reflect the two sources of this data (site, satellite) [PR #1104](https://github.com/openghg/openghg/pull/1104)
 - Ensure metadata keywords for NOAA obspack are consistent with wider definitions including renaming data_source to dataset_source (data_source would be "internal"). [PR #1110](https://github.com/openghg/openghg/pull/1110)
+- Updated data type classes to dynamically select inputs to pass to parse function and to include any required/optional keys not passed to the parse function within the metadata. [PR #1111](https://github.com/openghg/openghg/pull/1111)
 
 ### Fixed
 

--- a/openghg/standardise/surface/_noaa.py
+++ b/openghg/standardise/surface/_noaa.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 from openghg.standardise.meta import dataset_formatter
 from openghg.types import optionalPathType
-from openghg.util import check_and_set_null_variable, null_metadata_values
+from openghg.util import check_and_set_null_variable, not_set_metadata_values
 
 logger = logging.getLogger("openghg.standardise.surface")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -340,7 +340,7 @@ def _read_obspack(
     processed_ds = processed_ds.set_coords(["time"])
 
     # Estimate sampling period using metadata and midpoint time
-    not_set_values = null_metadata_values()
+    not_set_values = not_set_metadata_values()
     if sampling_period in not_set_values:
         sampling_period_estimate = _estimate_sampling_period(obspack_ds)
     else:

--- a/openghg/standardise/surface/_noaa.py
+++ b/openghg/standardise/surface/_noaa.py
@@ -4,9 +4,8 @@ from typing import Any, Dict, Hashable, Optional, Union, cast
 import xarray as xr
 
 from openghg.standardise.meta import dataset_formatter
-from openghg.store.spec import null_metadata_values
 from openghg.types import optionalPathType
-from openghg.util import check_and_set_null_variable
+from openghg.util import check_and_set_null_variable, null_metadata_values
 
 logger = logging.getLogger("openghg.standardise.surface")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -203,7 +203,7 @@ class BaseStore:
             # Sources of additional metadata - order in list is order of preference.
             sources = [input_parameters, additional_metadata]
             for source in sources:
-                metadata = merge_dict(metadata, source, keys_dict2=required)
+                metadata = merge_dict(metadata, source, keys_right=required)
 
             required_not_found = set(required) - set(metadata.keys())
             if required_not_found:
@@ -213,13 +213,13 @@ class BaseStore:
 
             # Check if named optional keys are included in the input_parameters and add
             optional_matched = set(optional) & set(input_parameters.keys())
-            metadata = merge_dict(metadata, input_parameters, keys_dict2=optional_matched)
+            metadata = merge_dict(metadata, input_parameters, keys_right=optional_matched)
 
             # Add additional metadata keys
             if additional_metadata:
                 # Ensure required keys aren't added again (or clash with values from input_parameters)
                 additional_metadata_to_add = set(additional_metadata.keys()) - set(required)
-                metadata = merge_dict(metadata, additional_metadata, keys_dict2=additional_metadata_to_add)
+                metadata = merge_dict(metadata, additional_metadata, keys_right=additional_metadata_to_add)
 
             parsed_data["metadata"] = metadata
 

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -203,6 +203,7 @@ class BaseStore:
             # Sources of additional metadata - order in list is order of preference.
             sources = [input_parameters, additional_metadata]
             for source in sources:
+                # merge "required" keys from source into metadata; on conflict, keep value from metadata
                 metadata = merge_dict(metadata, source, keys_right=required)
 
             required_not_found = set(required) - set(metadata.keys())

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -179,28 +179,49 @@ class BaseStore:
 
         return self.metakeys
 
-    def update_metadata(self, data: Dict, input_parameters: dict, additional_metadata: Dict) -> Dict:
+    def update_metadata(self, data: dict, input_parameters: dict, additional_metadata: dict) -> dict:
         """This adds additional metadata keys to the metadata within the data dictionary.
 
         Args:
-            data: Dictionary containing data and metadata for species
-            input_parameters: Input parameters from read_file.
+            data: Dictionary containing data and metadata for datasource
+            input_parameters: Input parameters from read_file...
             additional_metadata: Keys to add to the metadata dictionary
         Returns:
             dict: data dictionary with metadata keys added
         """
+        from openghg.util import merge_dict
+
         # Get defined metakeys from the config setup
         metakeys = self.add_metakeys()
         required = metakeys["required"]
+        # We might not get any optional keys
+        optional = metakeys.get("optional", {})
 
-        input_parameters_required = {key: value for key, value in input_parameters.items() if key in required}
-
-        # Basic implemntation of this
-        # TODO: Move this somewhere else? This shouldn't need self but does need to understand form of data.
-        # TODO: May want to add checks to make sure we're not overwriting anything important.
         for parsed_data in data.values():
-            parsed_data["metadata"].update(input_parameters_required)
-            parsed_data["metadata"].update(additional_metadata)
+            metadata = parsed_data["metadata"]
+
+            # Sources of additional metadata - order in list is order of preference.
+            sources = [input_parameters, additional_metadata]
+            for source in sources:
+                metadata = merge_dict(metadata, source, keys_dict2=required)
+
+            required_not_found = set(required) - set(metadata.keys())
+            if required_not_found:
+                raise ValueError(
+                    f"The following required keys are missing: {', '.join(required_not_found)}. Please specify."
+                )
+
+            # Check if named optional keys are included in the input_parameters and add
+            optional_matched = set(optional) & set(input_parameters.keys())
+            metadata = merge_dict(metadata, input_parameters, keys_dict2=optional_matched)
+
+            # Add additional metadata keys
+            if additional_metadata:
+                # Ensure required keys aren't added again (or clash with values from input_parameters)
+                additional_metadata_to_add = set(additional_metadata.keys()) - set(required)
+                metadata = merge_dict(metadata, additional_metadata, keys_dict2=additional_metadata_to_add)
+
+            parsed_data["metadata"] = metadata
 
         return data
 
@@ -296,7 +317,7 @@ class BaseStore:
                 dict: Dictionary of UUIDs of Datasources data has been assigned to keyed by species name
         """
         from openghg.store.base import Datasource
-        from openghg.store.spec import null_metadata_values
+        from openghg.util import not_set_metadata_values
 
         uuids = {}
 
@@ -317,7 +338,7 @@ class BaseStore:
                 # Our lookup results and gas data have the same keys
                 uuid = lookup_results[key]
 
-                ignore_values = null_metadata_values()
+                ignore_values = not_set_metadata_values()
 
                 # Do we want all the metadata in the Dataset attributes?
                 to_add = {

--- a/openghg/store/spec/__init__.py
+++ b/openghg/store/spec/__init__.py
@@ -3,5 +3,4 @@ from ._specification import (
     define_data_type_classes,
     define_standardise_parsers,
     define_transform_parsers,
-    null_metadata_values,
 )

--- a/openghg/store/spec/_specification.py
+++ b/openghg/store/spec/_specification.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple, Dict, List
+from typing import Any, Tuple, Dict
 from openghg.types import (
     SurfaceTypes,
     ColumnTypes,
@@ -13,7 +13,6 @@ __all__ = [
     "define_data_type_classes",
     "define_standardise_parsers",
     "define_transform_parsers",
-    "null_metadata_values",
 ]
 
 
@@ -94,15 +93,3 @@ def define_transform_parsers() -> Dict[str, Any]:
     }
 
     return data_type_parsers
-
-
-def null_metadata_values() -> List:
-    """
-    Defines values which indicate metadata value is not specified.
-    Returns:
-        list: values to be seen as null
-    """
-    # TODO: Depending on how this is implemented, may want to update this to include np.nan values
-    null_values = ["not_set", "NOT_SET"]
-
-    return null_values

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -36,6 +36,17 @@ from ._file import (
 from ._function_inputs import match_function_inputs
 from ._hashing import hash_bytes, hash_file, hash_retrieved_data, hash_string
 from ._inlet import format_inlet, extract_height_name
+from ._metadata_util import (
+    null_metadata_values,
+    not_set_metadata_values,
+    remove_null_keys,
+    check_number_match,
+    check_str_match,
+    check_value_match,
+    check_not_set_value,
+    get_overlap_keys,
+    merge_dict,
+)
 from ._site import get_site_info, sites_in_network
 from ._species import (
     get_species_info,

--- a/openghg/util/_metadata_util.py
+++ b/openghg/util/_metadata_util.py
@@ -160,7 +160,7 @@ def get_overlap_keys(left: dict, right: dict) -> list:
     return overlapping_keys
 
 
-def _filter_keys(dictionary: dict, keys: Optional[Iterable] = None, negate: bool = False):
+def _filter_keys(dictionary: dict, keys: Optional[Iterable] = None, negate: bool = False) -> dict:
     """
     Convenience function to filter a dictionary by a set of keys.
     """

--- a/openghg/util/_metadata_util.py
+++ b/openghg/util/_metadata_util.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Iterable, List, Optional
+from typing import Any, Union, Iterable, List, Literal, Optional
 import logging
 import math
 
@@ -179,7 +179,7 @@ def merge_dict(
     keys_dict2: Optional[Iterable] = None,
     remove_null: bool = True,
     null_values: Iterable = null_metadata_values(),
-    check_value: bool = True,
+    on_conflict: Literal["check_value", "error"] = "check_value",
     relative_tolerance: float = 1e-3,
     lower: bool = True,
     not_set_values: Iterable = not_set_metadata_values(),
@@ -240,7 +240,7 @@ def merge_dict(
     # Merge the two dictionaries for the keys we know don't overlap
     merged_dict = dict1_non_overlap | dict2_not_overlap
 
-    if check_value:
+    if on_conflict == "check_value":
         overlap_values_not_matching = {}
         for key in overlapping_keys:
             value1 = dict1[key]
@@ -265,7 +265,7 @@ def merge_dict(
                     )
                 else:
                     overlap_values_not_matching[key] = (value1, value2)
-    else:
+    elif on_conflict == "error":
         raise ValueError(f"Unable to merge dictionaries with overlapping keys: {','.join(overlapping_keys)}")
 
     if overlap_values_not_matching:

--- a/openghg/util/_metadata_util.py
+++ b/openghg/util/_metadata_util.py
@@ -1,0 +1,267 @@
+from typing import Any, Union, Iterable, List, Optional
+import logging
+import math
+
+
+__all__ = [
+    "null_metadata_values",
+    "not_set_metadata_values",
+    "remove_null_keys",
+    "check_number_match",
+    "check_str_match",
+    "check_value_match",
+    "check_not_set_value",
+    "get_overlap_keys",
+    "merge_dict",
+]
+
+
+logger = logging.getLogger("openghg.util")
+logger.setLevel(logging.INFO)  # Have to set level for logger as well as handler
+
+
+def null_metadata_values() -> List:
+    """
+    Defines values which indicate metadata key should be ignored and not retained within
+    the metadata (or added to the metastore).
+
+    Returns:
+        list: values to be seen as null
+    """
+    null_values = [None]
+
+    return null_values
+
+
+def not_set_metadata_values() -> List:
+    """
+    Defines values which indicate metadata value has not been explicitly specified
+    but that we still want to retain within the metadata (and metastore) so the key is present.
+
+    Returns:
+        list: values which indicate key has not been set
+    """
+    # TODO: Depending on how this is implemented, may want to update this to include np.nan values
+    not_set_values = ["not_set", "NOT_SET"]
+
+    return not_set_values
+
+
+def remove_null_keys(dictionary: dict, null_values: Iterable = null_metadata_values()) -> dict:
+    """
+    Remove keys from a dictionary for values which we want to ignore. By default,
+    ignore_values is (None, ).
+
+    Returns:
+        dict: Copy of dictionary with key: null value pairs removed.
+    """
+    dictionary = {key: value for key, value in dictionary.items() if value not in null_values}
+    return dictionary
+
+
+def check_number_match(
+    number1: Union[str, int, float], number2: Union[str, int, float], relative_tolerance: float = 1e-3
+) -> bool:
+    """
+    Check values that can be identified as numbers match within a specified tolerance.
+
+    Args:
+        number1, number2: Input values for comparison - number-like.
+        relative_tolerance: Allowed relative difference between numbers.
+    Returns:
+        bool: True/False if numbers match within relative tolerance.
+    """
+    if math.isclose(float(number1), float(number2), rel_tol=relative_tolerance):
+        return True
+    else:
+        return False
+
+
+def check_str_match(value1: Any, value2: Any, lower: bool = True) -> bool:
+    """
+    Check values which can be converted to strings match. Can specify whether lower
+    case should be applied when checking match (case-insensitive).
+
+    Args:
+        value1, value2: Input values for comparison - will convert to strings.
+        lower: Apply lower case to the two string to make this case-insensitive.
+    Returns:
+        bool: True/False if values match depending on case-sensitivity.
+    """
+    value1 = str(value1)
+    value2 = str(value2)
+
+    if lower:
+        value1 = value1.lower()
+        value2 = value2.lower()
+
+    if value1 == value2:
+        return True
+    else:
+        return False
+
+
+def check_value_match(value1: Any, value2: Any, relative_tolerance: float = 1e-3, lower: bool = True) -> bool:
+    """
+    Check input values match.
+    - For values which can be identified as numbers, a float comparison will be made
+      using the relative_tolerance.
+    - For other values a string comparison will be made, with lower case applied by default.
+
+    Args:
+        value1, value2: Input values for comparison
+        relative_tolerance: Tolerance between two numbers.
+            Only used if values are identified as number-like
+        lower: Whether to apply lower case to the two input values as strings.
+            Used when making a string comparison if values are not identified
+            as number-like.
+    Returns:
+        bool: True/False if it is determined that values do/don't match
+    """
+    from openghg.util._strings import is_number
+
+    if is_number(value1) and is_number(value2):
+        return check_number_match(value1, value2, relative_tolerance)
+    else:
+        return check_str_match(value1, value2, lower)
+
+
+def check_not_set_value(
+    value1: Any, value2: Any, not_set_values: Iterable = not_set_metadata_values()
+) -> Any:
+    """
+    Check whether either value is in the list of null values and if so return the other
+    value in preference.
+    Not set values are sometimes needed if we want to include a key but need a string to indicate
+    this value has not been specified by the user.
+
+    Args:
+        value1, value2: Input values for comparison
+        not_set_values: List of values which indicate value has not been explicitly set. (e.g. "not_set")
+            By default this is defined by null_metadata_values() function
+    Returns:
+        value: if one value is null (value1 checked first) returns the other value
+        None: if neither value is null.
+    """
+    if value1 in not_set_values:
+        return value2
+    elif value2 in not_set_values:
+        return value1
+    else:
+        return None
+
+
+def get_overlap_keys(dict1: dict, dict2: dict) -> list:
+    """
+    Find the keys which match between two dictionaries. Return list of these keys.
+    """
+    overlapping_keys_check = set(dict1.keys()) & set(dict2.keys())
+    overlapping_keys = list(overlapping_keys_check)
+    return overlapping_keys
+
+
+def merge_dict(
+    dict1: dict,
+    dict2: dict,
+    keys: Optional[Iterable] = None,
+    keys_dict1: Optional[Iterable] = None,
+    keys_dict2: Optional[Iterable] = None,
+    remove_null: bool = True,
+    null_values: Iterable = null_metadata_values(),
+    check_value: bool = True,
+    relative_tolerance: float = 1e-3,
+    lower: bool = True,
+    not_set_values: Iterable = not_set_metadata_values(),
+    resolve_mismatch: bool = False,
+) -> dict:
+    """
+    The merge_dict function merges the key:value pairs of two dictionaries checking for
+    overlap between them.
+
+    Depending on the choice of inputs, if the same keys are present in both dictionaries:
+        - if one of the two values is identified as a null value (e.g. "not_set") the
+          other value will be used in preference.
+        - otherwise, the value from dict1 gets preference in the merged dictionary.
+
+    Args:
+        dict1, dict2 : Dictionaries to compare and merge
+        keys: Only include specific keys across both dictionaries in merged output
+        keys_dict1, keys_dict1: Select specific keys from dict1/dict2 when merging
+        check_value: If keys overlap, check values match.
+            See check_value_match() function for rules of matching.
+        relative_tolerance: Tolerance between two numbers when checking values.
+        lower: Whether to apply lower case to the two input values as strings when checking values.
+        not_set_values: Values which indicate this value has not been specified.
+            See null_metadata_values() function for list of default values.
+        resolve_mismatch: If keys overlap, values do not match and neither is null,
+            use value from dict1 and raise a warning. This will raise an error if set to False.
+    Returns:
+        dict: Merged dictionary
+
+        if check_value is False:
+            raises ValueError if any keys overlap
+        if resolve_mismatch is False:
+            raises ValueError if values for overlapping keys don't match (and neither matched null_values)
+    """
+    # Remove null values
+    if remove_null:
+        dict1 = remove_null_keys(dict1, null_values)
+        dict2 = remove_null_keys(dict2, null_values)
+
+    # Filter dictionaries based on any input key selections
+    if keys is not None:
+        dict1 = {key: value for key, value in dict1.items() if key in keys}
+        dict2 = {key: value for key, value in dict2.items() if key in keys}
+    else:
+        if keys_dict1 is not None:
+            dict1 = {key: value for key, value in dict1.items() if key in keys_dict1}
+        if keys_dict2 is not None:
+            dict2 = {key: value for key, value in dict2.items() if key in keys_dict2}
+
+    overlapping_keys = get_overlap_keys(dict1, dict2)
+
+    dict1_non_overlap = {key: value for key, value in dict1.items() if key not in overlapping_keys}
+    dict2_not_overlap = {key: value for key, value in dict2.items() if key not in overlapping_keys}
+
+    # Merge the two dictionaries for the keys we know don't overlap
+    merged_dict = dict1_non_overlap | dict2_not_overlap
+
+    if check_value:
+        overlap_values_not_matching = {}
+        for key in overlapping_keys:
+            value1 = dict1[key]
+            value2 = dict2[key]
+
+            # Check whether either one of the values indicates this is null.
+            # - if so this prefer the other value if there is a difference
+            value_present = check_not_set_value(value1, value2, not_set_values)
+            if check_value_match(value1, value2, relative_tolerance, lower):
+                if value_present is None:
+                    logger.warning(
+                        f"Same key '{key}' supplied from different sources. Error not raised because values match: '{value1}' (1), '{value2}' (2)."
+                    )
+                merged_dict[key] = value1
+            elif value_present is not None:
+                merged_dict[key] = value_present
+            else:
+                if resolve_mismatch:
+                    merged_dict[key] = value1
+                    logger.warning(
+                        f"Values do not match between dictionaries. Updating to {key} = {value1} (not {value2})"
+                    )
+                else:
+                    overlap_values_not_matching[key] = (value1, value2)
+    else:
+        raise ValueError(f"Unable to merge dictionaries with overlapping keys: {','.join(overlapping_keys)}")
+
+    if overlap_values_not_matching:
+        mismatch_details = [
+            f" - '{key}', dict1: {values[0]}, dict2: {values[1]}"
+            for key, values in overlap_values_not_matching.items()
+        ]
+        mismatch_str = "\n".join(mismatch_details)
+        msg = f"Same key(s) supplied from different sources:\n{mismatch_str}"
+        logger.error(msg)
+        raise ValueError(msg)
+
+    return merged_dict

--- a/openghg/util/_metadata_util.py
+++ b/openghg/util/_metadata_util.py
@@ -262,7 +262,7 @@ def merge_dict(
                 merged_dict[key] = value_present
             else:
                 if on_conflict in ["left", "right", "drop"]:
-                    msg = f"Values do not match between dictionaries. "
+                    msg = "Values do not match between dictionaries. "
                     if on_conflict == "left":
                         merged_dict[key] = value1
                         msg += f"Updating to '{on_conflict}' {key} = {value1} (not {value2})."

--- a/openghg/util/_metadata_util.py
+++ b/openghg/util/_metadata_util.py
@@ -160,6 +160,17 @@ def get_overlap_keys(dict1: dict, dict2: dict) -> list:
     return overlapping_keys
 
 
+def _filter_keys(dictionary: dict, keys: Optional[Iterable] = None, negate: bool = False):
+    """
+    Convenience function to filter a dictionary by a set of keys.
+    """
+    if keys is None:
+        return dictionary  # probably should return a copy for consistency, but keys = None is mostly for convenience
+    if negate is True:
+        return {key: value for key, value in dictionary.items() if key not in keys}
+    return {key: value for key, value in dictionary.items() if key in keys}
+
+
 def merge_dict(
     dict1: dict,
     dict2: dict,
@@ -213,13 +224,13 @@ def merge_dict(
 
     # Filter dictionaries based on any input key selections
     if keys is not None:
-        dict1 = {key: value for key, value in dict1.items() if key in keys}
-        dict2 = {key: value for key, value in dict2.items() if key in keys}
+        dict1 = _filter_keys(dict1, keys)
+        dict2 = _filter_keys(dict2, keys)
     else:
         if keys_dict1 is not None:
-            dict1 = {key: value for key, value in dict1.items() if key in keys_dict1}
+            dict1 = _filter_keys(dict1, keys_dict1)
         if keys_dict2 is not None:
-            dict2 = {key: value for key, value in dict2.items() if key in keys_dict2}
+            dict2 = _filter_keys(dict2, keys_dict2)
 
     overlapping_keys = get_overlap_keys(dict1, dict2)
 

--- a/openghg/util/_metadata_util.py
+++ b/openghg/util/_metadata_util.py
@@ -234,7 +234,7 @@ def merge_dict(
 
     overlapping_keys = get_overlap_keys(left, right)
 
-    if on_overlap == "error":
+    if overlapping_keys and on_overlap == "error":
         raise ValueError(f"Unable to merge dictionaries with overlapping keys: {','.join(overlapping_keys)}")
 
     left_non_overlap = {key: value for key, value in left.items() if key not in overlapping_keys}

--- a/openghg/util/_metadata_util.py
+++ b/openghg/util/_metadata_util.py
@@ -257,7 +257,10 @@ def merge_dict(
                     logger.warning(
                         f"Same key '{key}' supplied from different sources. Error not raised because values match: '{value1}' (1), '{value2}' (2)."
                     )
-                merged_dict[key] = value1
+                if on_conflict == "right":
+                    merged_dict[key] = value2
+                else:
+                    merged_dict[key] = value1
             elif check_not_set is True:
                 merged_dict[key] = value_present
             else:

--- a/openghg/util/_strings.py
+++ b/openghg/util/_strings.py
@@ -1,5 +1,7 @@
 import re
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, overload
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, Iterable, overload
+
+from openghg.util import not_set_metadata_values, null_metadata_values
 
 __all__ = ["clean_string", "to_lowercase"]
 
@@ -172,26 +174,32 @@ def extract_float(s: str) -> float:
     raise ValueError(f"No float values found in '{s}'")
 
 
-def check_and_set_null_variable(param: Union[str, None], null_value: Optional[str] = None) -> str:
+def check_and_set_null_variable(
+    param: Union[str, None],
+    not_set_value: Optional[str] = None,
+    null_values: Iterable = null_metadata_values(),
+) -> Union[str, None]:
     """
-    Check whether a variable is set to None and if so replace this with
-    the defined string to define a null variable.
+    Check whether a variable is set to a null value (e.g. None) and if so replace this with
+    a defined string used to indicate the variable has not been set.
     This is typically: "not_set"
 
     Args:
         param: variable to check
-        null_value: Optional value to replace if None. Otherwise details
-            from openghg.store.spec.null_metadata_values will be used.
+        not_set_value: Optional value to replace if None. By default details
+            from openghg.util.not_set_metadata_values() will be used.
+        null_values: Values to identify as null. By default details
+            from openghg.util.null_metadata_values() will be used.
     Returns:
-        str: Original string or null value
+        str: Original string or value to indicate this is not set
+        None: Only returned if value is None and None is not included as one of the null_values.
     """
-    from openghg.store.spec import null_metadata_values
 
-    if null_value is None:
-        null_values = null_metadata_values()
-        null_value = null_values[0]
+    if not_set_value is None:
+        not_set_values = not_set_metadata_values()
+        not_set_value = not_set_values[0]
 
-    if param is None:
-        param = null_value
+    if param in null_values:
+        param = not_set_value
 
     return param

--- a/tests/util/test_metadata_util.py
+++ b/tests/util/test_metadata_util.py
@@ -110,7 +110,7 @@ def test_merge_dict_raises_no_value_check():
     dict2 = {"site": "bsd"}
 
     with pytest.raises(ValueError) as excinfo:
-        merge_dict(dict1, dict2, check_value=False)
+        merge_dict(dict1, dict2, on_conflict="error")
 
     assert "Unable to merge dictionaries with overlapping keys" in str(excinfo.value)
 

--- a/tests/util/test_metadata_util.py
+++ b/tests/util/test_metadata_util.py
@@ -3,7 +3,7 @@ from openghg.util import get_overlap_keys, merge_dict
 
 
 @pytest.mark.parametrize(
-    "dict1,dict2,expected_output",
+    "left,right,expected_output",
     [
         (
             {"site": "bsd", "inlet": "10m", "species": "ch4"},
@@ -18,20 +18,20 @@ from openghg.util import get_overlap_keys, merge_dict
         ({}, {}, []),
     ],
 )
-def test_get_overlap_keys(dict1, dict2, expected_output):
+def test_get_overlap_keys(left, right, expected_output):
     """
     Test get_overlap_keys can return expected overlapping keys.
     1. Check empty list returned when no overlap
     2. Check overlap with matching keys are identified
     3. Check two empty input dictionaries return an empty list
     """
-    output = get_overlap_keys(dict1, dict2)
+    output = get_overlap_keys(left, right)
     output.sort()
     assert output == expected_output
 
 
 @pytest.mark.parametrize(
-    "dict1,dict2,expected_output",
+    "left,right,expected_output",
     [
         (
             {"site": "bsd", "inlet": "10m"},
@@ -85,7 +85,7 @@ def test_get_overlap_keys(dict1, dict2, expected_output):
         ),       
     ],
 )
-def test_merge_dict(dict1, dict2, expected_output):
+def test_merge_dict(left, right, expected_output):
     """
     1. Check merge with no overlap
     2. Check merge when keys overlap with identical value
@@ -98,25 +98,25 @@ def test_merge_dict(dict1, dict2, expected_output):
     9. Check not set value will be retained if both keys have the same "not_set" value
     10. Check null value (e.g. None) can be removed and ignored.
 
-    For 3, 4 & 5, expect value from dict1 to be used (order matters)
+    For 3, 4 & 5, expect value from left to be used (order matters)
     """
-    output = merge_dict(dict1, dict2)
+    output = merge_dict(left, right)
     assert output == expected_output
 
 
 def test_merge_dict_raises_no_value_check():
     """Test error is raised when there is an overlapping key and value isn't checked"""
-    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
-    dict2 = {"site": "bsd"}
+    left = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    right = {"site": "bsd"}
 
     with pytest.raises(ValueError) as excinfo:
-        merge_dict(dict1, dict2, on_overlap="error")
+        merge_dict(left, right, on_overlap="error")
 
     assert "Unable to merge dictionaries with overlapping keys" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(
-    "on_conflict,dict1,dict2,expected_output",
+    "on_conflict,left,right,expected_output",
     [
         (
             "left",
@@ -138,22 +138,22 @@ def test_merge_dict_raises_no_value_check():
         ),      
     ],
 )
-def test_merge_dict_mismatch(dict1, dict2, on_conflict, expected_output):
+def test_merge_dict_mismatch(left, right, on_conflict, expected_output):
     """
     Test value mismatch can be updated in the correct way for the on_conflict input.
     (1) "left", (2) "right", (3) "drop".
     """
-    output = merge_dict(dict1, dict2, on_conflict=on_conflict)
+    output = merge_dict(left, right, on_conflict=on_conflict)
     assert output == expected_output
 
 
 def test_merge_dict_raises_mismatch():
     """Test error can be raised when there is an overlapping key and value doesn't match"""
-    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
-    dict2 = {"site": "TAC"}
+    left = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    right = {"site": "TAC"}
 
     with pytest.raises(ValueError) as excinfo:
-        merge_dict(dict1, dict2, on_conflict="error")
+        merge_dict(left, right, on_conflict="error")
 
     assert "Same key(s) supplied from different sources:" in str(excinfo.value)
 
@@ -161,75 +161,75 @@ def test_merge_dict_raises_mismatch():
 def test_merge_specific_keys():
     """Test specific keys can be selected for both dict inputs when merging the dictionaries"""
     specific_keys = ["site", "inlet", "data_level"]
-    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
-    dict2 = {"data_level": "1", "species": "inert"}
+    left = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    right = {"data_level": "1", "species": "inert"}
     expected_output = {"site": "bsd", "inlet": "10m", "data_level": "1"}
 
-    output = merge_dict(dict1, dict2, keys=specific_keys)
+    output = merge_dict(left, right, keys=specific_keys)
     assert output == expected_output
 
 
-def test_merge_specific_keys_dict1():
-    """Test specific keys can be selected for dict1 inputs when merging the dictionaries"""
-    specific_keys_dict1 = ["site", "inlet"]
-    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
-    dict2 = {"data_level": "1", "species": "inert"}
+def test_merge_specific_keys_left():
+    """Test specific keys can be selected for left inputs when merging the dictionaries"""
+    specific_keys_left = ["site", "inlet"]
+    left = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    right = {"data_level": "1", "species": "inert"}
     expected_output = {"site": "bsd", "inlet": "10m", "data_level": "1", "species": "inert"}
 
-    output = merge_dict(dict1, dict2, keys_dict1=specific_keys_dict1)
+    output = merge_dict(left, right, keys_left=specific_keys_left)
     assert output == expected_output
 
 
-def test_merge_specific_keys_dict2():
-    """Test specific keys can be selected for dict2 inputs when merging the dictionaries"""
-    specific_keys_dict2 = ["data_level"]
-    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
-    dict2 = {"data_level": "1", "species": "inert"}
+def test_merge_specific_keys_right():
+    """Test specific keys can be selected for right inputs when merging the dictionaries"""
+    specific_keys_right = ["data_level"]
+    left = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    right = {"data_level": "1", "species": "inert"}
     expected_output = {"site": "bsd", "inlet": "10m", "species": "ch4", "data_level": "1"}
 
-    output = merge_dict(dict1, dict2, keys_dict2=specific_keys_dict2)
+    output = merge_dict(left, right, keys_right=specific_keys_right)
     assert output == expected_output
 
 
 def test_merge_not_set_values():
     """Test not_set_values so value is ignored in preference to other value"""
     not_set_values = ["nothing to see here"]
-    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
-    dict2 = {"site": "nothing to see here", "data_level": "1"}
+    left = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    right = {"site": "nothing to see here", "data_level": "1"}
     expected_output = {"site": "bsd", "inlet": "10m", "species": "ch4", "data_level": "1"}
 
-    output = merge_dict(dict1, dict2, not_set_values=not_set_values)
+    output = merge_dict(left, right, not_set_values=not_set_values)
     assert output == expected_output
 
 
 def test_merge_not_set_values_ignore():
     """Test default not_set_values can be ignored."""
     not_set_values = []
-    dict1 = {"site": "not_set", "inlet": "10m", "species": "ch4"}
-    dict2 = {"site": "bsd", "data_level": "1"}
+    left = {"site": "not_set", "inlet": "10m", "species": "ch4"}
+    right = {"site": "bsd", "data_level": "1"}
     expected_output = {"site": "not_set", "inlet": "10m", "species": "ch4", "data_level": "1"}
 
-    output = merge_dict(dict1, dict2, not_set_values=not_set_values)
+    output = merge_dict(left, right, not_set_values=not_set_values)
     assert output == expected_output
 
 
 def test_merge_null_values():
     """Test null_values so value is ignored in preference to other value"""
     null_values = ["null"]
-    dict1 = {"site": "bsd", "inlet": "10m", "species": "null"}
-    dict2 = {"site": "null", "data_level": "null"}
+    left = {"site": "bsd", "inlet": "10m", "species": "null"}
+    right = {"site": "null", "data_level": "null"}
     expected_output = {"site": "bsd", "inlet": "10m"}
 
-    output = merge_dict(dict1, dict2, null_values=null_values)
+    output = merge_dict(left, right, null_values=null_values)
     assert output == expected_output
 
 
 def test_merge_null_values_ignore():
     """Test null values can be made to remain if remove_null is set to False."""
     remove_null = False
-    dict1 = {"site": None, "inlet": "10m"}
-    dict2 = {"site": "bsd", "data_level": "1"}
+    left = {"site": None, "inlet": "10m"}
+    right = {"site": "bsd", "data_level": "1"}
     expected_output = {"site": None, "inlet": "10m", "data_level": "1"}
     
-    output = merge_dict(dict1, dict2, remove_null=remove_null)
+    output = merge_dict(left, right, remove_null=remove_null)
     assert output == expected_output

--- a/tests/util/test_metadata_util.py
+++ b/tests/util/test_metadata_util.py
@@ -1,0 +1,215 @@
+import pytest
+from openghg.util import get_overlap_keys, merge_dict
+
+
+@pytest.mark.parametrize(
+    "dict1,dict2,expected_output",
+    [
+        (
+            {"site": "bsd", "inlet": "10m", "species": "ch4"},
+            {"data_level": "1"}, 
+            []
+        ),
+        (
+            {"site": "bsd", "inlet": "10m", "species": "ch4"},
+            {"site": "bsd", "inlet": "10m", "data_level": "1"}, 
+            ["inlet", "site"]
+        ),
+        ({}, {}, []),
+    ],
+)
+def test_get_overlap_keys(dict1, dict2, expected_output):
+    """
+    Test get_overlap_keys can return expected overlapping keys.
+    1. Check empty list returned when no overlap
+    2. Check overlap with matching keys are identified
+    3. Check two empty input dictionaries return an empty list
+    """
+    output = get_overlap_keys(dict1, dict2)
+    output.sort()
+    assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    "dict1,dict2,expected_output",
+    [
+        (
+            {"site": "bsd", "inlet": "10m"},
+            {"data_level": "1"}, 
+            {"site": "bsd", "inlet": "10m", "data_level": "1"},
+        ),
+        (
+            {"site": "bsd", "inlet": "10m"},
+            {"site": "bsd", "data_level": "1"}, 
+            {"site": "bsd", "inlet": "10m", "data_level": "1"},
+        ),
+        (
+            {"site": "bsd", "inlet": "10m"},
+            {"site": "BSD", "data_level": "1"}, 
+            {"site": "bsd", "inlet": "10m", "data_level": "1"},
+        ),
+        (
+            {"site": "BSD", "data_level": "1"},
+            {"site": "bsd", "inlet": "10m"}, 
+            {"site": "BSD", "inlet": "10m", "data_level": "1"},
+        ),
+        (
+            {"site": "bsd", "inlet": "10m", "latitude": 56.733},
+            {"latitude": "56.7330001"}, 
+            {"site": "bsd", "inlet": "10m", "latitude": 56.733},
+        ),
+        (
+            {"site": "bsd", "inlet": "10m"},
+            {},
+            {"site": "bsd", "inlet": "10m"},
+        ),
+        (
+            {"site": "bsd", "inlet": "not_set"},
+            {"site": "not_set", "inlet": "10m"},
+            {"site": "bsd", "inlet": "10m"},
+        ),
+        (
+            {"site": "bsd", "inlet": "not_set"},
+            {"site": "not_set", "inlet": "10m", "species": "not_set"},
+            {"site": "bsd", "inlet": "10m", "species": "not_set"},
+        ),
+        (
+            {"site": "not_set", "inlet": "not_set"},
+            {"site": "not_set", "inlet": "10m"},
+            {"site": "not_set", "inlet": "10m"},
+        ),
+        (
+            {"site": "bsd", "inlet": None},
+            {"site": None, "inlet": "10m", "data_level": None},
+            {"site": "bsd", "inlet": "10m"},
+        ),       
+    ],
+)
+def test_merge_dict(dict1, dict2, expected_output):
+    """
+    1. Check merge with no overlap
+    2. Check merge when keys overlap with identical value
+    3. Check merge when keys overlap with same str value when lower case
+    4. Check merge when keys overlap with same str value when lower case (reverse order)
+    5. Check merge when keys overlap and number is within tolerance
+    6. Check empty dictionary can be included and original dict returned
+    7. Check not set value (e.g. "not_set") can be ignored and other value used
+    8. Check not set value will be retained if key doesn't overlap
+    9. Check not set value will be retained if both keys have the same "not_set" value
+    10. Check null value (e.g. None) can be removed and ignored.
+
+    For 3, 4 & 5, expect value from dict1 to be used (order matters)
+    """
+    output = merge_dict(dict1, dict2)
+    assert output == expected_output
+
+
+def test_merge_dict_raises_no_value_check():
+    """Test error is raised when there is an overlapping key and value isn't checked"""
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"site": "bsd"}
+
+    with pytest.raises(ValueError) as excinfo:
+        merge_dict(dict1, dict2, check_value=False)
+
+    assert "Unable to merge dictionaries with overlapping keys" in str(excinfo.value)
+
+
+def test_merge_dict_raises_mismatch():
+    """Test error is raised when there is an overlapping key and value doesn't match"""
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"site": "TAC"}
+
+    with pytest.raises(ValueError) as excinfo:
+        merge_dict(dict1, dict2)
+
+    assert "Same key(s) supplied from different sources:" in str(excinfo.value)
+
+
+def test_merge_dict_mismatch():
+    """Test value mismatch can be updated using value from dict1 when flag is passed"""
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"inlet": "90m"}
+    expected_output = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+
+    output = merge_dict(dict1, dict2, resolve_mismatch=True)
+    assert output == expected_output
+
+
+def test_merge_specific_keys():
+    """Test specific keys can be selected for both dict inputs when merging the dictionaries"""
+    specific_keys = ["site", "inlet", "data_level"]
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"data_level": "1", "species": "inert"}
+    expected_output = {"site": "bsd", "inlet": "10m", "data_level": "1"}
+
+    output = merge_dict(dict1, dict2, keys=specific_keys)
+    assert output == expected_output
+
+
+def test_merge_specific_keys_dict1():
+    """Test specific keys can be selected for dict1 inputs when merging the dictionaries"""
+    specific_keys_dict1 = ["site", "inlet"]
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"data_level": "1", "species": "inert"}
+    expected_output = {"site": "bsd", "inlet": "10m", "data_level": "1", "species": "inert"}
+
+    output = merge_dict(dict1, dict2, keys_dict1=specific_keys_dict1)
+    assert output == expected_output
+
+
+def test_merge_specific_keys_dict2():
+    """Test specific keys can be selected for dict2 inputs when merging the dictionaries"""
+    specific_keys_dict2 = ["data_level"]
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"data_level": "1", "species": "inert"}
+    expected_output = {"site": "bsd", "inlet": "10m", "species": "ch4", "data_level": "1"}
+
+    output = merge_dict(dict1, dict2, keys_dict2=specific_keys_dict2)
+    assert output == expected_output
+
+
+def test_merge_not_set_values():
+    """Test not_set_values so value is ignored in preference to other value"""
+    not_set_values = ["nothing to see here"]
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"site": "nothing to see here", "data_level": "1"}
+    expected_output = {"site": "bsd", "inlet": "10m", "species": "ch4", "data_level": "1"}
+
+    output = merge_dict(dict1, dict2, not_set_values=not_set_values)
+    assert output == expected_output
+
+
+def test_merge_not_set_values_ignore():
+    """Test default not_set_values can be ignored."""
+    not_set_values = []
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"site": "not_set", "data_level": "1"}
+
+    with pytest.raises(ValueError) as excinfo:
+        merge_dict(dict1, dict2, not_set_values=not_set_values)
+    
+    assert "Same key(s) supplied from different sources:" in str(excinfo.value)
+
+
+def test_merge_null_values():
+    """Test null_values so value is ignored in preference to other value"""
+    null_values = ["null"]
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "null"}
+    dict2 = {"site": "null", "data_level": "null"}
+    expected_output = {"site": "bsd", "inlet": "10m"}
+
+    output = merge_dict(dict1, dict2, null_values=null_values)
+    assert output == expected_output
+
+
+def test_merge_null_values_ignore():
+    """Test error is raised if remove_null is set to False."""
+    remove_null = False
+    dict1 = {"site": "bsd", "inlet": "10m", "species": "ch4"}
+    dict2 = {"site": None, "data_level": "1"}
+
+    with pytest.raises(ValueError) as excinfo:
+        merge_dict(dict1, dict2, remove_null=remove_null)
+    
+    assert "Same key(s) supplied from different sources:" in str(excinfo.value)


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Splitting out https://github.com/openghg/openghg/pull/1069 to demonstrate the logical steps (Part 3): this is to update the logic for merging additional metadata into the metadata created by the parse functions. This builds on Part 2 https://github.com/openghg/openghg/pull/1112 .

### Combining metadata sources

The `BaseStore.update_metadata` method is updated to sure up the logic around combining metadata sources. This also currently includes making sure any mismatches are highlighted.

#### Metadata sources

Three(/four) current sources of metadata are being merged:
- metadata returned from the parse functions / constructed within the data class
- input parameters - live data passed into read_file function - when merging the metadata only the input parameters NOT passed to the parse function are included.
- additional metadata - defined within read_file function and related to the specific data class - not determined by the user.
  - The optional_metadata input parameter (dictionary) is merged into this after being checked against the required keys list to ensure this is not attempting to add any required keys.

#### Combining sources within update_metadata

- Required keys only from `input_parameters` and `additional_metadata` are added to the current `metadata` for each data source.
   - If any required keys are still missing from the metadata an Error is raised
- Any optional keys from `input_parameters` are added to the metadata
- All keys from `additional_metadata` which have not been added before (i.e. not required keys) are added to the metadata

At all stages, any overlapping keys between the metadata and the selected keys within the source being added will be checked. See details of dictionary merging logic below.

#### New sub-module

Most of the underlying dictionary merging logic is encapsulated within the new `metadata_util` sub-module which includes:
 - `merge_dict` function to deal with the merging of two dictionaries in a way to make sure overlapping keys aren't combined without comment. This includes a set of logical checks to follow when merging:
     - If both values are within tolerance (this can be within a float tolerance or string case-insensitive match) this should log a warning but continue. Uses value from `dict1` in merged output dictionary.
     - If one of the values is "not_set" this should choose the other value, log a warning and continue.
     - If the values do not match within tolerance an Error will be raised by default (this can be bypassed using the `resolve_mismatch` flag - `dict1` will always be given precedence in this case)
     - When merging, a subset of keys from within each dictionary can be selected using `keys` or (`keys_dict1` and/or `keys_dict2`)
 - Module includes definitions of "null" and "not_set" values for metadata
    - this slightly changes our use of "null" and "not_set" from the previous set up as these terms were starting to overlap
       - The use of the term "null" now refers to `None` and is treated as a key to be removed from the metadata
       - The use of the term "not_set" now refers to the string "not_set" and is treated as a key to be retained within the metadata but to superseded if more details are given.

This sub-module is also tested independently of the `BaseStore.update_metadata` method.

### Points to review

Thoughts/Questions:
 - Definitions around null metadata values have been made more explicit and moved from `openghg.store.spec` to `openghg.util._metadata_util` - are we happy with this location for these details?
    - Note: This was mainly to try and ensure `util` functions aren't getting dependencies on `store` sub-modules but perhaps `store.spec` is a reasonable place for this.
 - ~At the moment this creates a hard fail when an incompatible match between the metadata sources is found - do we need to try and find a way to soften this (e.g. user flag) so this doesn't catch people out and not allow them to add data?~ Addressed via code review - this now logs a warning and uses the original metadata value by default.
 - Is there a better, simple way to create filtered dictionaries that don't copy the original dictionary via a dictionary comprehension?
 - Do we want `_metadata_util` to be separate from `_metadata` at all? The reason for putting this in `util` was to keep this general (works for any dicts) and to help avoid cross-dependencies on sub-modules but we do need to find the line for where these types of details should be stored (when does general become specific).

* **Please check if the PR fulfills these requirements**

- [x] Part 3/3 in final stages towards finising issue. Closes #1071 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Documentation and tutorials updated/added

Not needed
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
