### PR TITLE
Update the ObsSurface read_file function to use the `check_hashes` and `store_hashes` methods

### DIFF
--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
 from pathlib import Path
-from typing import Any, MutableSequence, cast
+from typing import Any, MutableSequence
 from collections.abc import Sequence
 
 import numpy as np
@@ -220,7 +220,6 @@ class ObsSurface(BaseStore):
             format_platform,
             evaluate_sampling_period,
             check_and_set_null_variable,
-            hash_file,
             load_standardise_parser,
             verify_site,
             check_if_need_new_version,

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -646,19 +646,6 @@ class ObsSurface(BaseStore):
 
         return datasource_uuids
 
-    def store_hashes(self, hashes: dict) -> None:
-        """Store hashes of data retrieved from a remote data source such as
-        ICOS or CEDA. This takes the full dictionary of hashes, removes the ones we've
-        seen before and adds the new.
-
-        Args:
-            hashes: Dictionary of hashes provided by the hash_retrieved_data function
-        Returns:
-            None
-        """
-        new = {k: v for k, v in hashes.items() if k not in self._retrieved_hashes}
-        self._retrieved_hashes.update(new)
-
     def delete(self, uuid: str) -> None:
         """Delete a Datasource with the given UUID
 

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -311,49 +311,51 @@ class ObsSurface(BaseStore):
             chunks = {}
 
         if not isinstance(filepath, list):
-            filepaths = [filepath]
+            filepaths_to_check = [filepath]
         else:
-            filepaths = filepath
+            filepaths_to_check = filepath
+
+        filepaths: list[Path] = []
+        precision_filepaths: list[Path] = []
+        for fp in filepaths_to_check:
+            if isinstance(fp, tuple):
+                if source_format.lower() != "gcwerks":
+                    raise TypeError(
+                        f"Only expect tuple of (data file, precision file) for GCWERKS input. This source_format = {source_format}"
+                    )
+                filepaths.append(Path(fp[0]))
+                precision_filepaths.append(Path(fp[1]))
+            else:
+                if source_format.lower() == "gcwerks":
+                    raise TypeError("For GCWERKS data we expect a tuple of (data file, precision file).")
+                filepaths.append(Path(fp))
+
+        # Check hashes of previous files (included after any filepath(s) formatting)
+        _, unseen_hashes = self.check_hashes(filepaths=filepaths, force=force)
+
+        if not unseen_hashes:
+            return [{}]
+
+        filepaths = list(unseen_hashes.values())
+
+        if not filepaths:
+            return [{}]
 
         # Get current parameter values and filter to only include function inputs
         current_parameters = locals().copy()
         fn_input_parameters = {key: current_parameters[key] for key in fn_input_parameters}
 
         # Create a progress bar object using the filepaths, iterate over this below
-        for fp in filepaths:
-            if source_format == "GCWERKS":
-                if isinstance(fp, tuple):
-                    filepath = Path(fp[0])
-                    precision_filepath = Path(fp[1])
-                else:
-                    raise TypeError("For GCWERKS data we expect a tuple of (data file, precision file).")
-            else:
-                filepath = fp
-
-            # Cast so it's clear we no longer expect a tuple
-            filepath = cast(pathType, filepath)
-            filepath = Path(filepath)
+        for i, filepath in enumerate(filepaths):
 
             fn_input_parameters["filepath"] = filepath
+            if precision_filepaths:
+                fn_input_parameters["precision_filepath"] = precision_filepaths[i]
 
             # Define parameters to pass to the parser function and remaining keys
             parser_input_parameters, additional_input_parameters = split_function_inputs(
                 fn_input_parameters, parser_fn
             )
-
-            # This hasn't been updated to use the new check_hashes function due to
-            # the added complication of the GCWERKS precision file handling,
-            # so we'll just use the old method for now.
-            file_hash = hash_file(filepath=filepath)
-            if file_hash in self._file_hashes and overwrite is False and force is False:
-                logger.warning(
-                    "This file has been uploaded previously with the filename : "
-                    f"{self._file_hashes[file_hash]} - skipping."
-                )
-                continue
-
-            if source_format == "GCWERKS":
-                parser_input_parameters["precision_filepath"] = precision_filepath
 
             # Call appropriate standardisation function with input parameters
             data: list[MetadataAndData] = parser_fn(**parser_input_parameters)
@@ -411,7 +413,7 @@ class ObsSurface(BaseStore):
 
             logger.info(f"Completed processing: {filepath.name}.")
 
-            self._file_hashes[file_hash] = filepath.name
+        self.store_hashes(unseen_hashes)
 
         return results
 

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -841,7 +841,7 @@ def test_check_obssurface_same_file_skips():
         store="user", filepath=filepath, source_format="CRDS", site="bsd", network="DECC"
     )
 
-    assert not results
+    assert not results[0]
 
 
 def test_check_obssurface_multi_file_same_skip():
@@ -888,7 +888,7 @@ def test_check_obssurface_multi_file_same_skip():
         update_mismatch="metadata",
     )
 
-    assert not results
+    assert not results[0]
 
 
 def test_gcwerks_fp_not_a_tuple_raises():


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

All the data type classes in `openghg.store` use the `check_hashes` and `store_hashes` methods on `BaseStore` except the `ObsSurface` class.

This PR updates the `ObsSurface` class to use these functions. To facilitate this an additional check for a particular source_format (GCWERKS) which looks for tuples of filepaths were rearranged so the filepaths had been extracted by the point the `*hashes` functions were called. A previous, but unusued `store_hashes` method on `ObsSurface` was also removed.

This feeds into #1252 where we're trying to split out the overlapping steps between the different data type classes so this code can be factored out to make this more easy to update going forward.

* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

Not needed
- Documentation and tutorials updated/added - internal change
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature - internal change
- Closes #xxxx (Replace xxxx with the Github issue number)
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
