### PR TITLE
Quick (and unpleasant) fix for force keyword to stop this always creating a new version

### DIFF
--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -136,11 +136,14 @@ class BoundaryConditions(BaseStore):
                 "Overwrite flag is deprecated in preference to `if_exists` (and `save_current`) inputs."
                 "See documentation for details of these inputs and options."
             )
-            if_exists = "new"
+            if_exists = "new"  # TODO: Update to "combine" when available
 
-        # Making sure new version will be created by default if force keyword is included.
+        # Warning that force without new version may cause a DataOverlapError
         if force and if_exists == "auto":
-            if_exists = "new"
+            logger.warning(
+                "This skips the check that files have already been added but may still result in a DataOverlapError."
+                " If adding multiple files use if_exists='new' for the first file only and use if_exists='auto' afterwards."
+            )
 
         new_version = check_if_need_new_version(if_exists, save_current)
 

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -105,11 +105,14 @@ class EulerianModel(BaseStore):
                 "Overwrite flag is deprecated in preference to `if_exists` (and `save_current`) inputs."
                 "See documentation for details of these inputs and options."
             )
-            if_exists = "new"
+            if_exists = "new"  # TODO: Update to "combine" when available
 
-        # Making sure new version will be created by default if force keyword is included.
+        # Warning that force without new version may cause a DataOverlapError
         if force and if_exists == "auto":
-            if_exists = "new"
+            logger.warning(
+                "This skips the check that files have already been added but may still result in a DataOverlapError."
+                " If adding multiple files use if_exists='new' for the first file only and use if_exists='auto' afterwards."
+            )
 
         new_version = check_if_need_new_version(if_exists, save_current)
 

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -155,11 +155,14 @@ class Flux(BaseStore):
                 "Overwrite flag is deprecated in preference to `if_exists` (and `save_current`) inputs."
                 "See documentation for details of these inputs and options."
             )
-            if_exists = "new"
+            if_exists = "new"  # TODO: Update to "combine" when available
 
-        # Making sure new version will be created by default if force keyword is included.
+        # Warning that force without new version may cause a DataOverlapError
         if force and if_exists == "auto":
-            if_exists = "new"
+            logger.warning(
+                "This skips the check that files have already been added but may still result in a DataOverlapError."
+                " If adding multiple files use if_exists='new' for the first file only and use if_exists='auto' afterwards."
+            )
 
         new_version = check_if_need_new_version(if_exists, save_current)
 

--- a/openghg/store/_flux_timeseries.py
+++ b/openghg/store/_flux_timeseries.py
@@ -137,11 +137,14 @@ class FluxTimeseries(BaseStore):
                 "Overwrite flag is deprecated in preference to `if_exists` (and `save_current`) inputs."
                 "See documentation for details of these inputs and options."
             )
-            if_exists = "new"
+            if_exists = "new"  # TODO: Update to "combine" when available
 
-        # Making sure new version will be created by default if force keyword is included.
+        # Warning that force without new version may cause a DataOverlapError
         if force and if_exists == "auto":
-            if_exists = "new"
+            logger.warning(
+                "This skips the check that files have already been added but may still result in a DataOverlapError."
+                " If adding multiple files use if_exists='new' for the first file only and use if_exists='auto' afterwards."
+            )
 
         new_version = check_if_need_new_version(if_exists, save_current)
 

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -345,11 +345,14 @@ class Footprints(BaseStore):
                 "Overwrite flag is deprecated in preference to `if_exists` (and `save_current`) inputs."
                 "See documentation for details of these inputs and options."
             )
-            if_exists = "new"
+            if_exists = "new"  # TODO: Update to "combine" when available
 
-        # Making sure new version will be created by default if force keyword is included.
+        # Warning that force without new version may cause a DataOverlapError
         if force and if_exists == "auto":
-            if_exists = "new"
+            logger.warning(
+                "This skips the check that files have already been added but may still result in a DataOverlapError."
+                " If adding multiple files use if_exists='new' for the first file only and use if_exists='auto' afterwards."
+            )
 
         new_version = check_if_need_new_version(if_exists, save_current)
 

--- a/openghg/store/_obscolumn.py
+++ b/openghg/store/_obscolumn.py
@@ -126,11 +126,14 @@ class ObsColumn(BaseStore):
                 "Overwrite flag is deprecated in preference to `if_exists` (and `save_current`) inputs."
                 "See documentation for details of these inputs and options."
             )
-            if_exists = "new"
+            if_exists = "new"  # TODO: Update to "combine" when available
 
-        # Making sure new version will be created by default if force keyword is included.
+        # Warning that force without new version may cause a DataOverlapError
         if force and if_exists == "auto":
-            if_exists = "new"
+            logger.warning(
+                "This skips the check that files have already been added but may still result in a DataOverlapError."
+                " If adding multiple files use if_exists='new' for the first file only and use if_exists='auto' afterwards."
+            )
 
         new_version = check_if_need_new_version(if_exists, save_current)
 

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -275,11 +275,14 @@ class ObsSurface(BaseStore):
                 "Overwrite flag is deprecated in preference to `if_exists` (and `save_current`) inputs."
                 "See documentation for details of these inputs and options."
             )
-            if_exists = "new"
+            if_exists = "new"  # TODO: Update to "combine" when available
 
-        # Making sure new version will be created by default if force keyword is included.
+        # Warning that force without new version may cause a DataOverlapError
         if force and if_exists == "auto":
-            if_exists = "new"
+            logger.warning(
+                "This skips the check that files have already been added but may still result in a DataOverlapError."
+                " If adding multiple files use if_exists='new' for the first file only and use if_exists='auto' afterwards."
+            )
 
         new_version = check_if_need_new_version(if_exists, save_current)
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The `force` keyword is used to allow users to add data identical to what has been seen before. At the moment the `force` keyword always sets `if_exists="new"` to ensure that a new version is created and an error is raised because the data is already present. However, the problem is when there are multiple files to be added which have all been seen before this creates a new version every time and there's no way to stop this.

This is a quick fix to not set `if_exists="new"` but to include a warning that this may result in a DataOverlapError. This also includes the advice to use `if_exists="new"` for the first file and to not use this keyword (or use `if_exists="auto"`) afterwards. It's definitely not the nicest solution but would get past the issue of multiple files being added which have been seen before.

Note: we're still missing what is becoming a key mode which allows data to be combined with data even when there is an overlap (Issue #881 ) which would fill in some of the missing scenarios we have at the moment for adding new data.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
