### PR TITLE
Fx1194 sync metadata to retrieve icos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.11.0...HEAD)
 
+### Fixed
+
+- Added `align_metadata_attributes` to retrieve_remote and shifted function defination to standardise/meta. [PR #1197](https://github.com/openghg/openghg/pull/1197)
+
 ## [0.11.0] - 2024-12-16
 
 ### Fixed

--- a/openghg/retrieve/icos/_retrieve.py
+++ b/openghg/retrieve/icos/_retrieve.py
@@ -1,7 +1,7 @@
 from typing import Any
 from openghg.dataobjects import ObsData
 from openghg.objectstore import get_writable_bucket
-from openghg.standardise.meta import dataset_formatter
+from openghg.standardise.meta import dataset_formatter, align_metadata_attributes
 from openghg.util import load_json
 from openghg.types import MetadataFormatError
 import openghg_defs
@@ -493,6 +493,7 @@ def _retrieve_remote(
         }
     standardised_data = dataset_formatter(data=standardised_data)
     standardised_data = assign_attributes(data=standardised_data, update_mismatch=update_mismatch)
+    align_metadata_attributes(data=standardised_data, update_mismatch=update_mismatch)
 
     return standardised_data
 

--- a/openghg/standardise/meta/__init__.py
+++ b/openghg/standardise/meta/__init__.py
@@ -6,4 +6,4 @@ from ._attributes import (
     dataset_formatter,
     data_variable_formatter,
 )
-from ._metadata import attributes_default_keys, sync_surface_metadata
+from ._metadata import attributes_default_keys, sync_surface_metadata, align_metadata_attributes

--- a/openghg/standardise/meta/_metadata.py
+++ b/openghg/standardise/meta/_metadata.py
@@ -174,3 +174,33 @@ def sync_surface_metadata(
                     meta_copy[key] = float(meta_copy[key])
 
     return meta_copy, attrs_copy
+
+
+def align_metadata_attributes(data: dict, update_mismatch: str) -> None:
+    """
+    Function to sync metadata and attributes if mismatch is found
+
+    Args:
+        data: Dictionary of source_name data, metadata, attributes
+        update_mismatch: This determines how mismatches between the internal data
+            "attributes" and the supplied / derived "metadata" are handled.
+            This includes the options:
+                - "never" - don't update mismatches and raise an AttrMismatchError
+                - "from_source" / "attributes" - update mismatches based on input data (e.g. data attributes)
+                - "from_definition" / "metadata" - update mismatches based on associated data (e.g. site_info.json)
+    Returns:
+        None
+    """
+    for _, gas_data in data.items():
+        measurement_data = gas_data["data"]
+        metadata = gas_data["metadata"]
+
+        attrs = measurement_data.attrs
+
+        metadata_aligned, attrs_aligned = sync_surface_metadata(
+            metadata=metadata, attributes=attrs, update_mismatch=update_mismatch
+        )
+
+        gas_data["metadata"] = metadata_aligned
+        gas_data["attributes"] = attrs_aligned
+        measurement_data.attrs = gas_data["attributes"]

--- a/openghg/standardise/meta/_metadata.py
+++ b/openghg/standardise/meta/_metadata.py
@@ -178,9 +178,13 @@ def sync_surface_metadata(
 
 def align_metadata_attributes(data: dict, update_mismatch: str) -> None:
     """
-    Function to sync metadata and attributes if mismatch is found.
-    Currently this function is applied over all of the surface data.
-    Soon it will be equipped to handle the column data too. With new architecture reforms this needs to be called before parser output.
+    Synchronize metadata and attributes in case of mismatches.
+
+    This function currently applies to all surface-level data. Future enhancements
+    will extend its functionality to handle column-level data as well.
+
+    Since remote retrievals bypass the traditional `read_file` method, this function
+    should be invoked before producing the final standardised output in the retrieval process.
 
     Args:
         data: Dictionary of source_name data, metadata, attributes

--- a/openghg/standardise/meta/_metadata.py
+++ b/openghg/standardise/meta/_metadata.py
@@ -178,7 +178,9 @@ def sync_surface_metadata(
 
 def align_metadata_attributes(data: dict, update_mismatch: str) -> None:
     """
-    Function to sync metadata and attributes if mismatch is found
+    Function to sync metadata and attributes if mismatch is found.
+    Currently this function is applied over all of the surface data.
+    Soon it will be equipped to handle the column data too. With new architecture reforms this needs to be called before parser output.
 
     Args:
         data: Dictionary of source_name data, metadata, attributes


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
 Shifted align_metadata_attributes function declaration from obsurface to metadata.py and called it in retrieve_remote so that update mismatch works for icos remote retrieval.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1194 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
