### PR TITLE
Added missing attributes to icos and test icos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Removed parsers that are unused. [PR #1129](https://github.com/openghg/openghg/pull/1129)
+- Added `data_owner` and `inlet_height_magl` as attributes to parse_icos. [PR #1147](https://github.com/openghg/openghg/pull/1147)
 
 ### Updated
 

--- a/openghg/standardise/surface/_icos.py
+++ b/openghg/standardise/surface/_icos.py
@@ -217,6 +217,10 @@ def _read_data_large_header(
         "network": network,
         "instrument": instrument,
     }
+    attributes = {
+        "inlet_height_magl": metadata["inlet_height_magl"],
+        "data_owner": "See data owner email"
+    }
 
     if measurement_type is not None:
         metadata["measurement_type"] = measurement_type
@@ -232,11 +236,13 @@ def _read_data_large_header(
     if len(f_header) == 1:
         data_owner_email = f_header[0].split(":")[1].strip()
         metadata["data_owner_email"] = data_owner_email
+        attributes["data_owner"] = data_owner_email
     else:
         f_header = [s for s in header if "CONTACT POINT EMAIL" in s]
         if len(f_header) == 1:
             data_owner_email = f_header[0].split(":")[1].strip()
             metadata["data_owner_email"] = data_owner_email
+            attributes["data_owner"] = data_owner_email
         else:
             raise ValueError("Couldn't identify data owner email")
 
@@ -250,6 +256,7 @@ def _read_data_large_header(
         species_fname.lower(): {
             "metadata": metadata,
             "data": data,
+            "attributes": attributes
         }
     }
 
@@ -377,6 +384,10 @@ def _read_data_small_header(
         "data_type": "surface",
         "source_format": "icos",
     }
+    attributes = {
+        "inlet_height_magl": metadata["inlet"],
+        "data_owner": "NOT_SET"
+    }
 
     if measurement_type is not None:
         metadata["measurement_type"] = measurement_type
@@ -385,6 +396,7 @@ def _read_data_small_header(
         species_fname: {
             "metadata": metadata,
             "data": data,
+            "attributes": attributes
         }
     }
 

--- a/openghg/standardise/surface/_icos.py
+++ b/openghg/standardise/surface/_icos.py
@@ -217,10 +217,7 @@ def _read_data_large_header(
         "network": network,
         "instrument": instrument,
     }
-    attributes = {
-        "inlet_height_magl": metadata["inlet_height_magl"],
-        "data_owner": "See data owner email"
-    }
+    attributes = {"inlet_height_magl": metadata["inlet_height_magl"], "data_owner": "See data owner email"}
 
     if measurement_type is not None:
         metadata["measurement_type"] = measurement_type
@@ -252,13 +249,7 @@ def _read_data_large_header(
         if interval_str == "hourly":
             metadata["sampling_period"] = "3600.0"
 
-    species_data = {
-        species_fname.lower(): {
-            "metadata": metadata,
-            "data": data,
-            "attributes": attributes
-        }
-    }
+    species_data = {species_fname.lower(): {"metadata": metadata, "data": data, "attributes": attributes}}
 
     return species_data
 
@@ -384,20 +375,11 @@ def _read_data_small_header(
         "data_type": "surface",
         "source_format": "icos",
     }
-    attributes = {
-        "inlet_height_magl": metadata["inlet"],
-        "data_owner": "NOT_SET"
-    }
+    attributes = {"inlet_height_magl": metadata["inlet"], "data_owner": "NOT_SET"}
 
     if measurement_type is not None:
         metadata["measurement_type"] = measurement_type
 
-    species_data = {
-        species_fname: {
-            "metadata": metadata,
-            "data": data,
-            "attributes": attributes
-        }
-    }
+    species_data = {species_fname: {"metadata": metadata, "data": data, "attributes": attributes}}
 
     return species_data

--- a/openghg/standardise/surface/_icos.py
+++ b/openghg/standardise/surface/_icos.py
@@ -217,7 +217,7 @@ def _read_data_large_header(
         "network": network,
         "instrument": instrument,
     }
-    attributes = {"inlet_height_magl": metadata["inlet_height_magl"], "data_owner": "See data owner email"}
+    attributes = {"inlet_height_magl": metadata["inlet_height_magl"], "data_owner": "See data_owner_email"}
 
     if measurement_type is not None:
         metadata["measurement_type"] = measurement_type

--- a/openghg/standardise/surface/_icos.py
+++ b/openghg/standardise/surface/_icos.py
@@ -233,13 +233,11 @@ def _read_data_large_header(
     if len(f_header) == 1:
         data_owner_email = f_header[0].split(":")[1].strip()
         metadata["data_owner_email"] = data_owner_email
-        attributes["data_owner"] = data_owner_email
     else:
         f_header = [s for s in header if "CONTACT POINT EMAIL" in s]
         if len(f_header) == 1:
             data_owner_email = f_header[0].split(":")[1].strip()
             metadata["data_owner_email"] = data_owner_email
-            attributes["data_owner"] = data_owner_email
         else:
             raise ValueError("Couldn't identify data owner email")
 

--- a/tests/standardise/surface/test_icos.py
+++ b/tests/standardise/surface/test_icos.py
@@ -30,7 +30,7 @@ def test_read_icos_large_header():
         "station_latitude": 51.99747,
         "station_long_name": "Ridge Hill, UK",
         "station_height_masl": 207.0,
-        'data_owner': 's.odoherty@bris.ac.uk,joseph.pitt@bristol.ac.uk,k.m.stanley@bristol.ac.uk',
+        'data_owner': 'See data_owner_email',
     }
 
     metadata = data["ch4"]["metadata"]

--- a/tests/standardise/surface/test_icos.py
+++ b/tests/standardise/surface/test_icos.py
@@ -30,6 +30,7 @@ def test_read_icos_large_header():
         "station_latitude": 51.99747,
         "station_long_name": "Ridge Hill, UK",
         "station_height_masl": 207.0,
+        'data_owner': 's.odoherty@bris.ac.uk,joseph.pitt@bristol.ac.uk,k.m.stanley@bristol.ac.uk',
     }
 
     metadata = data["ch4"]["metadata"]
@@ -110,6 +111,9 @@ def test_read_icos_small_header_file():
         "station_latitude": 56.55511,
         "station_long_name": "Angus Tower, UK",
         "station_height_masl": 300.0,
+        'data_owner': 'NOT_SET',
+        'inlet_height_magl': '222m',
+
     }
 
     assert attrs == expected_attrs
@@ -136,6 +140,8 @@ def test_read_icos_small_header_file():
         "station_height_masl": 300.0,
         "data_type": "surface",
         "source_format": "icos",
+        'data_owner': 'NOT_SET',
+        'inlet_height_magl': '222m',
     }
 
     assert co2_metadata == expected_metadata


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Added inlet_height_magl and data_owner attributes to parse_icos.
A step towards `sync_surface_metadata` movement to store level.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1145 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

