### PR TITLE
Adding option to get_obs_column to choose whether to return mole fractions or column values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.10.0...HEAD)
 
+### Updated
+
+- Added option to `get_obs_column` to return the column data directly rather than converting to mole fractions. [PR #1131](https://github.com/openghg/openghg/pull/1131)
+
+
 ## [0.10.0] - 2024-09-24
 
 ### Updated

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -473,6 +473,7 @@ def get_obs_column(
     platform: str = "satellite",
     start_date: Optional[Union[str, Timestamp]] = None,
     end_date: Optional[Union[str, Timestamp]] = None,
+    return_mf: bool = True,
     **kwargs: Any,
 ) -> ObsColumnData:
     """Extract available column data from the object store using keywords.
@@ -484,6 +485,7 @@ def get_obs_column(
         start_date: Start date
         end_date: End date
         time_resolution: One of ["standard", "high"]
+        return_mf: Return mole fraction rather than column data. Default=True
         kwargs: Additional search terms
     Returns:
         ObsColumnData: ObsColumnData object
@@ -503,70 +505,72 @@ def get_obs_column(
         **kwargs,
     )
 
-    if max_level > max(obs_data.data.lev.values) + 1:
-        logger.warning(
-            f"passed max level is above max level in data ({max(obs_data.data.lev.values)+1}). Defaulting to highest level"
+    if return_mf:
+
+        if max_level > max(obs_data.data.lev.values) + 1:
+            logger.warning(
+                f"passed max level is above max level in data ({max(obs_data.data.lev.values)+1}). Defaulting to highest level"
+            )
+            max_level = max(obs_data.data.lev.values) + 1
+
+        ## processing taken from acrg/acrg/obs/read.py get_gosat()
+        lower_levels = list(range(0, max_level))
+
+        prior_factor = (
+            obs_data.data.pressure_weights[dict(lev=list(lower_levels))]
+            * (1.0 - obs_data.data.xch4_averaging_kernel[dict(lev=list(lower_levels))])
+            * obs_data.data.ch4_profile_apriori[dict(lev=list(lower_levels))]
+        ).sum(dim="lev")
+
+        upper_levels = list(range(max_level, len(obs_data.data.lev.values)))
+        prior_upper_level_factor = (
+            obs_data.data.pressure_weights[dict(lev=list(upper_levels))]
+            * obs_data.data.ch4_profile_apriori[dict(lev=list(upper_levels))]
+        ).sum(dim="lev")
+
+        obs_data.data["mf_prior_factor"] = prior_factor
+        obs_data.data["mf_prior_upper_level_factor"] = prior_upper_level_factor
+        obs_data.data["mf"] = (
+            obs_data.data.xch4 - obs_data.data.mf_prior_factor - obs_data.data.mf_prior_upper_level_factor
         )
-        max_level = max(obs_data.data.lev.values) + 1
+        obs_data.data["mf_repeatability"] = obs_data.data.xch4_uncertainty
 
-    ## processing taken from acrg/acrg/obs/read.py get_gosat()
-    lower_levels = list(range(0, max_level))
+        # rt17603: 06/04/2018 Added drop variables to ensure lev and id dimensions are also dropped, Causing problems in footprints_data_merge() function
+        drop_data_vars = [
+            "xch4",
+            "xch4_uncertainty",
+            "lon",
+            "lat",
+            "ch4_profile_apriori",
+            "xch4_averaging_kernel",
+            "pressure_levels",
+            "pressure_weights",
+            "exposure_id",
+        ]
+        drop_coords = ["lev", "id"]
 
-    prior_factor = (
-        obs_data.data.pressure_weights[dict(lev=list(lower_levels))]
-        * (1.0 - obs_data.data.xch4_averaging_kernel[dict(lev=list(lower_levels))])
-        * obs_data.data.ch4_profile_apriori[dict(lev=list(lower_levels))]
-    ).sum(dim="lev")
+        for dv in drop_data_vars:
+            if dv in obs_data.data.data_vars:
+                obs_data.data = obs_data.data.drop_vars(dv)
+        for coord in drop_coords:
+            if coord in obs_data.data.coords:
+                obs_data.data = obs_data.data.drop_vars(coord)
 
-    upper_levels = list(range(max_level, len(obs_data.data.lev.values)))
-    prior_upper_level_factor = (
-        obs_data.data.pressure_weights[dict(lev=list(upper_levels))]
-        * obs_data.data.ch4_profile_apriori[dict(lev=list(upper_levels))]
-    ).sum(dim="lev")
+        obs_data.data.attrs["max_level"] = max_level
+        if species.upper() == "CH4":
+            # obs_data.data.mf.attrs["units"] = "1e-9"
+            obs_data.data.attrs["species"] = "CH4"
+        if species.upper() == "CO2":
+            # obs_data.data.mf.attrs["units"] = "1e-6"
+            obs_data.data.attrs["species"] = "CO2"
 
-    obs_data.data["mf_prior_factor"] = prior_factor
-    obs_data.data["mf_prior_upper_level_factor"] = prior_upper_level_factor
-    obs_data.data["mf"] = (
-        obs_data.data.xch4 - obs_data.data.mf_prior_factor - obs_data.data.mf_prior_upper_level_factor
-    )
-    obs_data.data["mf_repeatability"] = obs_data.data.xch4_uncertainty
+        # obs_data.data.attrs["scale"] = "GOSAT"
 
-    # rt17603: 06/04/2018 Added drop variables to ensure lev and id dimensions are also dropped, Causing problems in footprints_data_merge() function
-    drop_data_vars = [
-        "xch4",
-        "xch4_uncertainty",
-        "lon",
-        "lat",
-        "ch4_profile_apriori",
-        "xch4_averaging_kernel",
-        "pressure_levels",
-        "pressure_weights",
-        "exposure_id",
-    ]
-    drop_coords = ["lev", "id"]
-
-    for dv in drop_data_vars:
-        if dv in obs_data.data.data_vars:
-            obs_data.data = obs_data.data.drop_vars(dv)
-    for coord in drop_coords:
-        if coord in obs_data.data.coords:
-            obs_data.data = obs_data.data.drop_vars(coord)
+        obs_data.metadata["transforms"] = (
+            f"For creating mole fraction, used apriori data for levels above max_level={max_level}"
+        )
 
     obs_data.data = obs_data.data.sortby("time")
-
-    obs_data.data.attrs["max_level"] = max_level
-    if species.upper() == "CH4":
-        # obs_data.data.mf.attrs["units"] = "1e-9"
-        obs_data.data.attrs["species"] = "CH4"
-    if species.upper() == "CO2":
-        # obs_data.data.mf.attrs["units"] = "1e-6"
-        obs_data.data.attrs["species"] = "CO2"
-
-    # obs_data.data.attrs["scale"] = "GOSAT"
-
-    obs_data.metadata["transforms"] = (
-        f"For creating mole fraction, used apriori data for levels above max_level={max_level}"
-    )
 
     return ObsColumnData(data=obs_data.data, metadata=obs_data.metadata)
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This PR adds an additional `return_mf` option to `get_obs_column()` to not apply the updates to convert to mf and to just return the original column data (e.g. `xch4`). This is similiar but a bit different to #1130 as this bypasses the steps to convert the data rather than just rename the variables.

This feeds into PR https://github.com/openghg/openghg/pull/1117 (and related to #1130 ) as this allows us to use the `get` functions for both column and site data when creating an expected obspack output.

* **Please check if the PR fulfills these requirements**

- [x] Related to #1078
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] **No tests added** but they do pass [Tests passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] Documentation ~and tutorials~ updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
