### PR TITLE
Remove duplicated code from eulerian model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed options used with `xr.Dataset.to_zarr` in reponse to updates in xarray. [PR #1160](https://github.com/openghg/openghg/pull/1160)
 - Added xfail for `cfchecker` tests due to broken link. [PR #1178](https://github.com/openghg/openghg/pull/1178)
+- Removed duplicate code from `read_file` method in `BoundaryConditions` and `EulerianModel`. [PR #1192](https://github.com/openghg/openghg/pull/1192)
 
 ### Added
 

--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -180,8 +180,6 @@ class BoundaryConditions(BaseStore):
             fn_input_parameters, parser_fn
         )
 
-        parser_input_parameters["data_type"] = self._data_type
-
         # Call appropriate standardisation function with input parameters
         boundary_conditions_data = parser_fn(**parser_input_parameters)
 

--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -7,7 +7,7 @@ from typing import Any, TYPE_CHECKING, Dict, Optional, Tuple, Union
 import numpy as np
 from xarray import Dataset
 
-from openghg.util import synonyms, load_standardise_parser, split_function_inputs
+from openghg.util import align_lat_lon, load_standardise_parser, split_function_inputs, synonyms
 
 if TYPE_CHECKING:
     from openghg.store import DataSchema
@@ -133,28 +133,6 @@ class BoundaryConditions(BaseStore):
         bc_input = clean_string(bc_input)
         domain = clean_string(domain)
 
-        data_type = self._data_type
-        standardise_parsers = define_standardise_parsers()[data_type]
-
-        try:
-            source_format = standardise_parsers[source_format.upper()].value
-        except KeyError:
-            raise ValueError(f"Unknown data type {source_format} selected.")
-
-        # Get current parameter values and filter to only include function inputs
-        current_parameters = locals().copy()
-        fn_input_parameters = {key: current_parameters[key] for key in fn_input_parameters}
-
-        fn_input_parameters["filepath"] = filepath
-
-        # Loading parser
-        parser_fn = load_standardise_parser(data_type=data_type, source_format=source_format)
-
-        # Define parameters to pass to the parser function and remaining keys
-        parser_input_parameters, additional_input_parameters = split_function_inputs(
-            fn_input_parameters, parser_fn
-        )
-
         # Specify any additional metadata to be added
         additional_metadata = {}
 
@@ -173,6 +151,16 @@ class BoundaryConditions(BaseStore):
 
         filepath = Path(filepath)
 
+        standardise_parsers = define_standardise_parsers()[self._data_type]
+
+        try:
+            source_format = standardise_parsers[source_format.upper()].value
+        except KeyError:
+            raise ValueError(f"Unknown data type {source_format} selected.")
+
+        # Loading parser
+        parser_fn = load_standardise_parser(data_type=self._data_type, source_format=source_format)
+
         _, unseen_hashes = self.check_hashes(filepaths=filepath, force=force)
 
         if not unseen_hashes:
@@ -187,14 +175,22 @@ class BoundaryConditions(BaseStore):
         fn_current_parameters = locals().copy()  # Make a copy of parameters passed to function
         fn_input_parameters = {key: fn_current_parameters[key] for key in fn_input_parameters}
 
+        # Define parameters to pass to the parser function and remaining keys
+        parser_input_parameters, additional_input_parameters = split_function_inputs(
+            fn_input_parameters, parser_fn
+        )
+
+        parser_input_parameters["data_type"] = self._data_type
+
         # Call appropriate standardisation function with input parameters
         boundary_conditions_data = parser_fn(**parser_input_parameters)
 
+        # Checking against expected format for BoundaryConditions, and align to expected lat/lons if necessary.
         for split_data in boundary_conditions_data.values():
-            # Currently ACRG boundary conditions are split by month or year
-            bc_data = split_data["data"]
 
-            # Checking against expected format for boundary conditions
+            split_data["data"] = align_lat_lon(data=split_data["data"], domain=domain)
+
+            bc_data = split_data["data"]
             BoundaryConditions.validate_data(bc_data)
 
         # Check to ensure no required keys are being passed through optional_metadata dict

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -146,35 +146,6 @@ class EulerianModel(BaseStore):
             fn_input_parameters, parser_fn
         )
 
-        if overwrite and if_exists == "auto":
-            logger.warning(
-                "Overwrite flag is deprecated in preference to `if_exists` (and `save_current`) inputs."
-                "See documentation for details of these inputs and options."
-            )
-            if_exists = "new"
-
-        # Making sure new version will be created by default if force keyword is included.
-        if force and if_exists == "auto":
-            if_exists = "new"
-
-        new_version = check_if_need_new_version(if_exists, save_current)
-
-        filepath = Path(filepath)
-
-        _, unseen_hashes = self.check_hashes(filepaths=filepath, force=force)
-
-        if not unseen_hashes:
-            return {}
-
-        filepath = next(iter(unseen_hashes.values()))
-
-        if chunks is None:
-            chunks = {}
-
-        # Get current parameter values and filter to only include function inputs
-        fn_current_parameters = locals().copy()  # Make a copy of parameters passed to function
-        fn_input_parameters = {key: fn_current_parameters[key] for key in fn_input_parameters}
-
         # Call appropriate standardisation function with input parameters
         eulerian_model_data = parser_fn(**parser_input_parameters)
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The `read_file` method in `EulerianModel` and `BoundaryConditions` had duplicate code and was in a different order from the subclasses of `BaseStore`. This PR fixes that.

* **Please check if the PR fulfills these requirements**

- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

