### PR TITLE
Dropping of exposure_id variable for GOSAT data containing "exposure_id" variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.13.0...HEAD)
 
+### Added
+- Dropped `exposure_id` variable for GOSAT data to avoid change in dimension size error raised from `to_zarr`. [PR #1243](https://github.com/openghg/openghg/pull/1243)
+
 ## [0.13.0] - 2025-03-10
 
 ### Added

--- a/openghg/standardise/column/_openghg.py
+++ b/openghg/standardise/column/_openghg.py
@@ -69,6 +69,10 @@ def parse_openghg(
 
     data = xr.open_dataset(filepath).chunk(chunks)
 
+    # TODO: Remove this once ragged arrays from xarray is handled
+    if "exposure_id" in data:
+        data = data.drop_vars("exposure_id")
+
     # Extract current attributes from input data
     attributes = cast(MutableMapping, data.attrs)
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Currently, Zarr complains if there is a difference in dimension size between stored and incoming data. Especially this has been observed for the `exposure_id` variable. As the variable is not that important it is being removed however to avoid such issues to be raised in future for other dimensions please see https://github.com/openghg/openghg/issues/1242

* **Please check if the PR fulfills these requirements**

- [x] Closes #1240 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
