### PR TITLE
Fix resampling for surface obs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `"keep_variables"` parameter in `get_obs_surface` to choose which variables we want to keep when retrieving data. This can be use to prevent resampling functions to try to resample unused variables filled with nans or string [#PR1283](https://github.com/openghg/openghg/pull/1283)
 - Added a new resampling feature for obs where a f"{species}_variability" variable is preseent but not f"{species}_number_of_observation" [#PR1275](https://github.com/openghg/openghg/pull/1275)
 - Added ability to retrieve ICOS combined Obspack .nc data. [PR #1212](https://github.com/openghg/openghg/pull/1212)
 - Added ability to process ModelScenario for Observation and Footprint satellite data. Added `platform` keyword to split the process and added ability to pass `satellite` as argument.[#PR 1244](https://github.com/openghg/openghg/pull/1244)
@@ -20,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For new object stores, a config file copied into this by default. If no config file is detected the internal defaults for the config are used instead. A custom config file can stil be created as needed. [PR #1260](https://github.com/openghg/openghg/pull/1260)
 
 ### Fixed
-- Bugs of resampling functions : delete all variables in the obs data that are filled of nan, test the emptiness of the dataset, and delete "flag" variable, all that before resampling to prevent errors [#PR1275](https://github.com/openghg/openghg/pull/1275)
+- Bugs of resampling functions : delete all variables in the obs data that are filled of nan, test the emptiness of the dataset, and delete "flag" variable (removed in [#PR1283] https://github.com/openghg/openghg/pull/1283), all that before resampling to prevent errors [#PR1275](https://github.com/openghg/openghg/pull/1275)
 - Fixed bug where `period="varies"` could not be used or set when determining the time period associated with the input data. [#PR 1259](https://github.com/openghg/openghg/pull/1259) and [#PR 1267](https://github.com/openghg/openghg/pull/1267)
 - Dropped `exposure_id` variable for GOSAT data to avoid change in dimension size error raised from `to_zarr`. [PR #1243](https://github.com/openghg/openghg/pull/1243) [PR #1257](https://github.com/openghg/openghg/pull/1257)
 - Drop `id` coordinate for GOSAT data to avoid merging errors [PR #1257](https://github.com/openghg/openghg/pull/1257)

--- a/openghg/data_processing/_resampling.py
+++ b/openghg/data_processing/_resampling.py
@@ -29,6 +29,7 @@ from collections.abc import Callable, Sequence
 from functools import partial, wraps
 from typing import Any, Concatenate, Literal
 
+import logging
 import pandas as pd
 import xarray as xr
 from openghg.util import Registry
@@ -40,6 +41,9 @@ from ._xarray_helpers import xr_sqrt
 
 registry = Registry(suffix="resample")
 register = registry.register
+
+logger = logging.getLogger("openghg.data_processing")
+logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
 
 # somewhat complicated typing for decorator:

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -173,9 +173,12 @@ def get_obs_surface(
     if data.sizes["time"] == 0:
         raise SearchError(f"Dataset is empty for obs. with {surface_keywords}.")
 
-    if keep_variables : 
+    if keep_variables:
         var_list = [str(dv) for dv in data.data_vars if str(dv) in keep_variables]
-        if not var_list : raise ValueError(f"Variables among {keep_variables} expected, but none of them found. Present variables are  : {[str(dv) for dv in data.data_vars]}")
+        if not var_list:
+            raise ValueError(
+                f"Variables among {keep_variables} expected, but none of them found. Present variables are  : {[str(dv) for dv in data.data_vars]}"
+            )
         data = data[var_list]
 
     if data.attrs["inlet"] == "multiple":

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -978,7 +978,7 @@ def test_drop_only_correct_nan():
         ("data_level", "1", "2"),
         ("data_sublevel", "1.1", "1.2"),
         ("dataset_source", "InGOS", "European ObsPack"),
-        ("platform", "surface-insitu", "surface-flask")
+        ("platform", "surface-insitu", "surface-flask"),
     ],
 )
 def test_obs_data_param_split(data_keyword, data_value_1, data_value_2):
@@ -1102,12 +1102,31 @@ def test_optional_metadata():
             "openghg",
             "from_definition",
         ),
-        ("ch4_bao_tower-insitu_1_ccgg_all.nc", "bao", None, None, "noaa", None, "insitu", "noaa", "from_source"),
+        (
+            "ch4_bao_tower-insitu_1_ccgg_all.nc",
+            "bao",
+            None,
+            None,
+            "noaa",
+            None,
+            "insitu",
+            "noaa",
+            "from_source",
+        ),
         ("ICOS_ATC_L2_L2-2024.1_RGL_90.0_CTS.CH4", "rgl", "g2301", None, "icos", None, None, "icos", "never"),
     ],
 )
 def test_sync_surface_metadata_store_level(
-    filepath, site, instrument, sampling_period, network, inlet, measurement_type, source_format, update_mismatch, caplog
+    filepath,
+    site,
+    instrument,
+    sampling_period,
+    network,
+    inlet,
+    measurement_type,
+    source_format,
+    update_mismatch,
+    caplog,
 ):
     clear_test_stores()
     bucket = get_writable_bucket(name="user")


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
add a keep_variables option in get_obs_surface. This can be use to pr…event resampling functions to try to resample unused variables filled with nans or string

* **Please check if the PR fulfills these requirements**

- [X] Closes #1274 and hopefully #1121 and partially #1120 
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
