### PR TITLE
Added option to compute modelled obs. (and fp_x_flux) by sector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Option to compute modelled obs (and "fp x flux") by flux sector/source in `ModelScenario.footprints_data_merge`. [PR #1330](https://github.com/openghg/openghg/pull/1330)
 - Option to return "fp x flux" from `ModelScenario.footprints_data_merge`. [PR #1328](https://github.com/openghg/openghg/pull/1328)
 - Function to compute baseline sensitivities for NESW. This is used in `calc_modelled_baseline` and will be useful for OpenGHG inversions. [PR #1326](https://github.com/openghg/openghg/pull/1326)
 

--- a/tests/analyse/test_modelled_obs.py
+++ b/tests/analyse/test_modelled_obs.py
@@ -307,3 +307,15 @@ def test_modelled_obs_co2_consistency(model_scenario_co2_dummy, model_scenario_p
     combined_paris = model_scenario_paris_co2_dummy.footprints_data_merge()
 
     xr.testing.assert_equal(combined.mf_mod_high_res, combined_paris.mf_mod_high_res)
+
+
+# TODO: this test could go elsewhere?
+def test_model_modelled_obs_co2_multisector(model_scenario_co2_dummy, flux_co2_dummy):
+    """Test footprints_data_merge with multisector return options"""
+    model_scenario_co2_dummy.add_flux(species="co2", flux={"TESTSOURCE2": flux_co2_dummy})
+    combined_dataset = model_scenario_co2_dummy.footprints_data_merge(calc_fp_x_flux=True, split_by_sectors=True)
+    print(combined_dataset)
+    print(combined_dataset.data_vars)
+    assert all(dv in combined_dataset for dv in ["mf_mod_high_res", "fp_x_flux", "mf_mod_high_res_sectoral", "fp_x_flux_sectoral"])
+
+    assert all(combined_dataset.source.values == ["TESTSOURCE", "TESTSOURCE2"])


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This option can be passed to `footprints_data_merge`. This will also compute fp_x_flux for each sector, if `calc_fp_x_flux` is True.

The sectoral versions are stored under `mf_mod_sectoral` (or `mf_mod_high_res_sectoral`) and `fp_x_flux_sectoral`.

The total modelled obs (and fp_x_flux) are computed as well.


* **Please check if the PR fulfills these requirements**

- [x] Closes #1309 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

