### PR TITLE
1151 data with period varies cannot be standardised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped `exposure_id` variable for GOSAT data to avoid change in dimension size error raised from `to_zarr`. [PR #1243](https://github.com/openghg/openghg/pull/1243)
 - Added ability to process ModelScenario for Observation and Footprint satellite data. Added `platform` keyword to split the process and added ability to pass `satellite` as argument.[#PR 1244](https://github.com/openghg/openghg/pull/1244)
 
+### Updated
+- Introduced functionality to process data with the time_period set to "varies," with a default value of '1 second'. Additionally, the inferred_freq has been updated to input_freq when the continuous flag is set to False.[#1259](https://github.com/openghg/openghg/pull/1259)
+
 ## [0.13.0] - 2025-03-10
 
 ### Added

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -293,6 +293,8 @@ class Footprints(BaseStore):
         elif satellite is not None and obs_region is not None:
             satellite = clean_string(satellite)
             obs_region = clean_string(obs_region)
+            continuous = False
+            logger.warning("\n*** WARNING: For satellite data, 'continuous' is set to `False` ***\n")
         else:
             raise ValueError("Please pass either site or satellite and obs_region values")
 

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -294,7 +294,7 @@ class Footprints(BaseStore):
             satellite = clean_string(satellite)
             obs_region = clean_string(obs_region)
             continuous = False
-            logger.warning("\n*** WARNING: For satellite data, 'continuous' is set to `False` ***\n")
+            logger.info("For satellite data, 'continuous' is set to `False`")
         else:
             raise ValueError("Please pass either site or satellite and obs_region values")
 

--- a/openghg/store/_infer_time.py
+++ b/openghg/store/_infer_time.py
@@ -158,7 +158,7 @@ def infer_date_range(
                 if input_freq != null_freq:
                     inferred_freq = input_freq
                     logger.warning(
-                        "\n*** WARNING:Inferred frequency is set to the provided 'period'. This could indicate that the 'period' value may be incorrect. Exercise caution when using this value. ***\n"
+                        "Inferred frequency is set to the provided 'period'. This could indicate that the 'period' value may be incorrect. Exercise caution when using this value."
                     )
                 else:
                     inferred_freq = null_freq
@@ -188,7 +188,7 @@ def infer_date_range(
         else:
             period_str = "varies"
             logger.warning(
-                "\n*** WARNING: The `time_period` is set to `varies`. Defaults to a `1 second` period for further processing and updates the `time_period` in metadata with the default value. ***\n"
+                "The `time_period` is set to `varies`. Defaults to a `1 second` period for further processing and updates the `time_period` in metadata with the default value."
             )
 
     return start_date, end_date, period_str

--- a/openghg/store/_infer_time.py
+++ b/openghg/store/_infer_time.py
@@ -181,6 +181,9 @@ def infer_date_range(
             period_str = create_frequency_str(time_value, time_unit)
         else:
             period_str = "varies"
+            logger.warning(
+                "\n*** WARNING: `time_period`, is set to `varies` in metadata. Defaults period to `1 seconds` to process further. ***\n"
+            )
 
     return start_date, end_date, period_str
 

--- a/openghg/store/_infer_time.py
+++ b/openghg/store/_infer_time.py
@@ -155,7 +155,10 @@ def infer_date_range(
                     "Continuous data with no gaps is expected but no time period can be inferred. Run with continuous=False (and optionally specify period input) to remove this constraint."
                 )
             else:
-                inferred_freq = null_freq
+                if input_freq != null_freq:
+                    inferred_freq = input_freq
+                else:
+                    inferred_freq = null_freq
         else:
             inferred_freq = parse_period(inferred_period)
 

--- a/openghg/store/_infer_time.py
+++ b/openghg/store/_infer_time.py
@@ -182,7 +182,7 @@ def infer_date_range(
         else:
             period_str = "varies"
             logger.warning(
-                "\n*** WARNING: `time_period`, is set to `varies`. Defaults period to `1 seconds` to process further and updates `time_period` in metadata with the default value. ***\n"
+                "\n*** WARNING: The `time_period` is set to `varies`. Defaults to a `1 second` period for further processing and updates the `time_period` in metadata with the default value. ***\n"
             )
 
     return start_date, end_date, period_str

--- a/openghg/store/_infer_time.py
+++ b/openghg/store/_infer_time.py
@@ -182,7 +182,7 @@ def infer_date_range(
         else:
             period_str = "varies"
             logger.warning(
-                "\n*** WARNING: `time_period`, is set to `varies` in metadata. Defaults period to `1 seconds` to process further. ***\n"
+                "\n*** WARNING: `time_period`, is set to `varies`. Defaults period to `1 seconds` to process further and updates `time_period` in metadata with the default value. ***\n"
             )
 
     return start_date, end_date, period_str

--- a/openghg/store/_infer_time.py
+++ b/openghg/store/_infer_time.py
@@ -157,6 +157,9 @@ def infer_date_range(
             else:
                 if input_freq != null_freq:
                     inferred_freq = input_freq
+                    logger.warning(
+                        "\n*** WARNING:Inferred frequency is set to the provided 'period'. This could indicate that the 'period' value may be incorrect. Exercise caution when using this value. ***\n"
+                    )
                 else:
                     inferred_freq = null_freq
         else:

--- a/openghg/util/_time.py
+++ b/openghg/util/_time.py
@@ -714,8 +714,10 @@ def parse_period(period: str | tuple) -> TimePeriod:
             unit = period.lstrip(value_str).strip()  # Strip found value and any whitespace.
         else:
             value = 1
-            unit = "seconds"
-            logging.warning("For time period 'varies' value is set `1` and unit is set to `seconds`")
+            unit = period
+            if period == "varies":
+                unit = "seconds"
+                logging.warning("For time period 'varies' value is set `1` and unit is set to `seconds`")
 
     offset_naming = time_offset_definition()
 
@@ -832,7 +834,7 @@ def relative_time_offset(
     elif value is None or unit is None:
         raise ValueError("If period is not included, both value and unit must be specified.")
 
-    relative_units = ("weeks", "months", "years")
+    relative_units = ("seconds", "weeks", "months", "years")
 
     if unit in relative_units:
         time_delta = DateOffset(**{unit: value})

--- a/openghg/util/_time.py
+++ b/openghg/util/_time.py
@@ -716,7 +716,7 @@ def parse_period(period: str | tuple) -> TimePeriod:
             value = 1
             unit = period
             if period == "varies":
-                unit = "seconds"
+                unit = "s"
                 logging.warning("For time period 'varies' value is set `1` and unit is set to `seconds`")
 
     offset_naming = time_offset_definition()
@@ -834,7 +834,7 @@ def relative_time_offset(
     elif value is None or unit is None:
         raise ValueError("If period is not included, both value and unit must be specified.")
 
-    relative_units = ("seconds", "weeks", "months", "years")
+    relative_units = ("weeks", "months", "years")
 
     if unit in relative_units:
         time_delta = DateOffset(**{unit: value})

--- a/openghg/util/_time.py
+++ b/openghg/util/_time.py
@@ -1,4 +1,5 @@
 from datetime import date
+import logging
 from pandas import DataFrame, DateOffset, DatetimeIndex, Timedelta, Timestamp
 from xarray import Dataset
 import re
@@ -713,7 +714,8 @@ def parse_period(period: str | tuple) -> TimePeriod:
             unit = period.lstrip(value_str).strip()  # Strip found value and any whitespace.
         else:
             value = 1
-            unit = period
+            unit = "seconds"
+            logging.warning("For time period 'varies' value is set `1` and unit is set to `seconds`")
 
     offset_naming = time_offset_definition()
 

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -684,7 +684,7 @@ def test_standardise_footprints_satellite_raises_error():
         )
 
 
-def test_standardise_footprint_satellite():
+def test_standardise_footprint_satellite(caplog):
     """
     Tests standardise footprint for satellite data and associated metadata keys."""
     clear_test_stores()
@@ -702,13 +702,15 @@ def test_standardise_footprint_satellite():
             network=network,
             model="CAMS",
             inlet="column",
-            period='1S',
+            period='varies',
             domain=domain,
             obs_region=obs_region,
             selection="LAND",
             store="user",
-            continuous=False,
+            continuous=True,
         )
+
+    assert "'continuous' is set to `False`" in caplog.text
 
     data = get_footprint(
         satellite=satellite,
@@ -716,6 +718,7 @@ def test_standardise_footprint_satellite():
         obs_region=obs_region
     )
 
+    assert data.metadata["time_period"] == '1 second'
     assert data.metadata["obs_region"] == obs_region.lower()
     assert data.metadata["selection" ] == "land"
     assert data.metadata["domain"] == domain.lower()

--- a/tests/util/test_time.py
+++ b/tests/util/test_time.py
@@ -366,6 +366,7 @@ def test_check_duplicate_timestamps():
     "test_input,expected",
     [
         ("12H", (12, "hours")),
+        ("varies", (1, "seconds")),
         ("yearly", (1, "years")),
         ("monthly", (1, "months")),
         ((1, "minute"), (1, "minutes")),


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
  Added relevant warnings, If time_period is varies, the default is set to "1 second".
  If continuous=false inferred frequency is set to input_frequency



* **Please check if the PR fulfills these requirements**
- [x] Closes #1254 
- [x] Closes #1151  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
