### PR TITLE
Adding example of info_metadata to "Adding observation data" tutorial

### DIFF
--- a/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
+++ b/doc/source/tutorials/local/Adding_data/Adding_observation_data.rst
@@ -281,6 +281,23 @@ a previous step of the tutorial - see "Updating existing data" tutorial for more
 As will be covered in the :ref:`2. Searching for data` section, these keywords can then used when searching the
 object store. For the `tag` keyword this can be used to return all data which includes the chosen tag.
 
+Adding informational keys
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Informational keys and associated values can also be added using the `info_metadata` input. The most
+common example for this would be to add a `comment` input. For example:
+
+.. code:: ipython3
+
+    decc_results = standardise_surface(filepath=tac_data,
+                                       source_format="CRDS",
+                                       site="TAC",
+                                       network="DECC",
+                                       info_metadata={"comment": "Automatic quality checks have been applied."})
+
+Note that for both `info_metadata` and `tag` that these options are available for all data types (not just
+observations).
+
 Multiple stores
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Adding tutorial details for using `info_metadata` to showcase how to add a comment using `standardise_*`

This can also fulfill the requirement to allow a comment to be added.

* **Please check if the PR fulfills these requirements**

- [x] Closes #982 
- [x] Closes #1068
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added

Not needed
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
