### PR TITLE
Iss1125 empty object store invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bug where a datasource's folder in the `data` directory was not deleted by `Datasource.delete_all_data()`. This was causing `check_zarr_store` in `util/_user.py` to give a false negative [Issue #1125](https://github.com/openghg/openghg/issue/1125). [PR #1126](https://github.com/openghg/openghg/pull/1126) 
 - Bug where an input filepath list to standardise_surface was only storing the last file hash. This allowed for some files to bypass the check for the same files depending on where they were in the original filepath list. [PR #1100](https://github.com/openghg/openghg/pull/1100)
 - Bug where filepath needed to be a Path object when storing the file hash values. [PR #1108](https://github.com/openghg/openghg/pull/1108)
 - Catch an `AttributeError` when trying synchronise attributes and metadata and a user passes a `bool` - [PR #1029](https://github.com/openghg/openghg/pull/1029)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bug where a datasource's folder in the `data` directory was not deleted by `Datasource.delete_all_data()`. This was causing `check_zarr_store` in `util/_user.py` to give a false negative [Issue #1125](https://github.com/openghg/openghg/issue/1125). [PR #1126](https://github.com/openghg/openghg/pull/1126) 
+- Bug where a datasource's folder in the `data` directory was not deleted by `Datasource.delete_all_data()`. This was causing `check_zarr_store` in `util/_user.py` to give a false negative. [PR #1126](https://github.com/openghg/openghg/pull/1126) 
 - Bug where an input filepath list to standardise_surface was only storing the last file hash. This allowed for some files to bypass the check for the same files depending on where they were in the original filepath list. [PR #1100](https://github.com/openghg/openghg/pull/1100)
 - Bug where filepath needed to be a Path object when storing the file hash values. [PR #1108](https://github.com/openghg/openghg/pull/1108)
 - Catch an `AttributeError` when trying synchronise attributes and metadata and a user passes a `bool` - [PR #1029](https://github.com/openghg/openghg/pull/1029)

--- a/openghg/dataobjects/_datamanager.py
+++ b/openghg/dataobjects/_datamanager.py
@@ -221,7 +221,7 @@ class DataManager:
                     self.metadata[u] = internal_copy
                     logger.info(f"Modified metadata for {u}.")
 
-    def delete_datasource(self, uuid: Union[List, str], delete_one: bool = True) -> None:
+    def delete_datasource(self, uuid: Union[List, str]) -> None:
         """Delete Datasource(s) in the object store.
         At the moment we only support deleting the complete Datasource.
 
@@ -243,7 +243,7 @@ class DataManager:
         with open_metastore(bucket=self._bucket, data_type=dtype) as metastore:
             for uid in uuid:
                 # First remove the data from the metadata store
-                metastore.delete({"uuid": uid}, delete_one=delete_one)
+                metastore.delete({"uuid": uid})
 
                 # Delete all the data associated with a Datasource and the
                 # data in its zarr store.

--- a/openghg/store/base/_datasource.py
+++ b/openghg/store/base/_datasource.py
@@ -365,9 +365,12 @@ class Datasource:
         self._last_updated = timestamp_str_now
 
     def delete_all_data(self) -> None:
-        """Delete the zarr store that contains all the data
-        associated with this Datasource and clear out all keys
-        stored in this Datasource.=
+        """Delete datasource entirely.
+
+        Deletes the zarr store that contains all the data
+        associated with this Datasource, clears out all keys
+        stored in this Datasource, and removes the uuid
+        from the `data` path.
 
         Returns:
             None

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -259,7 +259,13 @@ class LocalZarrStore(Store):
         """
         self._check_writable()
         self._stores.clear()
-        shutil.rmtree(self._stores_path.parent, ignore_errors=True)
+
+        # make sure we're not deleting too much...
+        bucket_path = Path(self._bucket).expanduser().resolve()
+        if self._stores_path.parent not in [bucket_path, bucket_path / "data"]:
+            shutil.rmtree(self._stores_path.parent, ignore_errors=True)
+        else:
+            shutil.rmtree(self._stores_path, ignore_errors=True)
 
     def update(
         self,

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -259,7 +259,7 @@ class LocalZarrStore(Store):
         """
         self._check_writable()
         self._stores.clear()
-        shutil.rmtree(self._stores_path, ignore_errors=True)
+        shutil.rmtree(self._stores_path.parent, ignore_errors=True)
 
     def update(
         self,

--- a/tests/store/storage/test_localzarrstore.py
+++ b/tests/store/storage/test_localzarrstore.py
@@ -169,6 +169,8 @@ def test_delete_all(store):
 
     assert not parent.exists()
 
+    assert not parent.parent.exists()
+
 
 def test_pop_dataset(store):
     datapath = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Changed `LocalZarrStore.delete_all()` to delete the folder in the `data` dir associated with that zarr store. (That is, to delete `data/<datasource uuid>`, not just `data/<datasource uuid>/zarr`.)

It's possible that this should be handled by the `Datasource` instead. The way `Datasource` and `LocalZarrStore` interact at the moment, the path `data/<datasource uuid>` isn't explicitly used by `Datasource`. Instead, the datasource uuid is passed to `LocalZarrStore`, which decides where it should exist (i.e. in `data/<datasource uuid>/zarr`).

The datasource should probably know where its data is, and tell `LocalZarrStore` where to create the `zarr` directory, but that would be a bigger change. (Also, `LocalZarrStore` handles the locations of versions, which may or may not be what we want.)

Anyway, this fixes the problem of false negatives for the "zarr store check" in util/_user.py, from issue #1125, since that was caused by an empty folder like `data/<datasource uuid>`: the check says that `data/<datasource uuid>/zarr` doesn't exist, so it must not be a zarr store. The problem is that `data/<datasource uuid>` wasn't deleted when the datasource was deleted.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1125
- [x] Existing tests updated
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
