### PR TITLE
Removing default from measurement_type in standardise_surface

### DIFF
--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -66,7 +66,7 @@ def standardise_surface(
     dataset_source: str | None = None,
     sampling_period: Timedelta | str | None = None,
     calibration_scale: str | None = None,
-    measurement_type: str = "insitu",
+    measurement_type: str | None = None,
     verify_site_code: bool = True,
     site_filepath: optionalPathType = None,
     store: str | None = None,

--- a/openghg/standardise/surface/_noaa.py
+++ b/openghg/standardise/surface/_noaa.py
@@ -15,7 +15,7 @@ logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handle
 def parse_noaa(
     filepath: str | Path,
     site: str,
-    measurement_type: str,
+    measurement_type: str | None,
     inlet: str | None = None,
     network: str = "NOAA",
     instrument: str | None = None,
@@ -49,6 +49,15 @@ def parse_noaa(
         sampling_period = check_and_set_null_variable(sampling_period)
 
     sampling_period = str(sampling_period)
+
+    valid_types = ("flask", "insitu", "pfp")
+
+    if measurement_type is None:
+        raise ValueError(
+            f"measurement_type must be specified for source_format='noaa'. This must be one of {valid_types}"
+        )
+    elif measurement_type not in valid_types:
+        raise ValueError(f"measurement_type is '{measurement_type}' but must be one of {valid_types}")
 
     file_extension = Path(filepath).suffix
 
@@ -302,11 +311,6 @@ def _read_obspack(
     """
     from openghg.standardise.meta import assign_attributes
     from openghg.util import clean_string
-
-    valid_types = ("flask", "insitu", "pfp")
-
-    if measurement_type not in valid_types:
-        raise ValueError(f"measurement_type must be one of {valid_types}")
 
     with xr.open_dataset(filepath) as temp:
         obspack_ds = temp

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -444,6 +444,7 @@ def test_read_noaa_raw(bucket):
         source_format="NOAA",
         site="POCN25",
         network="NOAA",
+        measurement_type="flask",
         inlet="flask",
     )
 
@@ -474,6 +475,7 @@ def test_read_noaa_metastorepack(bucket):
         inlet="flask",
         source_format="NOAA",
         site="esp",
+        measurement_type="flask",
         network="NOAA",
         overwrite=True,
     )
@@ -1082,7 +1084,7 @@ def test_optional_metadata():
 
 
 @pytest.mark.parametrize(
-    "filepath, site, instrument, sampling_period, network, inlet, source_format, update_mismatch",
+    "filepath, site, instrument, sampling_period, network, inlet, measurement_type, source_format, update_mismatch",
     [
         (
             "DECC-picarro_TAC_20130131_co2-185m-20220928.nc",
@@ -1091,15 +1093,16 @@ def test_optional_metadata():
             "1h",
             "decc",
             "185m",
+            None,
             "openghg",
             "from_definition",
         ),
-        ("ch4_bao_tower-insitu_1_ccgg_all.nc", "bao", None, None, "noaa", None, "noaa", "from_source"),
-        ("ICOS_ATC_L2_L2-2024.1_RGL_90.0_CTS.CH4", "rgl", "g2301", None, "icos", None, "icos", "never"),
+        ("ch4_bao_tower-insitu_1_ccgg_all.nc", "bao", None, None, "noaa", None, "insitu", "noaa", "from_source"),
+        ("ICOS_ATC_L2_L2-2024.1_RGL_90.0_CTS.CH4", "rgl", "g2301", None, "icos", None, None, "icos", "never"),
     ],
 )
 def test_sync_surface_metadata_store_level(
-    filepath, site, instrument, sampling_period, network, inlet, source_format, update_mismatch, caplog
+    filepath, site, instrument, sampling_period, network, inlet, measurement_type, source_format, update_mismatch, caplog
 ):
     clear_test_stores()
     bucket = get_writable_bucket(name="user")
@@ -1112,6 +1115,7 @@ def test_sync_surface_metadata_store_level(
         sampling_period=sampling_period,
         network=network,
         inlet=inlet,
+        measurement_type=measurement_type,
         store="user",
         source_format=source_format,
         update_mismatch=update_mismatch,


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

At the moment `measurement_type` has a default of "insitu" within the `standardise_surface` function. This could cause issues as we're starting to include more data from flask sampling as this means misleading details would be included in the file attributes by default.

Summary of updates:
 - Remove default from `standardise_surface` for `measurement_type` and allow this to be None
 - Update impacted `parse_noaa` function to check for None input in initial function and make sure this is set to a valid type
 - Update impacted tests to make sure `measurement_type` keyword is specified when the `parse_noaa` function will be called.

This also feeds into the work to add the `platform` keyword as an option (see Issue #1247 ) as we'll want to link the `platform` and `measurement_type` keywords together as they describe similar details.

* **Please check if the PR fulfills these requirements**

- [x] Links to Issue #1247 and feeds into PR #1278 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

Not added:
- Did not update CHANGELOG.md as this does not change the input interface
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~ - not needed
- ~Documentation and tutorials updated/added~