### PR TITLE
Updating the logging to use 'openghg' name directly rather than __name__

### DIFF
--- a/openghg/__init__.py
+++ b/openghg/__init__.py
@@ -45,7 +45,7 @@ __revisionid__ = v.get("full-revisionid")
 del v, get_versions
 
 # Start module level logging
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("openghg")
 logger.setLevel(logging.DEBUG)
 logging.captureWarnings(capture=True)
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Very small change to help with finding and updating the logging setting in places outside of running openghg directly. This is primarily so we can more easily access the logger and handlers.

The primary use case for this at the moment is to allow us to more easily turn off the logging within the documentation but we may also be able to use this within the tests to stop tests output being written to the log as well.

* **Please check if the PR fulfills these requirements**

- [x] [Tests passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors