### PR TITLE
Add a month restriction during standardisation of old footprints 

### DIFF
--- a/openghg/standardise/footprints/_acrg_org.py
+++ b/openghg/standardise/footprints/_acrg_org.py
@@ -8,7 +8,6 @@ from openghg.util import (
     check_species_time_resolved,
     check_species_lifetime,
     timestamp_now,
-    # open_and_align_dataset,
     check_function_open_nc,
 )
 from openghg.store import infer_date_range, update_zero_dim
@@ -65,8 +64,7 @@ def parse_acrg_org(
         )
         time_resolved = high_time_resolution
 
-    # fp_data, filepath = open_and_align_dataset(filepath, domain)
-    xr_open_fn, filepath = check_function_open_nc(filepath, domain)
+    xr_open_fn, filepath = check_function_open_nc(filepath, domain, sel_month=True)
 
     fp_data = xr_open_fn(filepath)
 

--- a/tests/standardise/boundary_conditions/test_openghg.py
+++ b/tests/standardise/boundary_conditions/test_openghg.py
@@ -2,6 +2,7 @@ import logging
 
 from helpers import get_bc_datapath
 from openghg.standardise.boundary_conditions import parse_openghg
+
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)
 
@@ -13,10 +14,7 @@ def test_parse_openghg():
 
     data_path = get_bc_datapath(filename="ch4_EUROPE_201208.nc")
 
-    results = parse_openghg(filepath=data_path,
-                                        species="ch4",
-                                        bc_input="MOZART",
-                                        domain="EUROPE")
+    results = parse_openghg(filepath=data_path, species="ch4", bc_input="MOZART", domain="EUROPE")
 
     metadata = results["ch4_mozart_europe"]["metadata"]
 

--- a/tests/standardise/eulerian_model/test_parse_openghg.py
+++ b/tests/standardise/eulerian_model/test_parse_openghg.py
@@ -3,7 +3,7 @@ from openghg.standardise.eulerian_model import parse_openghg
 
 
 def test_parse_openghg():
-    """ This tests the parser for Eulerian model
+    """This tests the parser for Eulerian model
     Looks for processed key and metadata associated with the file"""
 
     test_datapath = get_eulerian_datapath("GEOSChem.SpeciesConc.20150101_0000z_reduced.nc4")

--- a/tests/store/test_boundary_conditions.py
+++ b/tests/store/test_boundary_conditions.py
@@ -34,7 +34,7 @@ def test_read_data_monthly(mocker):
         binary_data=binary_data,
         metadata=metadata,
         file_metadata=file_metadata,
-        source_format='openghg'
+        source_format="openghg",
     )
 
     # assert proc_results == {"ch4_mozart_europe": {"uuid": "test-uuid-1", "new": True}}

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -13,6 +13,7 @@ from openghg.util import (
     sort_by_filenames,
 )
 
+
 def test_read_header():
     filename = "header_test.dat"
     dir_path = os.path.dirname(__file__)


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Add a month restriction during standardisation of old footprints (plus other style corrections from flake8)

* **Please check if the PR fulfills these requirements**

- [X] Closes #1203  
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
