### PR TITLE
Changed cast to np.floating to np.float64

### DIFF
--- a/openghg/standardise/flux_timeseries/_crf.py
+++ b/openghg/standardise/flux_timeseries/_crf.py
@@ -56,7 +56,7 @@ def parse_crf(
         dataframe = dataframe.iloc[49]
 
     dataframe = pd.DataFrame(dataframe).iloc[2:-1]
-    dataframe = dataframe.rename(columns={dataframe.columns[0]: "flux_timeseries"}).astype(np.floating)
+    dataframe = dataframe.rename(columns={dataframe.columns[0]: "flux_timeseries"}).astype(np.float64)
     dataframe.index = pd.to_datetime(dataframe.index, format="%Y")
 
     metadata = {}


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Casting to generic types like `np.floating` has been deprecated: https://numpy.org/doc/2.2/reference/arrays.dtypes.html#arrays-dtypes (see section on generic types)


* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

Not needed
- Closes #xxxx (Replace xxxx with the Github issue number)
- Documentation and tutorials updated/added
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
