### PR TITLE
Removing measurement_type from parse functions which don't use this.

### DIFF
--- a/openghg/standardise/surface/_agage.py
+++ b/openghg/standardise/surface/_agage.py
@@ -21,7 +21,6 @@ def parse_agage(
     inlet: str | None = None,
     instrument: str | None = None,
     sampling_period: str | None = None,
-    measurement_type: str | None = None,
     update_mismatch: str = "from_source",
     site_filepath: optionalPathType = None,
 ) -> dict:
@@ -34,7 +33,6 @@ def parse_agage(
         network: Network name
         inlet: inlet name (optional)
         sampling_period: sampling period for this instrument. If not supplied, will be read from the file.
-        measurement_type: measurement type
         update_mismatch: This determines how mismatches between the internal data
             "attributes" and the supplied / derived "metadata" are handled.
             This includes the options:

--- a/openghg/standardise/surface/_crds.py
+++ b/openghg/standardise/surface/_crds.py
@@ -12,7 +12,6 @@ def parse_crds(
     inlet: str | None = None,
     instrument: str | None = None,
     sampling_period: str | float | int | None = None,
-    measurement_type: str | None = None,
     drop_duplicates: bool = True,
     update_mismatch: str = "never",
     site_filepath: optionalPathType = None,
@@ -28,7 +27,6 @@ def parse_crds(
         inlet: Inlet height
         instrument: Instrument name
         sampling_period: Sampling period in seconds
-        measurement_type: Measurement type e.g. insitu, flask
         drop_duplicates: Drop measurements at duplicate timestamps, keeping the first.
         update_mismatch: This determines how mismatches between the internal data
             "attributes" and the supplied / derived "metadata" are handled.
@@ -61,7 +59,6 @@ def parse_crds(
         inlet=inlet,
         instrument=instrument,
         sampling_period=sampling_period,
-        measurement_type=measurement_type,
         drop_duplicates=drop_duplicates,
     )
 
@@ -86,7 +83,6 @@ def _read_data(
     inlet: str | None = None,
     instrument: str | None = None,
     sampling_period: str | float | int | None = None,
-    measurement_type: str | None = None,
     site_filepath: optionalPathType = None,
     drop_duplicates: bool = True,
 ) -> dict:
@@ -99,7 +95,6 @@ def _read_data(
         inlet: Inlet height
         instrument: Instrument name
         sampling_period: Sampling period in seconds
-        measurement_type: Measurement type e.g. insitu, flask
         site_filepath: Alternative site info file (see openghg/openghg_defs repository for format).
             Otherwise will use the data stored within openghg_defs/data/site_info JSON file by default.
         drop_duplicates: Drop measurements at duplicate timestamps, keeping the first.

--- a/openghg/standardise/surface/_gcwerks.py
+++ b/openghg/standardise/surface/_gcwerks.py
@@ -58,7 +58,6 @@ def parse_gcwerks(
     inlet: str | None = None,
     instrument: str | None = None,
     sampling_period: str | None = None,
-    measurement_type: str | None = None,
     update_mismatch: str = "never",
     site_filepath: optionalPathType = None,
 ) -> dict:

--- a/openghg/standardise/surface/_npl.py
+++ b/openghg/standardise/surface/_npl.py
@@ -13,7 +13,6 @@ def parse_npl(
     inlet: str | None = None,
     instrument: str | None = None,
     sampling_period: str | None = None,
-    measurement_type: str | None = None,
     update_mismatch: str = "never",
 ) -> dict:
     """Reads NPL data files and returns the UUIDS of the Datasources
@@ -26,7 +25,6 @@ def parse_npl(
         inlet: Inlet height. Will be inferred if not specified
         instrument: Instrument name
         sampling_period: Sampling period
-        measurement_type: Type of measurement taken e.g."flask", "insitu"
         update_mismatch: This determines how mismatches between the internal data
             "attributes" and the supplied / derived "metadata" are handled.
             This includes the options:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)


* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
