### PR TITLE
Metakeys config not found but config folder exists error handling bug

### DIFF
--- a/openghg/objectstore/_config.py
+++ b/openghg/objectstore/_config.py
@@ -5,7 +5,7 @@ from pprint import pformat
 from pathlib import Path
 import pkgutil
 
-from openghg.types import ConfigFileError, ObjectStoreError
+from openghg.types import ConfigFileError
 from openghg.util import timestamp_now
 
 logger = logging.getLogger("openghg.objectstore")
@@ -127,10 +127,8 @@ def create_default_config(bucket: str) -> None:
         None
     """
     config_folderpath = _get_config_folderpath(bucket=bucket)
-    if config_folderpath.exists():
-        raise ObjectStoreError(f"config folder already exists at {config_folderpath}")
 
-    config_folderpath.mkdir(parents=True)
+    config_folderpath.mkdir(parents=True, exist_ok=True)
 
     # Make the expected folder structure
     db_config_folderpath = config_folderpath.joinpath("config")

--- a/openghg/objectstore/_config.py
+++ b/openghg/objectstore/_config.py
@@ -132,7 +132,7 @@ def create_default_config(bucket: str) -> None:
 
     # Make the expected folder structure
     db_config_folderpath = config_folderpath.joinpath("config")
-    db_config_folderpath.mkdir()
+    db_config_folderpath.mkdir(exist_ok=True)
 
     default_keys = get_metakey_defaults()
 
@@ -166,7 +166,7 @@ def _write_metakey_config(bucket: str, metakeys: dict) -> None:
 
     if not config_folder.exists():
         logger.debug(f"Creating folder at {config_folder}")
-        config_folder.mkdir(parents=True)
+        config_folder.mkdir(parents=True, exist_ok=True)
 
     metakey_path.write_text(json.dumps(config_data))
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
 Added exist_ok-True where it creates folderpath. Removed error inside create_default_config

* **Please check if the PR fulfills these requirements**

- [ ] Closes #1157 (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
