### PR TITLE
Ability to pass in path instead of only name to multi_store

### DIFF
--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -64,7 +64,9 @@ def get_writable_buckets() -> dict[str, str]:
     }
 
 
-def get_writable_bucket(name: str | None = None, store_path: str | None = None) -> str:
+def get_writable_bucket(
+    name: str | None = None, store_name: str | None = None, store_path: str | None = None
+) -> str:
     """Get the path to a writable bucket, passing in the name of a bucket if
     more than one writable bucket available.
 
@@ -77,6 +79,7 @@ def get_writable_bucket(name: str | None = None, store_path: str | None = None) 
         return str(get_tutorial_store_path())
 
     writable_buckets = get_writable_buckets()
+    name = store_name
 
     if not writable_buckets:
         raise ObjectStoreError("No writable object stores found. Check configuration file.")

--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -94,8 +94,8 @@ def get_writable_bucket(name: str | None = None, store_path: str | None = None) 
     # If store_path is specified, try to match it to a writable store
     elif store_path is not None:
         for bucket_name, bucket_info in writable_buckets.items():
-            if bucket_info.get("permissions") == "rw" and bucket_info.get("path") == store_path:
-                return bucket_info["path"]
+            if bucket_info == store_path:
+                return bucket_info
         raise ObjectStoreError(
             f"No writable store matches the given path '{store_path}', stores you can write to are: {', '.join(writable_buckets)}"
         )

--- a/openghg/objectstore/_local_store.py
+++ b/openghg/objectstore/_local_store.py
@@ -96,13 +96,9 @@ def get_writable_bucket(name: str | None = None, store_path: str | None = None) 
         for bucket_name, bucket_info in writable_buckets.items():
             if bucket_info.get("permissions") == "rw" and bucket_info.get("path") == store_path:
                 return bucket_info["path"]
-        raise ObjectStoreError(f"No writable store matches the given path '{store_path}'.")
-
-    # If neither name nor store_path is provided
-    writable_only = {name: info for name, info in writable_buckets.items() if info.get("permissions") == "rw"}
-
-    if len(writable_only) == 1:
-        return next(iter(writable_only.values()))["path"]
+        raise ObjectStoreError(
+            f"No writable store matches the given path '{store_path}', stores you can write to are: {', '.join(writable_buckets)}"
+        )
     else:
         raise ObjectStoreError(
             f"More than one writable store, stores you can write to are: {', '.join(writable_buckets)}."

--- a/openghg/standardise/_standardise.py
+++ b/openghg/standardise/_standardise.py
@@ -13,7 +13,11 @@ logger = logging.getLogger("openghg.standardise")
 
 
 def standardise(
-    data_type: str, filepath: multiPathType, store: str | None = None, **kwargs: Any
+    data_type: str,
+    filepath: multiPathType,
+    store_name: str | None = None,
+    store_path: str | None = None,
+    **kwargs: Any,
 ) -> list[dict]:
     """Generic standardise function, used by data-type specific versions.
 
@@ -29,7 +33,12 @@ def standardise(
     from openghg.store import get_data_class
 
     dclass = get_data_class(data_type)
-    bucket = get_writable_bucket(name=store)
+    if store_name is not None:
+        bucket = get_writable_bucket(store_name=store_name)
+    elif store_path is not None:
+        bucket = get_writable_bucket(store_path=store_path)
+    else:
+        bucket = get_writable_bucket()
 
     compression = kwargs.get("compression", True)
     compressor = kwargs.get("compressor")
@@ -71,7 +80,8 @@ def standardise_surface(
     verify_site_code: bool = True,
     site_filepath: str | Path | None = None,
     tag: str | list | None = None,
-    store: str | None = None,
+    store_name: str | None = None,
+    store_path: str | None = None,
     update_mismatch: str = "never",
     if_exists: str = "auto",
     save_current: str = "auto",
@@ -160,7 +170,8 @@ def standardise_surface(
             filepath = sort_by_filenames(filepath=filepath)
 
     return standardise(
-        store=store,
+        store_name=store_name,
+        store_path=store_path,
         data_type="surface",
         filepath=filepath,
         source_format=source_format,
@@ -205,7 +216,8 @@ def standardise_column(
     instrument: str | None = None,
     source_format: str = "openghg",
     tag: str | list | None = None,
-    store: str | None = None,
+    store_name: str | None = None,
+    store_path: str | None = None,
     if_exists: str = "auto",
     save_current: str = "auto",
     overwrite: bool = False,
@@ -264,7 +276,8 @@ def standardise_column(
     """
     filepath = Path(filepath)
     return standardise(
-        store=store,
+        store_name=store_name,
+        store_path=store_path,
         data_type="column",
         filepath=filepath,
         species=species,
@@ -299,7 +312,8 @@ def standardise_bc(
     period: str | tuple | None = None,
     continuous: bool = True,
     tag: str | list | None = None,
-    store: str | None = None,
+    store_name: str | None = None,
+    store_path: str | None = None,
     if_exists: str = "auto",
     save_current: str = "auto",
     overwrite: bool = False,
@@ -353,7 +367,8 @@ def standardise_bc(
     """
     filepath = Path(filepath)
     return standardise(
-        store=store,
+        store_name=store_name,
+        store_path=store_path,
         data_type="boundary_conditions",
         filepath=filepath,
         species=species,
@@ -394,7 +409,8 @@ def standardise_footprint(
     continuous: bool = True,
     retrieve_met: bool = False,
     tag: str | list | None = None,
-    store: str | None = None,
+    store_name: str | None = None,
+    store_path: str | None = None,
     if_exists: str = "auto",
     save_current: str = "auto",
     overwrite: bool = False,
@@ -483,7 +499,8 @@ def standardise_footprint(
         filepath = sort_by_filenames(filepath=filepath)
 
     return standardise(
-        store=store,
+        store_name=store_name,
+        store_path=store_path,
         data_type="footprints",
         filepath=filepath,
         site=site,
@@ -534,7 +551,8 @@ def standardise_flux(
     chunks: dict | None = None,
     continuous: bool = True,
     tag: str | list | None = None,
-    store: str | None = None,
+    store_name: str | None = None,
+    store_path: str | None = None,
     if_exists: str = "auto",
     save_current: str = "auto",
     overwrite: bool = False,
@@ -597,7 +615,8 @@ def standardise_flux(
         time_resolved = high_time_resolution
     return standardise(
         data_type="flux",
-        store=store,
+        store_name=store_name,
+        store_path=store_path,
         filepath=filepath,
         species=species,
         source=source,
@@ -633,7 +652,8 @@ def standardise_eulerian(
     if_exists: str = "auto",
     save_current: str = "auto",
     overwrite: bool = False,
-    store: str | None = None,
+    store_name: str | None = None,
+    store_path: str | None = None,
     force: bool = False,
     compression: bool = True,
     compressor: Any | None = None,
@@ -682,7 +702,8 @@ def standardise_eulerian(
         dict: Dictionary of result data
     """
     return standardise(
-        store=store,
+        store_name=store_name,
+        store_path=store_path,
         data_type="eulerian_model",
         filepath=filepath,
         source_format=source_format,
@@ -705,11 +726,12 @@ def standardise_eulerian(
 
 
 def standardise_from_binary_data(
-    store: str,
     data_type: str,
     binary_data: bytes,
     metadata: dict,
     file_metadata: dict,
+    store_name: str | None = None,
+    store_path: str | None = None,
     **kwargs: Any,
 ) -> list[dict] | None:
     """Standardise binary data from serverless function.
@@ -730,7 +752,10 @@ def standardise_from_binary_data(
     from openghg.store import get_data_class
 
     dclass = get_data_class(data_type)
-    bucket = get_writable_bucket(name=store)
+    bucket = get_writable_bucket(
+        store_name=store_name,
+        store_path=store_path,
+    )
 
     with dclass(bucket) as dc:
         result = dc.read_data(
@@ -750,7 +775,8 @@ def standardise_flux_timeseries(
     database_version: str | None = None,
     model: str | None = None,
     tag: str | list | None = None,
-    store: str | None = None,
+    store_name: str | None = None,
+    store_path: str | None = None,
     if_exists: str = "auto",
     save_current: str = "auto",
     overwrite: bool = False,
@@ -815,7 +841,8 @@ def standardise_flux_timeseries(
         region = domain
     return standardise(
         data_type="flux_timeseries",
-        store=store,
+        store_name=store_name,
+        store_path=store_path,
         filepath=filepath,
         species=species,
         source=source,

--- a/openghg/store/_populate.py
+++ b/openghg/store/_populate.py
@@ -98,7 +98,7 @@ def add_noaa_obspack(
             try:
                 # TODO - can we streamline this a bit to save repeated loads?
                 processed = standardise_surface(
-                    store=store,
+                    store_name=store,
                     filepath=filepath,
                     site=site,
                     measurement_type=measurement_type,

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -291,7 +291,7 @@ def test_standardise_column():
         obs_region=obs_region,
         selection=selection,
         force=True,
-        store="/tmp/openghg_testing-STORE_123",
+        store_path="/tmp/openghg_testing-STORE_123",
     )
 
     assert "ch4" == results[0].get("species")

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -291,7 +291,7 @@ def test_standardise_column():
         obs_region=obs_region,
         selection=selection,
         force=True,
-        store="user",
+        store="/tmp/openghg_testing-STORE_123",
     )
 
     assert "ch4" == results[0].get("species")


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Added the ability to generate config details directly based on the path. If a name is not provided, the folder name from the supplied path is picked as the store name. 

In-progress:
Adding the util function that handles the store parameter passed to standardised/get_* function

* **Please check if the PR fulfills these requirements**

- [ ] Closes #900 (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
