### PR TITLE
Workflow updated to fetch git_tag and env build in publsih step

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -136,8 +136,11 @@ jobs:
           conda config --append channels openghg
           mkdir ${{ github.workspace }}/build
           conda mambabuild --croot ${{ github.workspace }}/build recipes -c conda-forge
+        env:
+          GIT_TAG: ${{ github.ref_name }}
       - name: Publish build to Anaconda
         run: |
+          micromamba activate openghg_build
           BUILD_DIR=${GITHUB_WORKSPACE}/build
           BUILD=$(find "$BUILD_DIR" -name '*.tar.bz2')
           anaconda --token "$ANACONDA_TOKEN" upload --user openghg --label main "$BUILD"


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Workflow updated to fetch git_tag and activate env build in publish step of the release_conda job.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #1134 (Replace xxxx with the Github issue number)
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

