### PR TITLE
Update combine_datasets function to use native xarray steps rather than numpy

### DIFF
--- a/openghg/analyse/_alignment.py
+++ b/openghg/analyse/_alignment.py
@@ -311,7 +311,7 @@ def combine_datasets(
 
     if "fp" in merged_ds:
         if all(k in merged_ds.fp.dims for k in ("lat", "lon")):
-            flag = np.where(np.isfinite(merged_ds.fp.mean(dim=["lat", "lon"]).values))
-            merged_ds = merged_ds[dict(time=flag[0])]
+            flag = np.isfinite(merged_ds.fp.mean(["lat", "lon"]))
+            merged_ds = merged_ds.where(flag.compute(), drop=True)
 
     return merged_ds


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Small update to `combine_datasets` function to update steps to use xarray directly rather than using numpy. This is when creating a filter for footprint data to remove infinite values.

From comment on PR #1291 but added as a separate PR since this is a key part of the code.

* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

Not done
- ~Closes #xxxx (Replace xxxx with the Github issue number)~
- ~Documentation and tutorials updated/added~
- ~Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature~
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
