### PR TITLE
Added check for file lock permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Check for file lock permissions with helpful error message. File locks are now created with rw permissions for user and group. [PR #1168](https://github.com/openghg/openghg/pull/1168)
 - Removed parsers that are unused. [PR #1129](https://github.com/openghg/openghg/pull/1129)
 - Added `data_owner` and `inlet_height_magl` as attributes to parse_icos. [PR #1147](https://github.com/openghg/openghg/pull/1147)
 - Moved `sync_surface_metadata` to ObsSurface.read_file function so this is applied for all input data regardless of source_format. [PR #1138](https://github.com/openghg/openghg/pull/1138)

--- a/openghg/objectstore/metastore/_classic_metastore.py
+++ b/openghg/objectstore/metastore/_classic_metastore.py
@@ -32,7 +32,7 @@ from filelock import FileLock
 from openghg.objectstore import exists, get_object, set_object_from_json, get_object_lock_path
 from openghg.objectstore.metastore import TinyDBMetaStore
 from openghg.types import MetastoreError
-from openghg.util import hash_string
+from openghg.util import hash_string, permissions
 import tinydb
 from tinydb.middlewares import Middleware
 
@@ -237,6 +237,20 @@ class DataClassMetaStore(TinyDBMetaStore):
         super().__init__(database=database)
 
         lock_path = get_object_lock_path(bucket, self.key)
+
+        # If lock is created for first time, make sure group has 'rw' permissions
+        if not lock_path.exists():
+            lock_path.touch(mode=0o664)
+
+        # check permissions
+        perms = permissions(lock_path)
+
+        if "w" not in perms[0]:
+            raise PermissionError(
+                "You do not have the correct permissions to add data to this object store."
+                f"Ask {lock_path.owner()} to set group permissions for {lock_path} to 'rw'."
+            )
+
         self.lock = FileLock(lock_path, timeout=600)  # file lock with 10 minute timeout
 
     def acquire_lock(self) -> None:

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -32,6 +32,7 @@ from ._file import (
     load_transform_parser,
     read_header,
     check_function_open_nc,
+    permissions,
 )
 from ._function_inputs import split_function_inputs
 from ._hashing import hash_bytes, hash_file, hash_retrieved_data, hash_string

--- a/openghg/util/_file.py
+++ b/openghg/util/_file.py
@@ -277,9 +277,9 @@ def check_function_open_nc(filepath: multiPathType) -> Tuple[Callable, multiPath
 def permissions(file_path: str | Path) -> tuple[str, str, str]:
     """Return r, w, and/or x permissions for user, group, and other."""
     perms = oct(os.stat(file_path).st_mode)
-    user, group, other = perms[-3:]
+    user, group, other = perms[-3], perms[-2], perms[-1]
 
-    def bits_to_perms(bit_str: str):
+    def bits_to_perms(bit_str: str) -> str:
         bits = [int(b) for b in bin(int(bit_str))[-3:]]
         perms = "r" * bits[0] + "w" * bits[1] + "x" * bits[2]
         return perms

--- a/openghg/util/_file.py
+++ b/openghg/util/_file.py
@@ -1,5 +1,6 @@
 import bz2
 import json
+import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple, Optional, Union
 
@@ -271,3 +272,16 @@ def check_function_open_nc(filepath: multiPathType) -> Tuple[Callable, multiPath
         xr_open_fn = xr.open_dataset
 
     return xr_open_fn, filepath
+
+
+def permissions(file_path: str | Path) -> tuple[str, str, str]:
+    """Return r, w, and/or x permissions for user, group, and other."""
+    perms = oct(os.stat(file_path).st_mode)
+    user, group, other = perms[-3:]
+
+    def bits_to_perms(bit_str: str):
+        bits = [int(b) for b in bin(int(bit_str))[-3:]]
+        perms = "r" * bits[0] + "w" * bits[1] + "x" * bits[2]
+        return perms
+
+    return bits_to_perms(user), bits_to_perms(group), bits_to_perms(other)

--- a/openghg/util/_file.py
+++ b/openghg/util/_file.py
@@ -274,7 +274,7 @@ def check_function_open_nc(filepath: multiPathType) -> Tuple[Callable, multiPath
     return xr_open_fn, filepath
 
 
-def permissions(file_path: str | Path) -> tuple[str, str, str]:
+def permissions(file_path: Union[str, Path]) -> tuple[str, str, str]:
     """Return r, w, and/or x permissions for user, group, and other."""
     perms = oct(os.stat(file_path).st_mode)
     user, group, other = perms[-3], perms[-2], perms[-1]


### PR DESCRIPTION
* **Summary of changes** 

If a user does not have the right permissions, an error is raised with a suggested solution.

When the lock is first created, it has rw permissions for user and group.



* **Please check if the PR fulfills these requirements**

- [x] Closes #1167 
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

