### PR TITLE
Tidy up: naming of filepath in ObsColumn

### DIFF
--- a/openghg/standardise/column/_openghg.py
+++ b/openghg/standardise/column/_openghg.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 
 def parse_openghg(
-    data_filepath: Union[str, Path],
+    filepath: Union[str, Path],
     satellite: Optional[str] = None,
     domain: Optional[str] = None,
     selection: Optional[str] = None,
@@ -31,7 +31,7 @@ def parse_openghg(
     will attempt to extract this from the data file.
 
     Args:
-        data_filepath: Path of observation file
+        filepath: Path of observation file
         satellite: Name of satellite (if relevant)
         domain: For satellite only. If data has been selected on an area include the
             identifier name for domain covered. This can map to previously defined domains
@@ -61,12 +61,12 @@ def parse_openghg(
 
     # from openghg.standardise.meta import metadata_default_keys, assign_attributes
 
-    data_filepath = Path(data_filepath)
+    filepath = Path(filepath)
 
-    if data_filepath.suffix.lower() != ".nc":
+    if filepath.suffix.lower() != ".nc":
         raise ValueError("Input file must be a .nc (netcdf) file.")
 
-    data = xr.open_dataset(data_filepath).chunk(chunks)
+    data = xr.open_dataset(filepath).chunk(chunks)
 
     # Extract current attributes from input data
     attributes = cast(MutableMapping, data.attrs)

--- a/openghg/store/_obscolumn.py
+++ b/openghg/store/_obscolumn.py
@@ -165,8 +165,6 @@ class ObsColumn(BaseStore):
             fn_input_parameters, parser_fn
         )
 
-        parser_input_parameters["data_filepath"] = filepath
-
         obs_data = parser_fn(**parser_input_parameters)
 
         # TODO: Add in schema and checks for ObsColumn


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Small follow on from PR #1101 to make sure the consistent naming of `filepath` is included for the `ObsColumn` data type class and parse functions as well as for `ObsSurface`. All other classes should already adhere to this.

* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added

Not needed:
- Closes #xxxx (Replace xxxx with the Github issue number)
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml` 
