### PR TITLE
Fix filelock permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.11.1...HEAD)
+
+### Updated
 - Update `standardise_footprint` inputs to include more explicit keywords around selection of satellite points. This includes adding the `obs_region` keyword to describe an area selected for satellite points (not necessarily the same as `domain`) and updating the definition of `selection` to be linked to any additional selection filters included for the satellite data. [#PR 1218](https://github.com/openghg/openghg/pull/1218/)
 
 ### Added
@@ -16,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Changed `icos_data_level` to `data_level` in `ObsSurface.store_data` to fix bug where ICOS data was not distinguished by data level. [PR #1211](https://github.com/openghg/openghg/pull/1211)
-
+- Fixed permissions for file locks [PR #1221](https://github.com/openghg/openghg/pull/1221)
 
 ## [0.11.1] - 2025-01-10
 

--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -303,7 +303,7 @@ def get_object_lock_path(bucket: str, key: str) -> Path:
     Returns:
         Path to object lock file
     """
-    lock_path = Path(f"{bucket}/{key}._data.lock")
+    lock_path = Path(f"{bucket}/{key}._data.lock_v2")
     if not lock_path.parent.exists():
         lock_path.parent.mkdir(parents=True)
 

--- a/openghg/util/__init__.py
+++ b/openghg/util/__init__.py
@@ -32,7 +32,6 @@ from ._file import (
     load_transform_parser,
     read_header,
     check_function_open_nc,
-    permissions,
 )
 from ._function_inputs import split_function_inputs
 from ._hashing import hash_bytes, hash_file, hash_retrieved_data, hash_string

--- a/openghg/util/_file.py
+++ b/openghg/util/_file.py
@@ -1,7 +1,6 @@
 import bz2
 from functools import partial, wraps
 import json
-import os
 from pathlib import Path
 from typing import Any
 from collections.abc import Callable
@@ -290,16 +289,3 @@ def check_function_open_nc(
         xr_open_fn = xr.open_dataset
 
     return xr_open_fn, filepath
-
-
-def permissions(file_path: str | Path) -> tuple[str, str, str]:
-    """Return r, w, and/or x permissions for user, group, and other."""
-    perms = oct(os.stat(file_path).st_mode)
-    user, group, other = perms[-3], perms[-2], perms[-1]
-
-    def bits_to_perms(bit_str: str) -> str:
-        bits = [int(b) for b in bin(int(bit_str))[-3:]]
-        perms = "r" * bits[0] + "w" * bits[1] + "x" * bits[2]
-        return perms
-
-    return bits_to_perms(user), bits_to_perms(group), bits_to_perms(other)

--- a/tests/objectstore/test_local_object_store.py
+++ b/tests/objectstore/test_local_object_store.py
@@ -85,7 +85,7 @@ def test_get_object_lock_path(tmp_path):
 
     assert data_path.stem == lock_path.stem.split(".")[0]
     assert data_path.suffix == lock_path.suffixes[0]
-    assert lock_path.suffixes[1] == ".lock"
+    assert lock_path.suffixes[1] == ".lock_v2"
 
     # test getting lock even if file doesn't exist yet
     key2 = "key2"


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Changed to make sure `FileLock` object is created with rw-rw-r
permissions.

Changed file lock naming scheme so we'll start fresh with this PR
and won't need to fix the broken permissions on all the old files.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1219
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
