### PR TITLE
Allow ThreadSynchronizer to handle partial chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.10.1...HEAD)
 
+### Fixed
+
+- Fixed options used with `xr.Dataset.to_zarr` in reponse to updates in xarray. [PR #1160](https://github.com/openghg/openghg/pull/1160)
+
 ### Added
 
 - Removed parsers that are unused. [PR #1129](https://github.com/openghg/openghg/pull/1129)
@@ -15,10 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated ICOS standardise function to reflect changes in ASCII file format. [PR #1140](https://github.com/openghg/openghg/pull/1140)
-
-
-### Updated
-
 - Added `rename_vars` option to `get_obs_surface` to allow variable names based around species to be returned. [PR #1130](https://github.com/openghg/openghg/pull/1130)
 - Added option to `get_obs_column` to return the column data directly rather than converting to mole fractions. [PR #1131](https://github.com/openghg/openghg/pull/1131)
 

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -166,6 +166,7 @@ class LocalZarrStore(Store):
                 append_dim=append_dim,
                 compute=True,
                 synchronizer=zarr.ThreadSynchronizer(),
+                safe_chunks=False,
             )
         # Otherwise we create a new zarr Store for the version
         else:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

With new updates to xarray, it is no longer possible to append data to a zarr store if the chunks of the new data match the chunks of the existing data *and* the existing data in the zarr store has a partial chunk at the point where the new data will start.

To get around this, we can pass `safe_chunks=False` to bypass the new xarray check and keep the existing behavior.

In general, we should avoid this entire problem by adding as much data as possible at once, using
`open_mfdataset` to open the new data files.

There are other ways around this issue besides
setting `safe_chunks=False`, but this would entail detecting partial chunks in the region being written to, and then rechuncking or splitting up the new data so that the partial chunk is filled and then all the remaining chunks of the new data align exactly with the chunks in the zarr store.


* **Please check if the PR fulfills these requirements**

- [x] Closes #1159 
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

