### PR TITLE
Fixing documentation to use `filepath` rather than previous `filepaths`

### DIFF
--- a/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
+++ b/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
@@ -112,7 +112,7 @@ following arguments:
 * ``network``: ``"DECC"``
 * ``source_format``: ``"CRDS"``, the type of data we want to process
 
-.. jupyter-execute::
+.. code:: ipython3
 
     from openghg.standardise import standardise_surface
 

--- a/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
+++ b/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
@@ -112,13 +112,18 @@ following arguments:
 * ``network``: ``"DECC"``
 * ``source_format``: ``"CRDS"``, the type of data we want to process
 
-.. code:: ipython3
+.. ipython::
 
-    from openghg.standardise import standardise_surface
+    In [1]: from openghg.standardise import standardise_surface
 
-    decc_results = standardise_surface(filepath=tac_data, source_format="CRDS", site="TAC", network="DECC")
+    @verbatim
+    In [2]: decc_results = standardise_surface(filepath=tac_data, source_format="CRDS", site="TAC", network="DECC")
 
-    decc_results
+    @verbatim
+    In [3]: decc_results
+    Out[3]: {'processed': {'tac.picarro.hourly.54m.dat': {'ch4': {'uuid': 'e2339fdf-c0d5-46b8-b5b9-3d682610e9fe', 'new': True}, 'co2': {'uuid': '1b4603e6-cac2-458c-b47e-e441864b29eb', 'new': True}},
+    'tac.picarro.hourly.100m.dat': {'ch4': {'uuid': '2e5935cc-07e3-4c0f-bd7c-8c6e4e2b13b7', 'new': True}, 'co2': {'uuid': '64c020b8-35dd-483f-b38c-99de83ea412d', 'new': True}},
+    'tac.picarro.hourly.185m.dat': {'ch4': {'uuid': '13172db7-7859-4f38-90cf-219c1fbe3b99', 'new': True}, 'co2': {'uuid': 'c79a3473-9f50-47d8-83d8-66a62fd085f7', 'new': True}}}}
 
 This extracts the data and metadata from the files,
 standardises them, and adds them to our object store. The keywords of ``site`` and ``network``,

--- a/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
+++ b/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
@@ -107,24 +107,18 @@ First we retrieve the raw data.
 Now we add this data to the object store using ``standardise_surface``, passing the
 following arguments:
 
-* ``filepaths``: list of paths to ``.dat`` files
+* ``filepath``: list of paths to ``.dat`` files
 * ``site``:  ``"TAC"``, the site code for Tacolneston
 * ``network``: ``"DECC"``
 * ``source_format``: ``"CRDS"``, the type of data we want to process
 
-.. ipython::
+.. jupyter-execute::
 
-    In [1]: from openghg.standardise import standardise_surface
+    from openghg.standardise import standardise_surface
 
-    @verbatim
-    In [2]: decc_results = standardise_surface(filepaths=tac_data, source_format="CRDS", site="TAC", network="DECC")
+    decc_results = standardise_surface(filepath=tac_data, source_format="CRDS", site="TAC", network="DECC")
 
-    @verbatim
-    In [3]: decc_results
-    Out[3]: {'processed': {'tac.picarro.hourly.54m.dat': {'ch4': {'uuid': 'e2339fdf-c0d5-46b8-b5b9-3d682610e9fe', 'new': True}, 'co2': {'uuid': '1b4603e6-cac2-458c-b47e-e441864b29eb', 'new': True}},
-    'tac.picarro.hourly.100m.dat': {'ch4': {'uuid': '2e5935cc-07e3-4c0f-bd7c-8c6e4e2b13b7', 'new': True}, 'co2': {'uuid': '64c020b8-35dd-483f-b38c-99de83ea412d', 'new': True}},
-    'tac.picarro.hourly.185m.dat': {'ch4': {'uuid': '13172db7-7859-4f38-90cf-219c1fbe3b99', 'new': True}, 'co2': {'uuid': 'c79a3473-9f50-47d8-83d8-66a62fd085f7', 'new': True}}}}
-
+    decc_results
 
 This extracts the data and metadata from the files,
 standardises them, and adds them to our object store. The keywords of ``site`` and ``network``,
@@ -165,7 +159,7 @@ created when we run ``openghg --quickstart``.
 
     from openghg.standardise import standardise_surface
 
-    decc_results = standardise_surface(filepaths=tac_data, source_format="CRDS", site="TAC", network="DECC", store="user")
+    decc_results = standardise_surface(filepath=tac_data, source_format="CRDS", site="TAC", network="DECC", store="user")
 
 The ``store`` argument can be passed to any of the ``standardise`` functions in OpenGHG and is required if you have write access
 to more than one store.
@@ -251,12 +245,7 @@ species and instrument and do not need an accompanying precisions file. These ca
 The data will be processed in the same way as the old AGAGE data, and stored in the object store accordingly. 
 Ensure that the ``source_format`` argument matches the input filetype, as the two are not compatible. 
 
-
 .. _note-on-datasources:
-
-
-
-
 
 Note on Datasources
 ^^^^^^^^^^^^^^^^^^^

--- a/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
+++ b/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
@@ -201,7 +201,7 @@ We put the data file and precisions file into a tuple:
 We can add these files to the object store in the same way as the DECC
 data by including the right arguments:
 
-* ``filepaths``: tuple (or list of tuples) with paths to data and precision files
+* ``filepath``: tuple (or list of tuples) with paths to data and precision files
 * ``site`` (site code): ``"CGO"``
 * ``network``: ``"AGAGE"``
 * ``instrument``: ``"medusa"``
@@ -209,7 +209,7 @@ data by including the right arguments:
 
 .. code:: ipython3
 
-    agage_results = standardise_surface(filepaths=capegrim_tuple, source_format="GCWERKS", site="CGO",
+    agage_results = standardise_surface(filepath=capegrim_tuple, source_format="GCWERKS", site="CGO",
                                   network="AGAGE", instrument="medusa")
 
 When viewing ``agage_results`` there will be a large number of


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The standardise_surface calls within the documentation are currently using `filepaths` but this was changed in favour of `filepath` in a previous update. This PR is to correct this for the Add_observation_data tutorial.

* **Please check if the PR fulfills these requirements**

- [x] [Tests passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added