### PR TITLE
Fix mock metakeys

### DIFF
--- a/tests/store/test_footprints.py
+++ b/tests/store/test_footprints.py
@@ -813,7 +813,8 @@ def mock_metakeys():
     # TODO - implement this in a different way
     default_keys = get_metakey_defaults()
 
-    default_keys["footprints"]["optional"] = ["project", "special_tag"]
+    default_keys["footprints"]["optional"] = {"project": {"type": ["str"]},
+                                              "special_tag": {"type": ["str"]}}
 
     with patch("openghg.store.base._base.get_metakeys", return_value=default_keys):
         yield


### PR DESCRIPTION
…n (i.e. adding type dict with type string)

* **Summary of changes** (Bug fix, feature, docs update, ...)

Updating format for mocked optional metakeys to match to defaults.json
 - This was just type dict with type string for the optional inputs

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
