### PR TITLE
Fix for missing attributes in weighted resample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.12.0...HEAD)
 
-## Added
+### Added
 
 - New `datapack` submodule to allow output obspacks to be created. This includes the `create_obspack` function which takes an input search file and produces an obspack within a defined structure from this. [PR #1117](https://github.com/openghg/openghg/pull/1117)
+
+### Fixed
+
+- Bug where attributes were not preserved during some resampling operations. [PR #1233](https://github.com/openghg/openghg/pull/1233)
 
 ## [0.12.0] - 2025-02-27
 

--- a/openghg/data_processing/_resampling.py
+++ b/openghg/data_processing/_resampling.py
@@ -56,7 +56,6 @@ def add_averaging_attrs(func: ResampleFunctionType) -> ResampleFunctionType:
     def wrapper(ds: xr.Dataset, averaging_period: str, *args: P.args, **kwargs: P.kwargs) -> xr.Dataset:
         average_in_seconds = pd.Timedelta(averaging_period).total_seconds()
         avg_attrs = {"averaged_period": average_in_seconds, "averaged_period_str": averaging_period}
-
         return func(ds, averaging_period, *args, **kwargs).assign_attrs(avg_attrs)
 
     return wrapper
@@ -117,7 +116,7 @@ def weighted_resample(ds: xr.Dataset, averaging_period: str, species: str) -> xr
         averaging_period=averaging_period,
         species=species,
         mf_variability=mf_variability,
-    )
+    ).assign_attrs(ds.attrs)
 
     return result
 
@@ -158,7 +157,7 @@ def _weighted_resample(
     Returns:
         xr.Dataset: with obs., number of obs., (and variability) resampled
     """
-    sum_kwargs: dict[str, Any] = {"skipna": True, "min_count": 1}
+    sum_kwargs: dict[str, Any] = {"skipna": True, "min_count": 1, "keep_attrs": True}
 
     with xr.set_options(keep_attrs=True):
         n_obs_resample_sum = n_obs.resample(time=averaging_period).sum(**sum_kwargs)


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Because `_weighted_resample` creates a new dataset,  to preserve attributes they need to be manually copied to the new dataset. This fixes the issue.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1232 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

