### PR TITLE
included openghg_calscales in environment.yaml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,4 @@
-name: openghg_env
+name: openghg_env_dummy
 channels:
   - openghg
   - conda-forge
@@ -39,6 +39,6 @@ dependencies:
   - numcodecs
   - sympy
   - networkx
+  - openghg_calscales
   - pip:
     - icoscp<=0.1.17
-    - openghg-calscales


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
openghg_calscales was missing from environemnt.yaml and was installed through pip which was not picked from meta.yaml build on the github runner.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
