### PR TITLE
Update reading of config file to use internal defaults when file is not present in object store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped `exposure_id` variable for GOSAT data to avoid change in dimension size error raised from `to_zarr`. [PR #1243](https://github.com/openghg/openghg/pull/1243)
 - Added ability to process ModelScenario for Observation and Footprint satellite data. Added `platform` keyword to split the process and added ability to pass `satellite` as argument.[#PR 1244](https://github.com/openghg/openghg/pull/1244)
 
+### Updated
+- For new object stores, a config file copied into this by default. If no config file is detected the internal defaults for the config are used instead. A custom config file can stil be created as needed. [PR #1260](https://github.com/openghg/openghg/pull/1260)
+
 ## [0.13.0] - 2025-03-10
 
 ### Added

--- a/openghg/objectstore/__init__.py
+++ b/openghg/objectstore/__init__.py
@@ -30,6 +30,6 @@ from ._config import (
     check_metakeys,
     get_metakeys,
     write_metakeys,
-    create_default_config,
+    create_custom_config,
     get_metakey_defaults,
 )

--- a/openghg/objectstore/_config.py
+++ b/openghg/objectstore/_config.py
@@ -3,7 +3,6 @@ import logging
 import importlib
 from pprint import pformat
 from pathlib import Path
-import pkgutil
 
 from openghg.types import ConfigFileError
 from openghg.util import timestamp_now
@@ -12,7 +11,7 @@ logger = logging.getLogger("openghg.objectstore")
 logger.setLevel(logging.INFO)  # Have to set level for logger as well as handlerF
 
 
-def _get_config_folderpath(bucket: str) -> Path:
+def _get_custom_config_folderpath(bucket: str) -> Path:
     """Get the filepath of the config file for the object store
 
     Args:
@@ -23,15 +22,30 @@ def _get_config_folderpath(bucket: str) -> Path:
     return Path(bucket, "config")
 
 
-def _get_metakeys_filepath(bucket: str) -> Path:
-    """Get the path from the metakeys JSON file
+def _get_custom_metakeys_filepath(bucket: str) -> Path:
+    """Get the expected path from the metakeys JSON file
+    within an object store.
 
     Args:
         bucket: Object store bucket path
     Returns:
         Path: Path to metakeys JSON
     """
-    return _get_config_folderpath(bucket=bucket) / "metadata_keys.json"
+    return _get_custom_config_folderpath(bucket=bucket) / "metadata_keys.json"
+
+
+def get_metakeys_defaults_filepath() -> Path:
+    """Get path for the defaults metakeys file within openghg.
+
+    Returns:
+        Path: Path to default metakeys JSON
+    """
+    config_file_ref = importlib.resources.files("openghg") / "data/config/objectstore/defaults.json"
+
+    with importlib.resources.as_file(config_file_ref) as f:
+        config_file_path = f
+
+    return config_file_path
 
 
 def get_metakey_defaults() -> dict:
@@ -40,8 +54,8 @@ def get_metakey_defaults() -> dict:
     Returns:
         dict: Dictionary of defaults
     """
-    json_bytes = pkgutil.get_data("openghg", "data/config/objectstore/defaults.json")
-    return json.loads(json_bytes.decode(encoding="utf-8"))
+    config_filepath = get_metakeys_defaults_filepath()
+    return json.loads(config_filepath.read_text())
 
 
 def check_metakeys(metakeys: dict) -> bool:
@@ -118,15 +132,16 @@ def check_metakeys(metakeys: dict) -> bool:
     return True
 
 
-def create_default_config(bucket: str) -> None:
-    """Creates the default configuration file for an object store
+def create_custom_config(bucket: str) -> None:
+    """Creates a copy of the default configuration file and puts this in
+    an object store so this can be modified.
 
     Args:
         bucket: Object store bucket path
     Returns:
         None
     """
-    config_folderpath = _get_config_folderpath(bucket=bucket)
+    config_folderpath = _get_custom_config_folderpath(bucket=bucket)
 
     config_folderpath.mkdir(parents=True, exist_ok=True)
 
@@ -161,7 +176,7 @@ def _write_metakey_config(bucket: str, metakeys: dict) -> None:
         "metakeys": metakeys,
     }
 
-    metakey_path = _get_metakeys_filepath(bucket=bucket)
+    metakey_path = _get_custom_metakeys_filepath(bucket=bucket)
     config_folder = metakey_path.parent
 
     if not config_folder.exists():
@@ -171,22 +186,46 @@ def _write_metakey_config(bucket: str, metakeys: dict) -> None:
     metakey_path.write_text(json.dumps(config_data))
 
 
-def get_metakeys(bucket: str) -> dict[str, dict]:
-    """Read the object store config
+def _get_metakeys_from_file(metakey_path: Path) -> dict:
+    """Get the metakeys from a JSON file. Expect this will
+    either contain 'metakeys' key containing the config data
+    or the top level will contain this data directly.
 
     Args:
-        store: Store name
+        metakey_path: Path to metakey JSON file
+    Returns:
+        dict: metakey details from the JSON file
+    """
+    config_data = json.loads(metakey_path.read_text())
+    if "metakeys" in config_data:
+        metakeys = config_data["metakeys"]
+    else:
+        metakeys = config_data
+
+    return metakeys
+
+
+def get_metakeys(bucket: str | None = None) -> dict[str, dict]:
+    """Read the metakeys. This will look for a custom
+    config file within the object store and if one is not
+    found this will use the defaults from within openghg.
+
+    Args:
+        bucket: Path to object store
     Returns:
         dict: Configuration data
     """
-    metakey_path = _get_metakeys_filepath(bucket=bucket)
+    if bucket is not None:
+        metakey_path: Path | None = _get_custom_metakeys_filepath(bucket=bucket)
+    else:
+        metakey_path = None
 
-    if not metakey_path.exists():
-        logger.debug(f"Creating default metakeys file at {metakey_path}.")
-        create_default_config(bucket=bucket)
+    if metakey_path is None or not metakey_path.exists():
+        metakey_path = get_metakeys_defaults_filepath()
 
-    config_data = json.loads(metakey_path.read_text())
-    return config_data["metakeys"]
+    metakeys = _get_metakeys_from_file(metakey_path)
+
+    return metakeys
 
 
 def write_metakeys(bucket: str, metakeys: dict) -> None:

--- a/openghg/objectstore/_config.py
+++ b/openghg/objectstore/_config.py
@@ -31,7 +31,7 @@ def _get_custom_metakeys_filepath(bucket: str) -> Path:
     Returns:
         Path: Path to metakeys JSON
     """
-    return _get_custom_config_folderpath(bucket=bucket) / "metadata_keys.json"
+    return _get_custom_config_folderpath(bucket=bucket) / "metadata_keys_v2.json"
 
 
 def get_metakeys_defaults_filepath() -> Path:

--- a/openghg/objectstore/_config.py
+++ b/openghg/objectstore/_config.py
@@ -22,16 +22,21 @@ def _get_custom_config_folderpath(bucket: str) -> Path:
     return Path(bucket, "config")
 
 
-def _get_custom_metakeys_filepath(bucket: str) -> Path:
+def _get_custom_metakeys_filepath(bucket: str, previous: bool = False) -> Path:
     """Get the expected path from the metakeys JSON file
     within an object store.
 
     Args:
         bucket: Object store bucket path
+        previous: Get previous name for the file (now deprecated)
     Returns:
         Path: Path to metakeys JSON
     """
-    return _get_custom_config_folderpath(bucket=bucket) / "metadata_keys_v2.json"
+    if previous:
+        filename = "metadata_keys.json"
+    else:
+        filename = "metadata_keys_v2.json"
+    return _get_custom_config_folderpath(bucket=bucket) / filename
 
 
 def get_metakeys_defaults_filepath() -> Path:
@@ -222,6 +227,13 @@ def get_metakeys(bucket: str | None = None) -> dict[str, dict]:
 
     if metakey_path is None or not metakey_path.exists():
         metakey_path = get_metakeys_defaults_filepath()
+
+    if bucket is not None:
+        prev_metakey_path = _get_custom_metakeys_filepath(bucket=bucket, previous=False)
+        if prev_metakey_path.exists():
+            logger.warning(
+                f"Previous config file: '{prev_metakey_path}' exists in the object store. This is now deprecated and so is no longer used."
+            )
 
     metakeys = _get_metakeys_from_file(metakey_path)
 

--- a/tests/objectstore/test_config.py
+++ b/tests/objectstore/test_config.py
@@ -35,7 +35,7 @@ def test_create_custom_config(tmp_store):
     """
     create_custom_config(bucket=str(tmp_store))
 
-    assert (tmp_store / "config" / "metadata_keys.json").exists()
+    assert (tmp_store / "config" / "metadata_keys_v2.json").exists()
 
 
 def test_get_metakeys():

--- a/tests/objectstore/test_config.py
+++ b/tests/objectstore/test_config.py
@@ -2,7 +2,7 @@ import pytest
 from openghg.objectstore import (
     check_metakeys,
     get_metakey_defaults,
-    create_default_config,
+    create_custom_config,
     get_metakeys,
     write_metakeys,
 )
@@ -25,17 +25,17 @@ def test_get_metakey_defaults():
     assert defaults.keys() == storage_classes.keys()
 
 
-def test_create_default_config(tmp_store):
+def test_create_custom_config(tmp_store):
 
-    create_default_config(bucket=str(tmp_store))
+    create_custom_config(bucket=str(tmp_store))
 
     assert (tmp_store / "config" / "metadata_keys.json").exists()
 
 
-def test_get_metakeys(tmp_store):
-    create_default_config(bucket=tmp_store)
-
-    metakeys = get_metakeys(bucket=tmp_store)
+def test_get_metakeys():
+    """Test metakeys can be extracted.
+    """
+    metakeys = get_metakeys()
 
     assert metakeys.keys() == data_class_info().keys()
 

--- a/tests/objectstore/test_config.py
+++ b/tests/objectstore/test_config.py
@@ -1,10 +1,15 @@
 import pytest
+import json
 from openghg.objectstore import (
     check_metakeys,
     get_metakey_defaults,
     create_custom_config,
     get_metakeys,
     write_metakeys,
+)
+from openghg.objectstore._config import (
+    _get_custom_metakeys_filepath,
+    _get_metakeys_from_file
 )
 from openghg.store import data_class_info
 from openghg.types import ConfigFileError
@@ -26,7 +31,8 @@ def test_get_metakey_defaults():
 
 
 def test_create_custom_config(tmp_store):
-
+    """Test custom config can be created and detected in the object store.
+    """
     create_custom_config(bucket=str(tmp_store))
 
     assert (tmp_store / "config" / "metadata_keys.json").exists()
@@ -39,6 +45,23 @@ def test_get_metakeys():
 
     assert metakeys.keys() == data_class_info().keys()
 
+
+def test_custom_metakeys(tmp_store):
+    """Check metakeys can be read from a custom file
+    """
+    create_custom_config(tmp_store)
+
+    metakeys_filepath = _get_custom_metakeys_filepath(tmp_store)
+    config_data = _get_metakeys_from_file(metakeys_filepath)
+
+    new_key = "new_key"
+    config_data["surface"]["required"][new_key] = {"type": ["str"]}
+
+    with open(metakeys_filepath, "w") as filepath:
+        json.dump(config_data, filepath)
+    
+    metakeys = get_metakeys(bucket=tmp_store)
+    assert new_key in metakeys["surface"]["required"]
 
 def test_write_metakeys(tmp_store):
     mock_keys = {"required": {"site": {"type": ["str"]}}}


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The keys used for each data_type to distinguish data are defined within a config file. At the moment this config file is copied into an object store when this is first created but this then doesn't get updated if further changes are made to the default.

This PR is to update this workflow:
 - Don't create the config file in an object store by default
 - Still look for a config file in the object store BUT the filename this looks for has now been changed to "_v2" so the file in old object store will no longer be found and accessed.
    - If previous file is detected a warning is included
 - If no config file is found this now uses the internal defaults in openghg
 - It is still possible to create a config file which will be put in the object store but this is now defined as a "custom" file and should be created deliberately using `create_custom_config` (formerly `create_default_config`)

* **Please check if the PR fulfills these requirements**

- [x] Closes #1255 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not included
- ~Documentation and tutorials updated/added~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
