### PR TITLE
Units for mf similar to xch4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `ModelScenario` to work with the new PARIS footprint format for time-resolved footprints. [PR #1324](https://github.com/openghg/openghg/pull/1324)
 - Updated the package release pyproject.toml and removed the setup.py to make sure PEP621 is followed. [PR #1345](https://github.com/openghg/openghg/pull/1345)
 
+### Fixed
+
+- Added unit of `xch4` data var as units attribute to `mf` inside `get_obs_column`. [PR #1360](https://github.com/openghg/openghg/pull/1360)
+
 ## [0.14.0] - 2025-04-16
 
 ### Added

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -303,6 +303,7 @@ def get_obs_column(
         )
         obs_data.data["mf_repeatability"] = obs_data.data.xch4_uncertainty
 
+        obs_data.data["mf"].attrs["units"] = obs_data.data.xch4.attrs["units"]
         # rt17603: 06/04/2018 Added drop variables to ensure lev and id dimensions are also dropped, Causing problems in footprints_data_merge() function
         drop_data_vars = [
             "xch4",

--- a/tests/retrieve/test_access.py
+++ b/tests/retrieve/test_access.py
@@ -320,6 +320,7 @@ def test_get_obs_column():
     assert obscolumn.time[0] == Timestamp("2017-03-18T15:32:54")
     assert np.isclose(obscolumn["mf"][0], 1238.2743)
     assert obscolumn.attrs["species"] == "CH4"
+    assert obscolumn["mf"].attrs["units"] == '1e-9'
 
 
 def test_get_obs_column_max_level():


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Added units attribute to `mf` of xch4 data var
Added check in the existing test

* **Please check if the PR fulfills these requirements**

- [x] Closes #1353 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
