### PR TITLE
Updating way model baseline values are numerically expressed

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -1260,7 +1260,7 @@ class ModelScenario:
         self,
         resample_to: str | None = "coarsest",
         platform: str | None = None,
-        output_units: float = 1e-9,
+        output_units: float = 1,
         cache: bool = True,
         recalculate: bool = False,
     ) -> DataArray:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
The default for 'calc_modelled_obs' is to produced simulated mole fractions in ppb. This is potentially problematic given the number of different species being used. 

I have changed the default to 1 (from 1e-9) so baseline mole fraction simulations are output in mol/mol.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
