### PR TITLE
Fix to store ICOS data by data level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.11.1...HEAD)
 
+### Fixed
+
+- Changed `icos_data_level` to `data_level` in `ObsSurface.store_data` to fix bug where ICOS data was not distinguished by data level. [PR #1211](https://github.com/openghg/openghg/pull/1211)
+
+
 ## [0.11.1] - 2025-01-10
 
 ### Fixed
 
-- Changed `icos_data_level` to `data_level` in `ObsSurface.store_data` to fix bug where ICOS data was not distinguished by data level. [PR #1211](https://github.com/openghg/openghg/pull/1211)
 - Added `align_metadata_attributes` to retrieve_remote and shifted function defination to standardise/meta. [PR #1197](https://github.com/openghg/openghg/pull/1197)
 - Added `icos flags` to handle data that is flagged bad for remote icos data.[PR #1200](https://github.com/openghg/openghg/pull/1200)
 - Pinned Zarr to `2.18.3` as github runners are picking `zarr 3.0` which is still in significant development state.[PR #1205](https://github.com/openghg/openghg/pull/1205)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Changed `icos_data_level` to `data_level` in `ObsSurface.store_data` to fix bug where ICOS data was not distinguished by data level. [PR #1211](https://github.com/openghg/openghg/pull/1211)
 - Added `align_metadata_attributes` to retrieve_remote and shifted function defination to standardise/meta. [PR #1197](https://github.com/openghg/openghg/pull/1197)
 - Added `icos flags` to handle data that is flagged bad for remote icos data.[PR #1200](https://github.com/openghg/openghg/pull/1200)
 - Pinned Zarr to `2.18.3` as github runners are picking `zarr 3.0` which is still in significant development state.[PR #1205](https://github.com/openghg/openghg/pull/1205)

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -616,7 +616,7 @@ class ObsSurface(BaseStore):
                 "network",
                 "source_format",
                 "data_source",
-                "icos_data_level",
+                "data_level",
             )
 
         # Create Datasources, save them to the object store and get their UUIDs

--- a/tests/retrieve/icos/test_retrieve_icos.py
+++ b/tests/retrieve/icos/test_retrieve_icos.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 from helpers import clear_test_stores
 from openghg.dataobjects import SearchResults
+from openghg.retrieve import search_surface
 from openghg.retrieve.icos import retrieve_atmospheric
 from openghg.types import AttrMismatchError
 
@@ -38,6 +39,34 @@ def test_icos_retrieve_skips_datalevel_1_csv_files():
     }
 
     assert first_obs.metadata == expected_metadata
+
+
+@pytest.mark.icos
+def test_icos_retrieve_stores_by_data_level():
+    """Check that retrieving data with different levels creates different datasources."""
+    retrieve_atmospheric(
+        site="BIR",
+        species=["CH4"],
+        inlet="50m",
+        data_level=2,
+        dataset_source="European ObsPack",
+        update_mismatch="from_source",
+        store="user",
+    )
+
+    retrieve_atmospheric(
+        site="BIR",
+        species=["CH4"],
+        inlet="50m",
+        data_level=1,
+        dataset_source="ICOS",
+        update_mismatch="from_source",
+        store="user",
+    )
+
+    res = search_surface(store="user", site="BIR", species="CH4")
+
+    assert len(res) == 2
 
 
 @pytest.mark.icos


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The method `ObsSurface.store_data` was still using the old keyword
`icos_data_level` instead of the new keyword `data_level` to distinguish
data sources.

This was causing ICOS data with different levels to be written to the same
datasource.

A test was added to check this; it failed before the change to `store_data`,
and passes afterwards.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1210 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature