### PR TITLE
Added tox for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `platform` keyword can now be used with surface data and can be passed to the standardise_surface function (e.g. "surface-insitu", "surface-flask"). This can be used to (a) separate data into different datasources based on platform when storing and (b) when deciding whether to resample data when aligning using ModelScenario methods. [PR #1278](https://github.com/openghg/openghg/pull/1278), [PR #1279](https://github.com/openghg/openghg/pull/1279) and [PR #1289](https://github.com/openghg/openghg/pull/1289).
 - Added ability to reindex footprint data to obs data with tolerance of `1ms` with method="nearest".[#PR 1264](https://github.com/openghg/openghg/pull/1264)
 - Added ability to standardise CORSO radiocarbon data, added new parser named `parse_icos_corso` to handle data modifications.[PR #1285](https://github.com/openghg/openghg/pull/1285)
+- `tox` testing setup. [#PR 1268](https://github.com/openghg/openghg/pull/1268)
 
 ### Updated
 
-- For new object stores, a config file copied into this by default. If no config file is detected the internal defaults for the config are used instead. A custom config file can stil be created as needed. [PR #1260](https://github.com/openghg/openghg/pull/1260)
+- For new object stores, a config file copied into this by default. If no config file is detected the internal defaults for the config are used instead. A custom config file can still be created as needed. [PR #1260](https://github.com/openghg/openghg/pull/1260)
 
 ### Fixed
 - Bugs of resampling functions : delete all variables in the obs data that are filled of nan, test the emptiness of the dataset, and delete "flag" variable (removed in [#PR1283] https://github.com/openghg/openghg/pull/1283), all that before resampling to prevent errors [#PR1275](https://github.com/openghg/openghg/pull/1275)

--- a/doc/source/development/python_devel.rst
+++ b/doc/source/development/python_devel.rst
@@ -8,8 +8,7 @@ The source code for OpenGHG is available on `GitHub <https://github.com/openghg/
 Setting up your computer
 =========================
 
-You'll need `git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ and Python >= 3.9, so please make sure you have both installed before continuing
-further.
+You'll need `git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ and Python >= 3.10, so please make sure you have both installed before continuing further.
 
 
 Clone OpenGHG
@@ -115,7 +114,6 @@ OpenGHG should now be installed, you can check this by opening ``ipython`` and r
 
    In [1]: import openghg
 
-
 Run tests
 ---------
 
@@ -125,6 +123,50 @@ To ensure everything is working on your system running the tests is a good idea.
 
     pytest -v tests
 
+Testing against multiple versions of Python
+-------------------------------------------
+
+Our GitHub workflows test against multiple versions of Python, using the latest versions of dependencies.
+This can sometimes result in failing tests when you push to GitHub, despite your tests passing locally.
+
+You can use ``tox`` to run tests in isolated environments built with the latest dependencies  different versions of Python.
+
+Managing different versions of Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To manage multiple versions of Python, you can use ``pyenv <https://github.com/pyenv/pyenv>`_.
+After following the installation instructions, you can install multiple versions of Python:
+
+.. code-block:: bash
+
+    pyenv install 3.10
+    pyenv install 3.11
+    pyenv install 3.12
+
+To view all available versions, call ``pyenv versions``. To view and set your preferred version globally, use ``pyenv global``.
+To activate multiple versions of Python, you can use ``pyenv local``:
+
+.. code-block:: bash
+
+    pyenv local 3.10 3.11 3.12
+
+This makes Python 3.10, 3.11, and 3.12 available in the current directory.
+The ``python`` command will default to the first version in the list; in this case, Python 3.10
+
+Running tests with ``tox``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To run tests against Python 3.10, 3.11, and 3.12, as well as run the linters (``black`` and ``flake8``) and ``mypy``, call ``tox``
+in your OpenGHG repo.
+
+To see all jobs that ``tox`` can run, use ``tox -l``. You can run a specific job with ``tox run -e <env>``.
+For instance
+
+.. code-block:: bash
+
+   tox run -e py312
+
+will run the tests against Python 3.12.
 
 Coding Style
 ============
@@ -384,4 +426,3 @@ When the feature is complete, create a *pull request* on GitHub so that the
 changes can be merged back into the development branch.
 For information, see the documentation
 `here <https://help.github.com/articles/about-pull-requests>`__.
-

--- a/doc/source/development/python_devel.rst
+++ b/doc/source/development/python_devel.rst
@@ -134,7 +134,7 @@ You can use ``tox`` to run tests in isolated environments built with the latest 
 Managing different versions of Python
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To manage multiple versions of Python, you can use ``pyenv <https://github.com/pyenv/pyenv>`_.
+To manage multiple versions of Python, you can use `pyenv <https://github.com/pyenv/pyenv>`_.
 After following the installation instructions, you can install multiple versions of Python:
 
 .. code-block:: bash

--- a/doc/source/development/python_devel.rst
+++ b/doc/source/development/python_devel.rst
@@ -151,7 +151,7 @@ To activate multiple versions of Python, you can use ``pyenv local``:
     pyenv local 3.10 3.11 3.12
 
 This makes Python 3.10, 3.11, and 3.12 available in the current directory.
-The ``python`` command will default to the first version in the list; in this case, Python 3.10
+The ``python`` command will default to the first version in the list; in this case, Python 3.10.
 
 Running tests with ``tox``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -167,6 +167,13 @@ For instance
    tox run -e py312
 
 will run the tests against Python 3.12.
+
+To pass arguments to ``pytest``, you can append them after the ``tox`` command as follows:
+
+.. code-block:: bash
+
+   tox run -e py312 -- tests/analyse/test_scenario.py
+
 
 Coding Style
 ============

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -47,6 +47,7 @@ dependencies:
   - requests-mock
   - pytest-tornasync
   - mypy==1.7.1
+  - tox>=4.24
   - types-PyYAML
   - types-requests
   - types-toml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ pytest-cov
 pytest-mock
 pytest-timeout
 requests-mock
+tox >=4.24
 # For mypy
 mypy==1.10.0
 types-paramiko

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+[tox]
+min_version = 4.24
+isolated_build = True
+env_list =
+    py3{10,11,12}
+    lint
+    type
+
+[testenv]
+description = "Run tests under {base_python}."
+deps =
+    pytest >= 6.2.5
+    pytest-tornasync
+    pytest-cov
+    pytest-mock
+    pytest-timeout
+    requests-mock
+
+commands =
+    pytest {posargs:tests}
+
+[testenv:lint]
+description = "Run linters."
+skip_install = true
+deps =
+    black
+    flake8
+commands =
+    black --check {posargs:.}
+    flake8 {posargs:.}
+
+[testenv:type]
+description = "Run type checker."
+deps =
+    mypy==1.10.0
+    types-paramiko
+    types-PyYAML
+    types-requests
+    types-toml
+    types-urllib3
+    msgpack-types
+
+commands =
+    mypy {posargs:openghg}

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ deps =
     black
     flake8
 commands =
-    black --check {posargs:.}
-    flake8 {posargs:.}
+    black --check {posargs:openghg}
+    flake8 {posargs:openghg}
 
 [testenv:type]
 description = "Run type checker."


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Tests against multiple versions of Python can now
be run locally, emulating our GitHub workflow.

Docs have been added to explain how to do this, but assuming `tox` is installed (via `pip install tox`) and you have Python 3.10, 3.11, and 3.12 installed, then running `tox` in the terminal in your OpenGHG repo will run tests against Python 3.10-3.12, as well as black (check only), flake8, and mypy.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1270 
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
