### PR TITLE
Updating _download.py to fix mypy issues - one fixed and one ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug where an input filepath list to standardise_surface was only storing the last file hash. This allowed for some files to bypass the check for the same files depending on where they were in the original filepath list. [PR #1100](https://github.com/openghg/openghg/pull/1100)
 - Bug where filepath needed to be a Path object when storing the file hash values. [PR #1108](https://github.com/openghg/openghg/pull/1108)
 - Catch an `AttributeError` when trying synchronise attributes and metadata and a user passes a `bool` - [PR #1029](https://github.com/openghg/openghg/pull/1029)
+- Mypy issue fixed for `util.download_data()` function based on updates described [requests Issue 465](https://github.com/psf/requests/issues/465) and included in [urllib3 PR 159](https://github.com/urllib3/urllib3/pull/159/files). This allowed the `decode_content` flag to be set directly rather than needing to patch the method. [PR #1118](https://github.com/openghg/openghg/pull/1118)
+
 
 ## [0.9.0] - 2024-08-14
 

--- a/openghg/util/_download.py
+++ b/openghg/util/_download.py
@@ -34,7 +34,6 @@ def download_data(
     Returns:
         bytes / None: Bytes if no filepath given
     """
-    import functools
     import io
     import shutil
     from urllib.parse import urlparse

--- a/openghg/util/_download.py
+++ b/openghg/util/_download.py
@@ -83,9 +83,11 @@ def download_data(
     file_size = int(r.headers.get("Content-Length", 0))
 
     desc = f"Downloading {filename}"
-    r.raw.read = functools.partial(r.raw.read, decode_content=True)
+    r.raw.decode_content = True
 
-    with wrap_file(r.raw, total=file_size, description=desc) as r_raw:
+    # mypy error ignored
+    # rich and requests libraries not quite aligning but urllib3.response.HTTPResponse should be very similiar to BinaryIO object expected.
+    with wrap_file(r.raw, total=file_size, description=desc) as r_raw:  # type:ignore
         with io.BytesIO() as buf:
             shutil.copyfileobj(r_raw, buf)
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This is a fix to the two `mypy` errors around the `openghg.util.download_data` function.

#### Fix 1

The `response.raw.read` method was being patched using `functools.partial` to set the `decode_content` flag to be True but this was unecessary as of [urllib3 PR 159](https://github.com/urllib3/urllib3/pull/159/files) as the `decode_content` flag was now exposed and could be set directly.

#### "Fix" 2

This was not fixed, just ignored for now. Justification: this involved the interaction between the `wrap_file` function from the `rich` package and the output from `requests` as these didn't quite align. As these are two third party packages this could easily happen and the "BinaryIO" object expected and the "HTTPResponse | Any" object provided are likely to be designed to be similiar (took a quick look at https://rich.readthedocs.io/en/stable/progress.html and https://requests.readthedocs.io/en/latest/user/quickstart/#raw-response-content for instance). Seems reasonable to ignore for now.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1115 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
