### PR TITLE
Use BaseStore registry to get data types and data type classes

### DIFF
--- a/openghg/store/spec/_specification.py
+++ b/openghg/store/spec/_specification.py
@@ -18,50 +18,16 @@ __all__ = [
 ]
 
 
-def define_data_types() -> tuple[str, ...]:
-    """
-    Define names of data types for objects within OpenGHG
-    """
-
-    data_types = (
-        "surface",
-        "column",
-        "flux",
-        "footprints",
-        "boundary_conditions",
-        "eulerian_model",
-        "flux_timeseries",
-    )
-
-    return data_types
-
-
 def define_data_type_classes() -> dict[str, Any]:
-    """
-    Define mapping between data types and associated input classes within OpenGHG
-    """
-    from openghg.store import (
-        BoundaryConditions,
-        Flux,
-        EulerianModel,
-        Footprints,
-        ObsColumn,
-        ObsSurface,
-        FluxTimeseries,
-    )
+    """Define mapping between data types and associated input classes within OpenGHG."""
+    from openghg.store.base import BaseStore
 
-    data_type_classes = {
-        "surface": ObsSurface,
-        "column": ObsColumn,
-        "flux": Flux,
-        # "met": ???
-        "footprints": Footprints,
-        "boundary_conditions": BoundaryConditions,
-        "eulerian_model": EulerianModel,
-        "flux_timeseries": FluxTimeseries,
-    }
+    return BaseStore._registry.copy()
 
-    return data_type_classes
+
+def define_data_types() -> tuple[str, ...]:
+    """Define names of data types for objects within OpenGHG."""
+    return tuple(define_data_type_classes().keys())
 
 
 def define_standardise_parsers() -> dict[str, Any]:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Updated `define_data_type_classes` to return the subclass registry from `BaseStore`.

Then `define_data_types` just returns a tuple of keys from the data type classes dictionary.


* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
