### PR TITLE
Adding in filter for 'flask' platform to align but not resample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Unpinned numpy so that we can now use numpy 2.0. [PR #1235](https://github.com/openghg/openghg/pull/1235)
-- When combining obs and footprint data in ModelScenario, allow flask data to just align the data and not resample. This can be done by passing the `platform` keyword and setting to any name which ends in "flask" to the ModelScenario.combine_obs_footprint() method. [PR #1236](https://github.com/openghg/openghg/pull/1236)
+- When combining obs and footprint data in ModelScenario, allow flask data to just align the data and not resample. This can be done by passing the `platform` keyword and setting to any name which contains "flask" to the ModelScenario combine_obs_footprint() method. [PR #1236](https://github.com/openghg/openghg/pull/1236)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Unpinned numpy so that we can now use numpy 2.0. [PR #1235](https://github.com/openghg/openghg/pull/1235)
-- When combining obs and footprint data in ModelScenario, allow flask data to just align the data and not resample. This can be done by passing the `platform` keyword and setting to any name which contains "flask" to the ModelScenario combine_obs_footprint() method. [PR #1236](https://github.com/openghg/openghg/pull/1236)
+- When combining obs and footprint data in ModelScenario, allow resample_to to be set to None so that the data is aligned but not resampled. This is also turned on by default by passing the `platform` keyword and setting to any name which contains "flask" to the relevant ModelScenario methods. [PR #1236](https://github.com/openghg/openghg/pull/1236)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Unpinned numpy so that we can now use numpy 2.0. [PR #1235](https://github.com/openghg/openghg/pull/1235)
+- When combining obs and footprint data in ModelScenario, allow flask data to just align the data and not resample. This can be done by passing the `platform` keyword and setting to any name which ends in "flask" to the ModelScenario.combine_obs_footprint() method. [PR #1236](https://github.com/openghg/openghg/pull/1236)
 
 ### Fixed
 

--- a/doc/source/tutorials/local/Analysing_data/Comparing_with_emissions.rst
+++ b/doc/source/tutorials/local/Analysing_data/Comparing_with_emissions.rst
@@ -258,6 +258,15 @@ aliases):
     modelled_observations_daily = scenario.calc_modelled_obs(resample_to="1D")
     modelled_observations_daily.plot()
 
+Explicit resampling of the data can be also be skipped by using a ``resample_to`` input
+of ``None``. This will align the footprints to the observations by forward filling the
+footprint values. Note: using ``platform="flask"`` will turn on this option as well.
+
+.. code:: ipython3
+
+    modelled_observations_align = scenario.calc_modelled_obs(resample_to=None)
+    modelled_observations_align.plot()
+
 To allow comparisons with multiple flux sources, more than one flux
 source can be linked to your ``ModelScenario``. This can be either be
 done upon creation or can be added using the ``add_flux()`` method. When

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -631,8 +631,8 @@ class ModelScenario:
             if platform == "satellite":
                 return obs_data, footprint_data
             elif "flask" in platform:
-                fp_data = fp_data.reindex_like(obs_data, method="ffill")
-                return obs_data, fp_data
+                footprint_data = footprint_data.reindex_like(obs_data, method="ffill")
+                return obs_data, footprint_data
 
         if resample_to == "footprint":
             resample_to = "other"

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -630,6 +630,9 @@ class ModelScenario:
             # Do not apply resampling for "satellite" (but have re-included "flask" for now)
             if platform == "satellite":
                 return obs_data, footprint_data
+            elif "flask" in platform:
+                fp_data = fp_data.reindex_like(obs_data, method="ffill")
+                return obs_data, fp_data
 
         if resample_to == "footprint":
             resample_to = "other"
@@ -824,7 +827,7 @@ class ModelScenario:
                           - either one of ["coarsest", "obs", "footprint"] to match to the datasets
                           - or using a valid pandas resample period e.g. "2H".
                          Default = "coarsest".
-            platform: Observation platform used to decide whether to resample e.g. "site", "satellite".
+            platform: Observation platform used to decide whether to resample e.g. "satellite", "insitu", "flask".
             cache: Cache this data after calculation. Default = True.
             recalculate: Make sure to recalculate this data rather than return from cache. Default = False.
 
@@ -893,7 +896,7 @@ class ModelScenario:
                           - either one of ["coarsest", "obs", "footprint"] to match to the datasets
                           - or using a valid pandas resample period e.g. "2H".
                          Default = "coarsest".
-            platform: Observation platform used to decide whether to resample e.g. "site", "satellite".
+            platform: Observation platform used to decide whether to resamplee.g. "satellite", "insitu", "flask"
             cache: Cache this data after calculation. Default = True.
             recalculate: Make sure to recalculate this data rather than return from cache. Default = False.
 
@@ -1256,7 +1259,7 @@ class ModelScenario:
                           - either one of ["coarsest", "obs", "footprint"] to match to the datasets
                           - or using a valid pandas resample period e.g. "2H".
                          Default = "coarsest".
-            platform: Observation platform used to decide whether to resample e.g. "site", "satellite".
+            platform: Observation platform used to decide whether to resamplee.g. "satellite", "insitu", "flask"
             cache: Cache this data after calculation. Default = True.
             recalculate: Make sure to recalculate this data rather than return from cache. Default = False.
 
@@ -1492,7 +1495,7 @@ class ModelScenario:
                           - either one of ["coarsest", "obs", "footprint"] to match to the datasets
                           - or using a valid pandas resample period e.g. "2H".
                          Default = "coarsest".
-            platform: Observation platform used to decide whether to resample e.g. "site", "satellite".
+            platform: Observation platform used to decide whether to resamplee.g. "satellite", "insitu", "flask"
             cache: Cache this data after calculation. Default = True.
             recalculate: Make sure to recalculate this data rather than return from cache. Default = False.
 

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -896,7 +896,7 @@ class ModelScenario:
                           - either one of ["coarsest", "obs", "footprint"] to match to the datasets
                           - or using a valid pandas resample period e.g. "2H".
                          Default = "coarsest".
-            platform: Observation platform used to decide whether to resamplee.g. "satellite", "insitu", "flask"
+            platform: Observation platform used to decide whether to resample e.g. "satellite", "insitu", "flask"
             cache: Cache this data after calculation. Default = True.
             recalculate: Make sure to recalculate this data rather than return from cache. Default = False.
 
@@ -1259,7 +1259,7 @@ class ModelScenario:
                           - either one of ["coarsest", "obs", "footprint"] to match to the datasets
                           - or using a valid pandas resample period e.g. "2H".
                          Default = "coarsest".
-            platform: Observation platform used to decide whether to resamplee.g. "satellite", "insitu", "flask"
+            platform: Observation platform used to decide whether to resample e.g. "satellite", "insitu", "flask"
             cache: Cache this data after calculation. Default = True.
             recalculate: Make sure to recalculate this data rather than return from cache. Default = False.
 
@@ -1495,7 +1495,7 @@ class ModelScenario:
                           - either one of ["coarsest", "obs", "footprint"] to match to the datasets
                           - or using a valid pandas resample period e.g. "2H".
                          Default = "coarsest".
-            platform: Observation platform used to decide whether to resamplee.g. "satellite", "insitu", "flask"
+            platform: Observation platform used to decide whether to resample e.g. "satellite", "insitu", "flask"
             cache: Cache this data after calculation. Default = True.
             recalculate: Make sure to recalculate this data rather than return from cache. Default = False.
 

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -640,6 +640,8 @@ class ModelScenario:
             elif "flask" in platform:
                 resample_to = None
                 align_to_obs = True
+            else:
+                logger.warning(f"Platform '{platform}' not used when determining resample strategy.")
 
         if resample_to is None:
             if align_to_obs:

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -650,7 +650,7 @@ def footprint_dummy():
      - Daily frequency from 2011-12-31 to 2012-01-03 (inclusive) (4 time points)
      - Small lat, lon (TEST_DOMAIN)
      - Small height
-     - "fp" values are all 1 **May change**
+     - "fp" values: 4 time points - 1.0, 1.1, 1.2, 1.3
      - "particle_locations_*" are 2, 3, 4, 5 for "n", "e", "s", "w"
      - "INERT" species
     """
@@ -665,6 +665,10 @@ def footprint_dummy():
     nlat, nlon, ntime = len(lat), len(lon), len(time)
     shape = (ntime, nlat, nlon)
     values = np.ones(shape)
+    add = 0.1
+    for i in range(1, len(values)):
+        values[i] += add
+        add += 0.1
 
     data_vars = {}
     data_vars["fp"] = (("time", "lat", "lon"), values)
@@ -819,6 +823,43 @@ def test_model_resample_ch4(model_scenario_ch4_dummy):
 
     resampled_mf = combined_dataset["mf"].values
     assert np.allclose(resampled_mf, expected_obs_mf)
+
+
+def test_model_align_flask(model_scenario_ch4_dummy):
+    """
+    Test expected aligned values for obs with known dummy data when
+    this has platform="surface-flask".
+    Expect data to be aligned but not resampled.
+    """
+    platform = "surface-flask"
+    combined_dataset = model_scenario_ch4_dummy.combine_obs_footprint(platform=platform)
+
+    obs_data = model_scenario_ch4_dummy.obs.data
+    footprint_data = model_scenario_ch4_dummy.footprint.data
+
+    # # Create expected values for resampled observations
+    # # In our case:
+    # # - observation data contains values from 1, 48 for each time point
+    # # - footprint data contained 2 overlapping time points which should now be repeated
+
+    # Output should contain 48 time points (same as input obs data)
+    org_obs_time = obs_data["time"]
+    aligned_time = combined_dataset["time"]
+    xr.testing.assert_allclose(org_obs_time, aligned_time)
+
+    # Footprint data should not have been resampled and should now be repeated via "ffill"
+    aligned_fp = combined_dataset["fp"]
+    aligned_fp_1 = aligned_fp.sel(time=slice("2012-01-01T00:00:00", "2012-01-01T23:00:00")).transpose("time", "lat", "lon").values
+    aligned_fp_2 = aligned_fp.sel(time=slice("2012-01-02T00:00:00", "2012-01-02T23:00:00")).transpose("time", "lat", "lon").values
+
+    org_fp_1 = footprint_data["fp"].sel(time=slice("2012-01-01T00:00:00", "2012-01-01T23:00:00")).values
+    org_fp_2 = footprint_data["fp"].sel(time=slice("2012-01-02T00:00:00", "2012-01-02T23:00:00")).values
+
+    expected_fp_1 = np.repeat(org_fp_1, len(aligned_fp_1), axis=0)
+    expected_fp_2 = np.repeat(org_fp_2, len(aligned_fp_2), axis=0)
+
+    np.testing.assert_allclose(aligned_fp_1, expected_fp_1)
+    np.testing.assert_allclose(aligned_fp_2, expected_fp_2)
 
 
 def test_model_modelled_obs_ch4(model_scenario_ch4_dummy, footprint_dummy, flux_ch4_dummy):


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Within `ModelScenario` this needs to align together observation and footprint data as one of the steps towards created modelled observations. For site (regular) data this is done using resampling methods to ensure the frequency of the observation and footprint data match and that the exact time points are aligned. For flask (irregular) data however, this shouldn't be resampled in the same way as we do not expect this to be on a regular frequency.

This PR is to put in a short term fix where the `platform` keyword can be used to indicate that the footprint data should be aligned to the observations but to not apply any resampling. The check for this looks for `platform` keywords which contain the word "flask" to keep this flexible for now (so this should work for e.g. "surface-flask" or "flask").

This is done by allowing `resample_to` to be set as `None` and using this option when checking the `platform` input.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1237 
   - [x] Links to [Issue 233 on openghg_inversions](https://github.com/openghg/openghg_inversions/issues/233)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Documentation and tutorials updated/added

Not needed
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
