### PR TITLE
Added E701 to flake8 ignore list.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ profile=hug
 src_paths=isort,test
 
 [flake8]
-ignore = E203, W503, E501, W291, E127, E128, E704
+ignore = E203, W503, E501, W291, E127, E128, E701, E704
 max-line-length = 110
 per-file-ignores =
     */__init__.py: F401, E402


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

This option conflicts with Black:
https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#e701-e704

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
