### PR TITLE
Fixed obs standardisation (issue with ID coordinate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added ability to retrieve ICOS combined Obspack .nc data. [PR #1212](https://github.com/openghg/openghg/pull/1212)
-- Dropped `exposure_id` variable for GOSAT data to avoid change in dimension size error raised from `to_zarr`. [PR #1243](https://github.com/openghg/openghg/pull/1243)
+- Dropped `exposure_id` variable and `id` coordinate for GOSAT data to avoid change in dimension size error raised from `to_zarr`. [PR #1243](https://github.com/openghg/openghg/pull/1243) [PR #1257](https://github.com/openghg/openghg/pull/1257)
 - Added ability to process ModelScenario for Observation and Footprint satellite data. Added `platform` keyword to split the process and added ability to pass `satellite` as argument.[#PR 1244](https://github.com/openghg/openghg/pull/1244)
 
 ## [0.13.0] - 2025-03-10
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bug where attributes were not preserved during some resampling operations. [PR #1233](https://github.com/openghg/openghg/pull/1233)
-- Removing variable "id" to avoid merging conflicts when standardising obs. [PR #1257](https://github.com/openghg/openghg/pull/1257)
 
 ## [0.12.0] - 2025-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bug where attributes were not preserved during some resampling operations. [PR #1233](https://github.com/openghg/openghg/pull/1233)
+- Removing variable "id" to avoid merging conflicts when standardising obs. [PR #1257](https://github.com/openghg/openghg/pull/1257)
 
 ## [0.12.0] - 2025-02-27
 

--- a/openghg/standardise/column/_openghg.py
+++ b/openghg/standardise/column/_openghg.py
@@ -72,6 +72,7 @@ def parse_openghg(
     # TODO: Remove this once ragged arrays from xarray is handled
     if "exposure_id" in data:
         data = data.drop_vars("exposure_id")
+        data = data.drop_vars("id")
 
     # Extract current attributes from input data
     attributes = cast(MutableMapping, data.attrs)

--- a/tests/standardise/column/test_openghg_column.py
+++ b/tests/standardise/column/test_openghg_column.py
@@ -31,6 +31,9 @@ def test_read_file():
 
     assert "ch4" in data
 
+    assert "exposure_id" not in data
+    assert "id" not in data
+
     output_ch4 = data["ch4"]
     data_ch4 = output_ch4["data"]
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
If exposure_id variable is dropped, id coordinate is dropped too. This fixes an issue with standardising and merging obs files (which usually have ID with shape (3,) but in a few files shape is (1,))

* **Please check if the PR fulfills these requirements**

- [x] Closes #1256
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature (no tests needed)
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
