### PR TITLE
Removing data_type from flux parse_* functions

### DIFF
--- a/openghg/standardise/flux/_intem.py
+++ b/openghg/standardise/flux/_intem.py
@@ -9,7 +9,6 @@ def parse_intem(
     species: str,
     source: str,
     chunks: dict,
-    data_type: str = "emissions",
     domain: str = "europe",
     model: str = "intem",
     period: str | tuple | None = None,
@@ -28,7 +27,6 @@ def parse_intem(
             for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
             See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
             To disable chunking pass in an empty dictionary.
-        data_type: Type of data, default is 'emissions'.
         domain: Geographic domain, default is 'europe'.
         model: Model name if applicable.
         period: The time period for which data is to be parsed.
@@ -78,7 +76,6 @@ def parse_intem(
 
     metadata["author"] = author_name
     metadata["processed"] = str(timestamp_now())
-    metadata["data_type"] = data_type
     metadata["source_format"] = "openghg"
     metadata["time_resolution"] = "high" if time_resolved else "standard"
     dataset_time = emissions_dataset["time"]

--- a/openghg/standardise/flux/_openghg.py
+++ b/openghg/standardise/flux/_openghg.py
@@ -9,7 +9,6 @@ def parse_openghg(
     species: str,
     source: str,
     domain: str,
-    data_type: str,
     database: str | None = None,
     database_version: str | None = None,
     model: str | None = None,
@@ -27,7 +26,6 @@ def parse_openghg(
         species: Name of species
         source: Source of the emissions data
         domain: Geographic domain
-        data_type: Type of data
         database: Name of the database
         database_version: Version of the database
         model: Model name if applicable.
@@ -83,9 +81,7 @@ def parse_openghg(
             metadata[key] = value
 
     metadata["author"] = author_name
-    metadata["data_type"] = data_type
     metadata["processed"] = str(timestamp_now())
-    metadata["data_type"] = "flux"
     metadata["source_format"] = "openghg"
 
     # As flux / emissions files handle things slightly differently we need to check the time values


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

At the moment, `data_type` is a required input to the `parse_openghg` function and an optional input for `parse_intem` for the `Flux` data_type class and adds this to be metadata. This is currently inconsistent with the other data_type standardise functions which don't do this.

If we wanted to include this in general we could add to the metadata in the base class or in the data_type classes.

* **Please check if the PR fulfills these requirements**

- [ ] Feeds into #1252 (but does not close this)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
