### PR TITLE
Adding in final check to get_obs_surface_local to check size of time dimension

### DIFF
--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -458,6 +458,11 @@ def get_obs_surface_local(
     #     )
     #     print("Suggestion: set calibration_scale to convert scales")
 
+    if obs_data.data["time"].size == 0:
+        err_msg = "After retrieval and filtering, data has no entries on the time axis."
+        logger.exception(err_msg)
+        raise SearchError(err_msg)
+
     return obs_data
 
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)



Within Issue #1121 , this showed a corner case where data can be returned which contains no entries on the time dimension if there is one variable in the data which contains NaN values. This is because after retrieving the data from the object store the NaN values will be dropped by default.

This is fix 1/2 for this Issue to make sure a `SearchError` is raised if we're trying to return data after the resampling and filtering which contains no data.

TODO:
 - [ ] Get example of data and set up which causes this error and add test

* **Please check if the PR fulfills these requirements**

- [ ] Fixes 1/2 updates from  #1121 
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed:
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
