### PR TITLE
Paris footprint chunking bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.15.0...HEAD)
 
 ### Updated
-- Updated temporary path creation to have user specific folder.[PR #1396](https://github.com/openghg/openghg/pull/1396)
+- Updated temporary path creation to have user specific folder. [PR #1396](https://github.com/openghg/openghg/pull/1396)
+
+### Fixed
+- Bug with chunking when standardising PARIS and FLEXPART CO2 footprints. [PR #1399](https://github.com/openghg/openghg/pull/1399)
 
 ## [0.15.0] - 2025-07-02
 

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -393,6 +393,7 @@ class Footprints(BaseStore):
             high_spatial_resolution=high_spatial_resolution,
             time_resolved=time_resolved,
             short_lifetime=short_lifetime,
+            source_format=source_format,
         )
         if chunks:
             logger.info(f"Rechunking with chunks={chunks}")
@@ -611,6 +612,7 @@ class Footprints(BaseStore):
             high_spatial_resolution=high_spatial_resolution,
             time_resolved=time_resolved,
             short_lifetime=short_lifetime,
+            source_format=source_format,
         )
         data_schema.validate_data(data)
 
@@ -620,6 +622,7 @@ class Footprints(BaseStore):
         high_time_resolution: bool = False,
         high_spatial_resolution: bool = False,
         short_lifetime: bool = False,
+        source_format: str = "",
     ) -> ChunkingSchema:
         """
         Get chunking schema for footprint data.
@@ -647,7 +650,7 @@ class Footprints(BaseStore):
             )
             time_resolved = high_time_resolution
         if time_resolved:
-            var = "fp_HiTRes"
+            var = "fp_HiTRes" if source_format.upper() not in ("PARIS", "FLEXPART") else "fp_time_resolved"
             time_chunk_size = 24
             secondary_vars = ["lat", "lon", "H_back"]
         else:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Fixed a bug when processing PARIS and FLEXPART CO2 footprints: the "chunking schema" was still using `fp_HiTRes` instead of `fp_time_resolved`. Added a test to catch the error, then fixed the error.

* **Please check if the PR fulfills these requirements**

- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
