### PR TITLE
Bug fix timestamp cannot be inferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped `exposure_id` variable for GOSAT data to avoid change in dimension size error raised from `to_zarr`. [PR #1243](https://github.com/openghg/openghg/pull/1243) [PR #1257](https://github.com/openghg/openghg/pull/1257)
 - Drop `id` coordinate for GOSAT data to avoid merging errors [PR #1257](https://github.com/openghg/openghg/pull/1257)
 - Fixed bugs in ModelScenario for satellite data e.g. requiring max_level as argument [#PR 1261](https://github.com/openghg/openghg/pull/1261)
-- Fixed `get_*` functions if passed with `start_date` or `end_date` in format of ""dd:mm:yy T 00:00:0000" can still fetch the relevant data.[#PR 1272](https://github.com/openghg/openghg/issues/1272)
+- Fixed `get_*` functions if passed with `start_date` or `end_date` in format of ""dd:mm:yy T 00:00:0000" can still fetch the relevant data.[#PR 1273](https://github.com/openghg/openghg/issues/1273)
 
 ## [0.13.0] - 2025-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped `exposure_id` variable for GOSAT data to avoid change in dimension size error raised from `to_zarr`. [PR #1243](https://github.com/openghg/openghg/pull/1243) [PR #1257](https://github.com/openghg/openghg/pull/1257)
 - Drop `id` coordinate for GOSAT data to avoid merging errors [PR #1257](https://github.com/openghg/openghg/pull/1257)
 - Fixed bugs in ModelScenario for satellite data e.g. requiring max_level as argument [#PR 1261](https://github.com/openghg/openghg/pull/1261)
+- Fixed `get_*` functions if passed with `start_date` or `end_date` in format of ""dd:mm:yy T 00:00:0000" can still fetch the relevant data.[#PR 1272](https://github.com/openghg/openghg/issues/1272)
 
 ## [0.13.0] - 2025-03-10
 

--- a/openghg/retrieve/_search.py
+++ b/openghg/retrieve/_search.py
@@ -4,6 +4,7 @@ the object store.
 """
 
 import logging
+import pandas as pd
 from typing import Any
 import warnings
 from openghg.objectstore.metastore import open_metastore
@@ -459,6 +460,9 @@ def search(**kwargs: Any) -> SearchResults:
             v = {key: clean_string(value) for key, value in v.items() if value is not None}
             if not v:  # Check empty dict
                 v = None
+        elif k.lower() in ["start_date", "end_date"]:
+            if v is not None:
+                v = pd.Timestamp(v)
         else:
             v = clean_string(v)
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Added check to see if start_date and end_date are None then they will be converted to pd.Timestamp format. This results in searching data with start_date and end_date.
start_date = 2016-01-01 14:59:12.500000+00:00
changes to format 2016-01-01 pd.Timestamp(14:59:12.500000+00:00)

* **Please check if the PR fulfills these requirements**

- [x] Closes #1272(Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
