### PR TITLE
Allow more types to be returned from parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.11.1...HEAD)
+
+### Updated
 - Update `standardise_footprint` inputs to include more explicit keywords around selection of satellite points. This includes adding the `obs_region` keyword to describe an area selected for satellite points (not necessarily the same as `domain`) and updating the definition of `selection` to be linked to any additional selection filters included for the satellite data. [#PR 1218](https://github.com/openghg/openghg/pull/1218/)
 
 ### Added
@@ -16,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Changed `icos_data_level` to `data_level` in `ObsSurface.store_data` to fix bug where ICOS data was not distinguished by data level. [PR #1211](https://github.com/openghg/openghg/pull/1211)
-
+- Allow parsers to return a list of `MetadataAndData` directly. [PR #1222](https://github.com/openghg/openghg/pull/1222)
 
 ## [0.11.1] - 2025-01-10
 

--- a/openghg/types/_types.py
+++ b/openghg/types/_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -43,9 +44,21 @@ class MetadataAndData:
     data: xr.Dataset
 
 
-def convert_to_list_of_metadata_and_data(nested_dict: dict) -> list[MetadataAndData]:
+def convert_to_list_of_metadata_and_data(
+    parser_output: dict | Iterable[HasMetadataAndData],
+) -> list[MetadataAndData]:
     """Convert from old nested dict format to list of MetadataAndData."""
-    return [MetadataAndData(v["metadata"], v["data"]) for v in nested_dict.values()]
+    if isinstance(parser_output, dict):
+        return [MetadataAndData(v["metadata"], v["data"]) for v in parser_output.values()]
+    else:
+        parser_output = list(parser_output)
+
+        if all(isinstance(x, HasMetadataAndData) for x in parser_output):
+            return [MetadataAndData(v.metadata, v.data) for v in parser_output]
+
+    raise ValueError(
+        "`parser_output` must be dict or Iterable of objects with .metadata and .data attributes."
+    )
 
 
 @runtime_checkable


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The function that converts parser outputs to a list
of `MetadataAndData` objects.

* **Please check if the PR fulfils these requirements**

- [x] Closes #1220
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
