### PR TITLE
Remove unused code from Datasource and LocalZarrStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 - Updated temporary path creation to have user specific folder. [PR #1396](https://github.com/openghg/openghg/pull/1396)
+- Removed unused code from Datasource and LocalZarrStore and changed the name of LocalZarrStore's `update` method to `overwrite`. See the PR for full details of code removed.[PR #1404](https://github.com/openghg/openghg/pull/1404)
 
 ### Fixed
 - Bug with chunking when standardising PARIS and FLEXPART CO2 footprints. [PR #1399](https://github.com/openghg/openghg/pull/1399)

--- a/openghg/objectstore/_legacy_datasource.py
+++ b/openghg/objectstore/_legacy_datasource.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from collections import defaultdict
-from typing import Any, cast, Literal, TypeVar
+from typing import Any, cast, Literal
 from typing_extensions import Self
 from types import TracebackType
 import logging
@@ -19,12 +19,12 @@ logger.setLevel(logging.DEBUG)
 
 __all___ = ["Datasource"]
 
-T = TypeVar("T", bound="Datasource")
-
 
 class Datasource(AbstractDatasource[xr.Dataset]):
-    """A Datasource holds data relating to a single source, such as a specific species
-    at a certain height on a specific instrument
+    """A Datasource holds data relating to a single source.
+
+    For instance, a specific species at a certain height on a specific
+    instrument could be a single "Datasource".
     """
 
     _datasource_root = "datasource"
@@ -256,7 +256,9 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             if new_version:
                 self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
             else:
-                self._store.overwrite(version=version_str, dataset=data, compressor=compressor, filters=filters)
+                self._store.overwrite(
+                    version=version_str, dataset=data, compressor=compressor, filters=filters
+                )
             # Only save the current daterange string for this version
             date_keys = [new_daterange_str]
         elif if_exists == "combine":

--- a/openghg/objectstore/_legacy_datasource.py
+++ b/openghg/objectstore/_legacy_datasource.py
@@ -256,7 +256,7 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             if new_version:
                 self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
             else:
-                self._store.update(version=version_str, dataset=data, compressor=compressor, filters=filters)
+                self._store.overwrite(version=version_str, dataset=data, compressor=compressor, filters=filters)
             # Only save the current daterange string for this version
             date_keys = [new_daterange_str]
         elif if_exists == "combine":

--- a/openghg/objectstore/_legacy_datasource.py
+++ b/openghg/objectstore/_legacy_datasource.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 from collections import defaultdict
-import warnings
 from typing import Any, cast, Literal, TypeVar
 from typing_extensions import Self
 from types import TracebackType
 import logging
-from pandas import DataFrame, Timestamp, Timedelta
+from pandas import Timestamp, Timedelta
 import xarray as xr
-import numpy as np
+
 from openghg.objectstore import exists, get_object_from_json
 from openghg.objectstore._local_store import delete_object
 from openghg.util import split_daterange_str, timestamp_tzaware
@@ -206,7 +205,6 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             None
         """
         from openghg.util import daterange_overlap, timestamp_now
-        from xarray import concat as xr_concat
 
         # Extract period associated with data from metadata
         # TODO: May want to add period as a potential data variable so would need to extract from there if needed
@@ -219,11 +217,7 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         if self._latest_version and not new_version:
             version_str = self._latest_version
         else:
-            version_str = f"v{str(len(self._data_keys) + 1)}"
-
-        # Ensure daterange strings are independent and do not overlap each other
-        # (this can occur due to representative date strings)
-        # new_data = self._clip_daterange_label(new_data)
+            version_str = f"v{len(self._data_keys) + 1!s}"
 
         # Save details of current Datasource status
         self._status = {}
@@ -247,106 +241,33 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         ]
 
         # We'll only need to sort the new dataset if the data we add comes before the current data
-        # already_sorted = True
 
         # If we don't have any data in this Datasource or we have no overlap we'll just add the new data
         if not self._store or not overlapping:
             self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
             date_keys.append(new_daterange_str)
-
-            # if sorted(date_keys) != date_keys:
-            #     already_sorted = False
         # Otherwise if we have data already stored in the Datasource
-        else:
+        elif if_exists == "new":
             # If we have existing data we'll just keep the new data
             # If new_version is True then we create a new version containing just this data
             # If new_version is False then we delete the current data and replace it with just the new data
-            if if_exists == "new":
-                logger.info("Updating store to include new added data only.")
+            logger.info("Updating store to include new added data only.")
 
-                if new_version:
-                    self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
-                else:
-                    self._store.update(
-                        version=version_str, dataset=data, compressor=compressor, filters=filters
-                    )
-                # Only save the current daterange string for this version
-                date_keys = [new_daterange_str]
-            elif if_exists == "combine":
-                raise NotImplementedError("Combining data not yet implemented.")
-                # We'll copy the data into a temporary store and then combine the data
-                memory_store = self._store._copy_to_memorystore(version=self._latest_version)
-                existing = xr.open_zarr(store=memory_store, consolidated=True)
-
-                logger.info("Combining overlapping data dateranges")
-                # Concatenate datasets along time dimension
-                try:
-                    combined = xr_concat((existing, data), dim=time_coord)
-                except (ValueError, KeyError):
-                    # If data variables in the two datasets are not identical,
-                    # xr_concat will raise an error
-                    dv_ex = set(existing.data_vars.keys())
-                    dv_new = set(data.data_vars.keys())
-
-                    # Check difference between datasets and fill any
-                    # missing variables with NaN values.
-                    dv_not_in_new = dv_ex - dv_new
-                    for dv in dv_not_in_new:
-                        fill_values = np.zeros(len(data[time_coord])) * np.nan
-                        data = data.assign({dv: (time_coord, fill_values)})
-
-                    dv_not_in_ex = dv_new - dv_ex
-                    for dv in dv_not_in_ex:
-                        fill_values = np.zeros(len(existing[time_coord])) * np.nan
-                        existing = existing.assign({dv: (time_coord, fill_values)})
-
-                    # Should now be able to concatenate successfully
-                    combined = xr_concat((existing, data), dim=time_coord)
-
-                # TODO: May need to find a way to find period for *last point* rather than *current point*
-                # combined_daterange = self.get_dataset_daterange_str(dataset=combined)
-                combined_daterange = self.get_representative_daterange_str(dataset=combined, period=period)
-
-                # logger.warning(
-                #     f"Dropping duplicates and rechunking data with time chunks of size {time_chunksize} and sorting."
-                # )
-
-                if data_type == "footprints":
-                    logger.warning("Sorting footprints by time may consume large amounts of memory.")
-
-                logger.debug(
-                    "Dropping duplicates, rechunking data and sorting by time variable in add_timed_data."
-                )
-
-                combined = (
-                    combined.drop_duplicates(dim=time_coord, keep="first")
-                    # .chunk({"time": time_chunksize})
-                    .sortby(time_coord)
-                )
-
-                if new_version:
-                    self._store.add(
-                        version=version_str,
-                        dataset=combined,
-                        compressor=compressor,
-                        filters=filters,
-                    )
-                else:
-                    self._store.update(
-                        version=version_str,
-                        dataset=combined,
-                        compressor=compressor,
-                        filters=filters,
-                    )
-
-                date_keys = [combined_daterange]
-            # If we don't know what (i.e. we've got "auto") to do we'll raise an error
+            if new_version:
+                self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
             else:
-                date_chunk_str = f"Current: {date_keys}; new: {overlapping}\n"
-                raise DataOverlapError(
-                    f"Unable to add new data. Time overlaps with current data:\n{date_chunk_str}"
-                    f"To update current data in object store use `if_exists` input (see options in documentation)"
-                )
+                self._store.update(version=version_str, dataset=data, compressor=compressor, filters=filters)
+            # Only save the current daterange string for this version
+            date_keys = [new_daterange_str]
+        elif if_exists == "combine":
+            raise NotImplementedError("Combining data not yet implemented.")
+        # If we don't know what (i.e. we've got "auto") to do we'll raise an error
+        else:
+            date_chunk_str = f"Current: {date_keys}; new: {overlapping}\n"
+            raise DataOverlapError(
+                f"Unable to add new data. Time overlaps with current data:\n{date_chunk_str}"
+                f"To update current data in object store use `if_exists` input (see options in documentation)"
+            )
 
         self._data_type = data_type
         self.add_metadata_key(key="data_type", value=data_type)
@@ -419,6 +340,7 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             metadata: Dictionary of metadata
             skip_keys: Keys to not standardise as lowercase
             extend_keys: Keys to add in addition to current keys (extend a list) if present.
+
         Returns:
             None
         """
@@ -437,9 +359,6 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         lowercased: dict = to_lowercase(metadata, skip_keys=skip_keys)
         metadata_to_add = {key: value for key, value in lowercased.items() if key not in extend_keys}
 
-        # # Add keys - overwriting any existing values
-        # self._metadata.update(metadata_to_add)
-
         merged_metadata = merge_dict(
             self._metadata, metadata_to_add, on_overlap="ignore", on_conflict="right"
         )
@@ -456,27 +375,6 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         merged_and_extended_metadata = merge_and_extend_dict(merged_metadata, metadata_extend)
 
         self._metadata = merged_and_extended_metadata
-
-    def get_dataframe_daterange(self, dataframe: DataFrame) -> tuple[Timestamp, Timestamp]:
-        """Returns the daterange for the passed DataFrame
-
-        Args:
-            dataframe: DataFrame to parse
-        Returns:
-            tuple (Timestamp, Timestamp): Start and end Timestamps for data
-        """
-        from openghg.util import timestamp_tzaware
-        from pandas import DatetimeIndex
-
-        warnings.warn("This function is deprecated any may be removed", DeprecationWarning)
-        if not isinstance(dataframe.index, DatetimeIndex):
-            raise TypeError("Only DataFrames with a DatetimeIndex must be passed")
-
-        # Here we want to make the pandas Timestamps timezone aware
-        start = timestamp_tzaware(dataframe.first_valid_index())
-        end = timestamp_tzaware(dataframe.last_valid_index())
-
-        return start, end
 
     def get_dataset_daterange(self, dataset: xr.Dataset) -> tuple[Timestamp, Timestamp]:
         """Get the daterange for the passed Dataset
@@ -497,20 +395,8 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         except AttributeError:
             raise AttributeError("This dataset does not have a time attribute, unable to read date range")
 
-    def get_dataset_daterange_str(self, dataset: xr.Dataset) -> str:
-        start, end = self.get_dataset_daterange(dataset=dataset)
-
-        # Tidy the string and concatenate them
-        start = str(start).replace(" ", "-")
-        end = str(end).replace(" ", "-")
-
-        daterange_str: str = start + "_" + end
-
-        return daterange_str
-
     def get_representative_daterange_str(self, dataset: xr.Dataset, period: str | None = None) -> str:
-        """
-        Get representative daterange which incorporates any period the data covers.
+        """Get representative daterange which incorporates any period the data covers.
 
         A representative daterange covers the start - end time + any additional period that is covered
         by each time point. The start and end times can be extracted from the input dataset and
@@ -548,65 +434,6 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         daterange_str = create_daterange_str(start=start_date, end=end_date)
 
         return daterange_str
-
-    def clip_daterange(self, end_date: Timestamp, start_date_next: Timestamp) -> Timestamp:
-        """
-        Clip any end_date greater than the next start date (start_date_next) to be
-        1 second less.
-        """
-        if end_date >= start_date_next:
-            end_date = start_date_next - Timedelta(seconds=1)
-
-        return end_date
-
-    def clip_daterange_from_str(self, daterange_str1: str, daterange_str2: str) -> str:
-        """
-        Ensure the end date of a daterange string is not greater than the start
-        date of the next daterange string. Update as needed.
-        """
-        from openghg.util import create_daterange_str
-
-        start_date_str, end_date_str = daterange_str1.split("_")
-        start_date_next_str, _ = daterange_str2.split("_")
-
-        start_date = Timestamp(start_date_str)
-        end_date = Timestamp(end_date_str)
-        start_date_next = Timestamp(start_date_next_str)
-
-        end_date = self.clip_daterange(end_date, start_date_next)
-
-        daterange_str1_clipped = create_daterange_str(start_date, end_date)
-
-        return daterange_str1_clipped
-
-    def _clip_daterange_label(self, labelled_datasets: dict[str, xr.Dataset]) -> dict[str, xr.Dataset]:
-        """
-        Check the daterange string labels for the datasets and ensure neighbouring
-        date ranges are not overlapping. The daterange string labels will be updated
-        as required.
-
-        Args:
-            labelled_datasets: Dictionary of datasets labelled by date range strings.
-                These are expected to be in time order.
-        Returns:
-            Dict : Same format as input with labels updated as necessary.
-        """
-
-        datestr_labels = list(labelled_datasets.keys())
-        num_data_groups = len(datestr_labels)
-
-        labelled_datasets_clipped = {}
-        for i in range(num_data_groups):
-            daterange_str_1 = datestr_labels[i]
-            if i < num_data_groups - 1:
-                daterange_str_2 = datestr_labels[i + 1]
-                daterange_str = self.clip_daterange_from_str(daterange_str_1, daterange_str_2)
-            else:
-                daterange_str = daterange_str_1
-            dataset = labelled_datasets[daterange_str_1]
-            labelled_datasets_clipped[daterange_str] = dataset
-
-        return labelled_datasets_clipped
 
     def get_period(self) -> str | None:
         """Extract period value from metadata. This expects keywords of either "sampling_period" (observation data) or
@@ -650,27 +477,6 @@ class Datasource(AbstractDatasource[xr.Dataset]):
 
         return period
 
-    @staticmethod
-    def load_dataset(bucket: str, key: str) -> xr.Dataset:
-        """Loads a xarray Dataset from the passed key for creation of a Datasource object
-
-        Data is lazy-loaded because we use `xarray.open_dataset`. This means that the
-        file handler for the data file remains open until the data is actually required.
-
-        This improves performance, since we often only update one or two chunks of the dataset
-        at a time.
-
-        Args:
-            bucket: Bucket containing data
-            key: Key for data
-        Returns:
-            xarray.Dataset: Dataset from NetCDF file
-        """
-
-        raise NotImplementedError(
-            "Loading of data directly from Datasource no longer supported. Use memory_store to access data stored in zarr store."
-        )
-
     def save(self) -> None:
         """Save this Datasource object as JSON to the object store
 
@@ -701,30 +507,6 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             str: Key for Datasource in object store
         """
         return f"{Datasource._datasource_root}/uuid/{self._uuid}"
-
-    def _copy_to_memorystore(self, version: str = "latest") -> dict:
-        """Copy the compressed data for a version from the zarr store into memory.
-        Most users should use get_data in place of this function as it offers a simpler
-        way of retrieving data.
-
-        Copying the compressed data into memory may be useful when exploring xarray and zarr
-        functionality.
-
-        Example:
-            memory_store = datasource._copy_to_memorystore(version="v1")
-            with xr.open_zarr(memory_store, consolidated=True) as ds:
-                ...
-
-        Returns:
-            Dict: In-memory copy of compressed data
-        """
-        if not self._data_keys:
-            return {}
-
-        if version == "latest":
-            version = self._latest_version
-
-        return self._store._copy_to_memorystore(version=version)
 
     def get_data(self, version: str = "latest") -> xr.Dataset:
         """Get the version of the dataset stored in the zarr store.
@@ -811,73 +593,6 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             start_a=start_date, end_a=end_date, start_b=self._start_date, end_b=self._end_date
         )
 
-    def keys_in_daterange(self, start_date: str | Timestamp, end_date: str | Timestamp) -> list[str]:
-        """Return the keys for data between the two passed dates
-
-        Args:
-            start_date: Start date
-            end_date: end date
-        Return:
-            list: List of keys to data
-        """
-        data_keys = self._data_keys[self._latest_version]
-
-        return self.key_date_compare(keys=data_keys, start_date=start_date, end_date=end_date)
-
-    def keys_in_daterange_str(self, daterange: str) -> list[str]:
-        """Return the keys for data within the specified daterange string
-
-        Args:
-            daterange: Daterange string of the form
-            2019-01-01T00:00:00_2019-12-31T00:00:00
-        Return:
-            list: List of keys to data
-        """
-        from openghg.util import timestamp_tzaware
-
-        split_daterange = daterange.split("_")
-
-        if len(split_daterange) > 2:
-            # raise DateError("")
-            raise TypeError("Invalid daterange string passed.")
-
-        start_date = timestamp_tzaware(split_daterange[0])
-        end_date = timestamp_tzaware(split_daterange[1])
-
-        data_keys = self._data_keys[self._latest_version]
-
-        return self.key_date_compare(keys=data_keys, start_date=start_date, end_date=end_date)
-
-    def key_date_compare(self, keys: list, start_date: Timestamp, end_date: Timestamp) -> list:
-        """Returns the keys in the key list that are between the given dates
-
-        Args:
-            keys: List of object store keys
-            start_date: Start date
-            end_date: End date
-        Returns:
-            list: List of keys
-        """
-        from openghg.util import timestamp_tzaware
-
-        in_date = []
-        for key in keys:
-            end_key = key.split("/")[-1]
-            dates = end_key.split("_")
-
-            if len(dates) > 2:
-                raise ValueError("Invalid date string")
-
-            start_key = timestamp_tzaware(dates[0])
-            end_key = timestamp_tzaware(dates[1])
-
-            # For this logic see
-            # https://stackoverflow.com/a/325964
-            if (start_key <= end_date) and (end_key >= start_date):
-                in_date.append(key)
-
-        return in_date
-
     def uuid(self) -> str:
         """Return the UUID of this object
 
@@ -901,14 +616,6 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             str: Data type held by Datasource
         """
         return self._data_type
-
-    def raw_keys(self) -> dict[str, list]:
-        """Returns the raw keys dictionary
-
-        Returns:
-            dict: Dictionary of keys
-        """
-        return self._data_keys
 
     def data_keys(self, version: str = "latest") -> list:
         """Returns the dateranges of data covered by a specific version of the data stored.

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -269,7 +269,7 @@ class LocalZarrStore(Store):
         else:
             shutil.rmtree(self._stores_path, ignore_errors=True)
 
-    def update(
+    def overwrite(
         self,
         version: str,
         dataset: xr.Dataset,

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -92,19 +92,6 @@ class LocalZarrStore(Store):
         for store in self._stores.values():
             store.close()
 
-    def store_key(self, version: str) -> str:
-        """Return the key of this zarr Store
-
-        Args:
-            version: Data version
-        Returns:
-            str: Key of zarr store
-        """
-        if version.lower() not in self._stores:
-            raise KeyError(f"Invalid version - {version}")
-
-        return str(Path(self._root_store_key, version))
-
     def store_path(self, version: str) -> Path:
         """Return the path of this zarr Store
 
@@ -309,6 +296,7 @@ class LocalZarrStore(Store):
 
         return {}
 
+    # TODO: implement attribute matching for zarr store
     def match_attributes(self, version: str, dataset: xr.Dataset) -> dict:
         """Ensure the attributes of the stored and incoming data are matched,
         any attributes that differ will be added as a new key with a number appended.

--- a/openghg/store/storage/_store.py
+++ b/openghg/store/storage/_store.py
@@ -55,11 +55,6 @@ class Store(ABC):
         pass
 
     @abstractmethod
-    def _pop(self, version: str) -> Dataset:
-        """Pop some data from the store. This removes the data at this version from the store
-        and returns it."""
-        pass
-
     def overwrite(self, version: str, dataset: Dataset, compressor: Any | None, filters: Any | None) -> None:
         """Overwrite the data at the given key"""
         pass

--- a/openghg/store/storage/_store.py
+++ b/openghg/store/storage/_store.py
@@ -60,9 +60,8 @@ class Store(ABC):
         and returns it."""
         pass
 
-    @abstractmethod
-    def update(self, version: str, dataset: Dataset, compressor: Any | None, filters: Any | None) -> None:
-        """Update the data at the given key"""
+    def overwrite(self, version: str, dataset: Dataset, compressor: Any | None, filters: Any | None) -> None:
+        """Overwrite the data at the given key"""
         pass
 
     @abstractmethod

--- a/openghg/store/storage/_store.py
+++ b/openghg/store/storage/_store.py
@@ -40,11 +40,6 @@ class Store(ABC):
         pass
 
     @abstractmethod
-    def store_key(self, version: str) -> str:
-        """Return the key of this zarr store"""
-        pass
-
-    @abstractmethod
     def version_exists(self, version: str) -> bool:
         """Check if a version exists in the current store"""
         pass

--- a/tests/dataobjects/test_datamanager.py
+++ b/tests/dataobjects/test_datamanager.py
@@ -138,7 +138,9 @@ def test_delete_footprint_data(footprint_read):
     # Assert there are files in the zarr store
     assert ds._store
 
-    zarr_store_key = ds._store.store_key(version="v1")
+    zarr_store_path = ds._store.store_path("v1")
+
+    assert zarr_store_path.exists()
 
     with open_object_store(bucket=bucket, data_type="footprints") as objstore:
         assert objstore.search({"uuid": uuid})
@@ -150,7 +152,7 @@ def test_delete_footprint_data(footprint_read):
         with pytest.raises(ObjectStoreError):
             objstore.get_datasource(uuid=uuid)
 
-        assert not exists(bucket=bucket, key=zarr_store_key)
+        assert not zarr_store_path.exists()
         assert objstore.search({"uuid": uuid}) == []
 
 

--- a/tests/store/storage/test_localzarrstore.py
+++ b/tests/store/storage/test_localzarrstore.py
@@ -91,17 +91,7 @@ def test_localzarrstore_add_files_identical(store):
         assert retrieved.identical(concat)
 
 
-def test_copy_to_memory_store(store):
-    datapath = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")
-    with xr.open_dataset(datapath) as ds:
-        store.add(version="v1", dataset=ds)
-
-        memory_store = store._copy_to_memorystore(version="v1")
-        ds_recombined = xr.open_zarr(store=memory_store)
-        assert ds.equals(ds_recombined)
-
-
-def test_update(store):
+def test_overwrite(store):
     fp_1 = get_footprint_datapath("TAC-100magl_UKV_TEST_201607.nc")
     fp_2 = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")
 
@@ -111,7 +101,7 @@ def test_update(store):
         assert ds.equals(ds_loaded)
 
     with xr.open_dataset(fp_2) as ds:
-        store.update(version="v1", dataset=ds)
+        store.overwrite(version="v1", dataset=ds)
         ds_loaded = store.get(version="v1")
         assert ds.equals(ds_loaded)
 
@@ -170,19 +160,6 @@ def test_delete_all(store):
     assert not parent.exists()
 
     assert not parent.parent.exists()
-
-
-def test_pop_dataset(store):
-    datapath = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")
-    with xr.open_dataset(datapath) as ds:
-        store.add(version="v1", dataset=ds)
-
-        with pytest.raises(NotImplementedError):
-            store._pop(version="v1")
-        # assert ds.equals(retrieved)
-
-        # assert not store.version_exists(version="v1")
-        # assert not store
 
 
 def test_match_chunking(store):
@@ -253,53 +230,6 @@ def test_match_chunking(store):
     chunking = store.match_chunking(version="v1", dataset=data_b_chunked)
 
     assert not chunking
-
-
-def test_copy_actually_copies(store):
-    time_a = pd.date_range("2012-01-01T00:00:00", "2012-01-31T00:00:00", freq="1d")
-    time_b = pd.date_range("2012-01-29T00:00:00", "2012-04-30T00:00:00", freq="1d")
-
-    values_a = np.zeros(len(time_a))
-    values_b = np.full(len(time_b), 1)
-
-    attributes = {}
-
-    data_a = xr.Dataset({"mf": ("time", values_a)}, coords={"time": time_a}, attrs=attributes)
-    data_b = xr.Dataset({"mf": ("time", values_b)}, coords={"time": time_b}, attrs=attributes)
-
-    ds_expected = xr.concat([data_a, data_b], dim="time").drop_duplicates("time")
-
-    store.add(version="v1", dataset=data_a)
-    # Copy the data into memory using get
-    ds_a_from_store = store.get(version="v1")
-    store.delete_version(version="v1")
-    ds_a_from_store = ds_a_from_store.compute()
-    ds_2 = xr.concat([ds_a_from_store, data_b], dim="time").drop_duplicates("time")
-
-    assert not ds_2.equals(ds_expected)
-    assert np.sum(np.isnan(ds_2.mf.values))
-
-    store.add(version="v1", dataset=data_a)
-    # If we call compute and load everything into memory before deleting the
-    # data from disk then it works
-    ds_a_from_store = store.get(version="v1")
-    ds_a_from_store = ds_a_from_store.compute()
-    store.delete_version(version="v1")
-    ds_2 = xr.concat([ds_a_from_store, data_b], dim="time").drop_duplicates("time")
-
-    assert ds_2.equals(ds_expected)
-    assert not np.sum(np.isnan(ds_2.mf.values))
-
-    store.add(version="v1", dataset=data_a)
-
-    # Let's try copying it to a dict
-    data_a_in_dict = store._copy_to_memorystore(version="v1")
-    ds_a_from_dict = xr.open_zarr(store=data_a_in_dict, consolidated=True)
-    store.delete_version(version="v1")
-    ds_2 = xr.concat([ds_a_from_dict, data_b], dim="time").drop_duplicates("time")
-
-    assert ds_2.equals(ds_expected)
-    assert not np.sum(np.isnan(ds_2.mf.values))
 
 
 def test_for_missing_data_from_appending_in_loop():

--- a/tests/store/storage/test_localzarrstore.py
+++ b/tests/store/storage/test_localzarrstore.py
@@ -25,7 +25,7 @@ def test_localzarrstore_not_writable():
         local_store.add(version="v1", dataset=xr.Dataset())
 
     with pytest.raises(PermissionError):
-        local_store.update(version="v1", dataset=xr.Dataset())
+        local_store.overwrite(version="v1", dataset=xr.Dataset())
 
     with pytest.raises(PermissionError):
         local_store.delete_version(version="v1")

--- a/tests/store/test_datasource.py
+++ b/tests/store/test_datasource.py
@@ -420,19 +420,6 @@ def test_surface_data_stored_and_dated_correctly(data, datasource):
     assert timestamp_tzaware(end) == timestamp_tzaware("2020-12-01 22:32:29")
 
 
-def test_to_memory_store(data, datasource):
-    d = datasource
-
-    metadata = data["ch4"]["metadata"]
-    ch4_data = data["ch4"]["data"]
-
-    d.add_data(metadata=metadata, data=ch4_data, data_type="surface")
-
-    memory_store = d._copy_to_memorystore(version="latest")
-    with xr.open_zarr(store=memory_store) as ds:
-        assert ds.equals(ch4_data)
-
-
 def test_add_data_with_gaps_check_stored_dataset(datasets_with_gaps, datasource):
     data_a, data_b, data_c = datasets_with_gaps
     attributes = create_attributes()

--- a/tests/store/test_datasource.py
+++ b/tests/store/test_datasource.py
@@ -241,23 +241,6 @@ def test_replace_version(bucket):
     # TODO: Add case for if_exists="combine" which should look more like original case above after updates
 
 
-def test_get_dataframe_daterange(bucket):
-    n_days = 100
-    epoch = datetime.datetime(1970, 1, 1, 1, 1)
-    random_data = pd.DataFrame(
-        data=np.random.randint(0, 100, size=(100, 4)),
-        index=pd.date_range(epoch, epoch + datetime.timedelta(n_days - 1), freq="D"),
-        columns=list("ABCD"),
-    )
-
-    d = Datasource(uuid="abc123", bucket=bucket)
-
-    start, end = d.get_dataframe_daterange(random_data)
-
-    assert start == pd.Timestamp("1970-01-01 01:01:00+0000")
-    assert end == pd.Timestamp("1970-04-10 01:01:00+0000")
-
-
 def test_save(bucket):
 
     datasource = Datasource(uuid="abc123", bucket=bucket)
@@ -365,64 +348,6 @@ def test_update_daterange_replacement(data, bucket):
 
     assert d._start_date == pd.Timestamp("2014-01-30 11:12:30+00:00")
     assert d._end_date == pd.Timestamp("2016-04-02 06:55:30+00:00")
-
-
-def test_load_dataset(bucket):
-    with pytest.raises(NotImplementedError):
-        Datasource.load_dataset(bucket=bucket, key="key")
-
-
-def test_in_daterange(data, bucket):
-    metadata = data["ch4"]["metadata"]
-    data = data["ch4"]["data"]
-
-    d = Datasource(uuid="test-id-123", bucket=bucket)
-    d.add_data(metadata=metadata, data=data, data_type="surface")
-
-    assert d.data_keys() == ["2014-01-30-11:12:30+00:00_2020-12-01-22:32:29+00:00"]
-
-    start = pd.Timestamp("2014-1-1")
-    end = pd.Timestamp("2014-2-1")
-    daterange = create_daterange_str(start=start, end=end)
-
-    dated_keys = d.keys_in_daterange_str(daterange=daterange)
-
-    assert dated_keys == ["2014-01-30-11:12:30+00:00_2020-12-01-22:32:29+00:00"]
-
-
-def test_key_date_compare(bucket):
-    d = Datasource(uuid="abc123", bucket=bucket)
-
-    keys = [
-        "2014-01-30-11:12:30+00:00_2014-11-30-11:23:30+00:00",
-        "2015-01-30-11:12:30+00:00_2015-11-30-11:23:30+00:00",
-        "2016-04-02-06:52:30+00:00_2016-11-02-12:54:30+00:00",
-        "2017-02-18-06:36:30+00:00_2017-12-18-15:41:30+00:00",
-        "2018-02-18-15:42:30+00:00_2018-12-18-15:42:30+00:00",
-        "2019-02-03-17:38:30+00:00_2019-12-09-10:47:30+00:00",
-        "2020-02-01-18:08:30+00:00_2020-12-01-22:31:30+00:00",
-    ]
-
-    start = timestamp_tzaware("2014-01-01")
-    end = timestamp_tzaware("2018-01-01")
-
-    in_date = d.key_date_compare(keys=keys, start_date=start, end_date=end)
-
-    expected = [
-        "2014-01-30-11:12:30+00:00_2014-11-30-11:23:30+00:00",
-        "2015-01-30-11:12:30+00:00_2015-11-30-11:23:30+00:00",
-        "2016-04-02-06:52:30+00:00_2016-11-02-12:54:30+00:00",
-        "2017-02-18-06:36:30+00:00_2017-12-18-15:41:30+00:00",
-    ]
-
-    assert in_date == expected
-
-    start = timestamp_tzaware("2026-01-01")
-    end = timestamp_tzaware("2029-01-01")
-
-    in_date = d.key_date_compare(keys=keys, start_date=start, end_date=end)
-
-    assert not in_date
 
 
 def test_integrity_check(data, bucket):
@@ -561,26 +486,6 @@ def test_add_data_with_overlap_check_stored_dataset(bucket, datasets_with_overla
         assert ds.time.size == n_days_expected
         combined = xr.concat([data_a, data_b, data_c], dim="time").drop_duplicates("time")
         assert ds.equals(combined)
-
-
-@pytest.mark.xfail(reason="Combining datasets is not currently supported")
-def test_add_data_combine_datasets(data, bucket):
-    d = Datasource(uuid="abc123", bucket=bucket)
-
-    metadata = data["ch4"]["metadata"]
-    ch4_data = data["ch4"]["data"]
-
-    d.add_data(metadata=metadata, data=ch4_data, data_type="surface")
-
-    ch4_data_clipped = ch4_data.isel(time=slice(10, ch4_data.time.size - 10))
-
-    d.add_data(metadata=metadata, data=ch4_data_clipped, data_type="surface", if_exists="combine")
-
-    assert d._store.version_exists(version="v1")
-
-    ds_data = d._copy_to_memorystore(version="v1")
-    combined_ds = xr.open_zarr(store=ds_data, consolidated=True)
-    assert combined_ds.equals(ch4_data)
 
 
 @pytest.mark.xfail(reason="Combining datasets with overlap is not yet supported")


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Removing unused code will make the `LocalZarrStore` refactor easier. We will also need to refactor `Datasource` in the near future to remove the use of "representative date strings".

Removing unused code or code that is only used in basic tests should make the currently used functionality clearer.

One change didn't involve removing code: the `update` method in `LocalZarrStore` was renamed to `overwrite`, since this matches what the method will be called after the zarr store refactor.

I also flattened some nested "if" statements in `Datasource.add_timed_data`.

Details of code removed that could potentially be used:
- From `Datasource`:
  - `get_dataframe_daterange` this was deprecated
  - `get_dataset_daterange_str` unused, calls `get_dataset_daterange` then converts the result to a string
  - `clip_daterange_from_str` this used to be used before we used Zarr to make the daterange strings non-overlapping
  - `_clip_daterange_label` this was a variant on the previous function
  - `_copy_to_memorystore` copied data to a "memory store" (part of LocalZarrStore functionality that was also removed) as a possible method for combining data; this was unused and a different method for combining data will be used in the future.
  - `keys_in_daterange` unused, maybe part of pre-Zarr code
  - `keys_in_daterange_str` variant of previous function
  - `key_date_compare` selects daterange strings between given start and end dates
  - `raw_keys` unused, just returns `self._data_keys`
  - code removed from `add_timed_data`: this was behind a `NotImplementedError` and had some old "update/combine" code in it.
- From `LocalZarrStore` (and `Store` ABC):
  - `_pop` ... not implemented
  - `_copy_to_memory_store` unused.. could potentially be revived in a different way after zarr store refactor
  - `store_key` this could be replaced by the `store_path`... it may have been in the ABC as a possible generalisation beyond Zarr "DirectoryStore"s but we haven't used it and it will be refactored anyway.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1413
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
