### PR TITLE
search_surface formats dictionary of data levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.10.0...HEAD)
 
+### Fixed
+
+- Bug where `search_surface` couldn't accept a dictionary argument for `data_level`. [PR #1133](https://github.com/openghg/openghg/pull/1133)
+
 ## [0.10.0] - 2024-09-24
 
 ### Updated

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -319,6 +319,8 @@ def search_surface(
     # Ensure data_level input is formatted
     if isinstance(data_level, list):
         data_level = [format_data_level(value) for value in data_level]
+    elif isinstance(data_level, dict):
+        data_level = {k: format_data_level(v) for k, v in data_level.items()}  # type: ignore  (this is potentially a problem for any parameter)
     else:
         data_level = format_data_level(data_level)
 

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -261,7 +261,7 @@ def search_surface(
     inlet: Union[str, slice, None, list[Union[str, slice, None]]] = None,
     height: Union[str, slice, None, list[Union[str, slice, None]]] = None,
     instrument: Union[str, list[str], None] = None,
-    data_level: Union[str, list[str], None] = None,
+    data_level: Union[str, list[str], dict, None] = None,
     data_sublevel: Union[str, list[str], None] = None,
     dataset_source: Optional[str] = None,
     data_source: Optional[str] = None,
@@ -320,7 +320,7 @@ def search_surface(
     if isinstance(data_level, list):
         data_level = [format_data_level(value) for value in data_level]
     elif isinstance(data_level, dict):
-        data_level = {k: format_data_level(v) for k, v in data_level.items()}  # type: ignore  (this is potentially a problem for any parameter)
+        data_level = {k: format_data_level(v) for k, v in data_level.items()}
     else:
         data_level = format_data_level(data_level)
 

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -247,12 +247,13 @@ def test_many_term_search():
 
 
 def test_optional_term_search():
-    """Test search using dict inputs. This should create an OR search between the key, value pairs in the dictionaries"""
+    """Test search using dicst inputs. This should create an OR search between the key, value pairs in the dictionaries"""
     # Note: had to be careful to not create duplicates as this currently raises an error.
     res = search(
         site="bsd",
         inlet_option={"inlet": "42m", "height": "42m"},
         name_option={"station_long_name": "bilsdale, uk", "long_name": "bilsdale"},
+        data_level={"icos_data_level": 2, "data_level": "not_set"},
     )
 
     assert len(res.metadata) == 3

--- a/tests/retrieve/test_search.py
+++ b/tests/retrieve/test_search.py
@@ -247,7 +247,7 @@ def test_many_term_search():
 
 
 def test_optional_term_search():
-    """Test search using dicst inputs. This should create an OR search between the key, value pairs in the dictionaries"""
+    """Test search using dict inputs. This should create an OR search between the key, value pairs in the dictionaries"""
     # Note: had to be careful to not create duplicates as this currently raises an error.
     res = search(
         site="bsd",


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

It is possible to pass a dictionary to any of the parameters in `search_surface` (or any `search_` functions), so the formatting functions we use must be able to format dictionaries. 

I fixed the specific case of `data_levels`. Formatting done in `_base_search` should work with dictionaries, since this formatting either uses `format_inlet`, which is overloaded to work with dictionaries and lists, or it applies `clean_string`, using cases for lists and dicts.

Note: I had to add a `type: ignore` for the dictionary check because passing a dictionary for `data_level` is not allowed by the signature of `search_surface`. However, this is a problem for all of the arguments in the signature of `search_surface`, so I think we need a more general fix. (Or just use dynamic typing here, since dicts are handled by `_base_search`.)

* **Please check if the PR fulfills these requirements**

- [x] Closes #1132
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
