### PR TITLE
User specific tmp path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.15.0...HEAD)
 
 ### Updated
-- Updated temporary path creation to have user specific folder.[PR #]()
+- Updated temporary path creation to have user specific folder.[PR #1396](https://github.com/openghg/openghg/pull/1396)
+
 ## [0.15.0] - 2025-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.15.0...HEAD)
 
+### Updated
+- Updated temporary path creation to have user specific folder.[PR #]()
 ## [0.15.0] - 2025-07-02
 
 ### Added

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -1,5 +1,5 @@
 """Some helper functions for things we do in tests frequently"""
-
+import getpass
 import shutil
 import tempfile
 from pathlib import Path
@@ -9,12 +9,15 @@ from typing import Dict, List, Union
 def temporary_store_paths() -> Dict[str, Path]:
     # Add some uppercasing and numbers here to enusure paths work
     # with other characters - see https://github.com/openghg/openghg/issues/701
-    return {
-        "user": Path(tempfile.gettempdir(), "openghg_testing-STORE_123"),
-        "group": Path(tempfile.gettempdir(), "openghg_testing_group_store"),
-        "shared": Path(tempfile.gettempdir(), "openghg_testing_shared_store"),
-    }
+    user = getpass.getuser()  # get current system user
 
+    base_tmp = Path(tempfile.gettempdir()) / f"openghg-testing-{user}"
+
+    return {
+        "user": base_tmp / f"openghg_testing-STORE_123",
+        "group": base_tmp / f"openghg_testing_group_store",
+        "shared": base_tmp / f"openghg_testing_shared_store",
+    }
 
 def clear_test_store(name: str) -> None:
     """Clear one of the testing object stores


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Added user-based directory in tempfile creation in tests to avoid permission denied error on bluepebble.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1395  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
