### PR TITLE
Adding a basic schema for EulerianModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The `standardise_flux`, `standardise_bc`, `standardise_eulerian` and `standardise_column` can now all accept a list of input netcdf files for filepath (rather than just a single file). This pre-processes the data and concatenates the files when opening them. [PR #1393](https://github.com/openghg/openghg/pull/1393)
 - Ability to pass the non configured path to the store argument directly for get_* functions. Also added the ability add the store to config using openghg --register-store command. [PR #1389](https://github.com/openghg/openghg/pull/1389)
+- Add basic schema for EulerianModel data type. This currently checks appropriate coordinates and types are included. [PR #1414](https://github.com/openghg/openghg/pull/1414)
 
 ### Updated
 - Updated temporary path creation to have user specific folder. [PR #1396](https://github.com/openghg/openghg/pull/1396)

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
+import numpy as np
+from xarray import Dataset
 import logging
+
+from openghg.store import DataSchema
 from openghg.store.base import BaseStore
 from openghg.util import load_standardise_parser, split_function_inputs
 
@@ -192,3 +196,41 @@ class EulerianModel(BaseStore):
         self.store_hashes(unseen_hashes)
 
         return datasource_uuids
+
+    @staticmethod
+    def schema() -> DataSchema:
+        """
+        Define schema for Eulerian model Dataset.
+
+        At present, this doesn't check the variables but does check that
+        "lat", "lon", "time" are included as appropriate types.
+
+        Returns:
+            DataSchema : Contains dummy schema for EulerianModel.
+        
+        TODO: Decide on data_vars checks as we build up the use of this data_type
+        """
+        data_vars = {}
+        dtypes = {"lat": np.floating, "lon": np.floating, "time": np.datetime64}
+
+        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
+
+        return data_format
+
+    @staticmethod
+    def validate_data(data: Dataset) -> None:
+        """
+        Validate input data against EulerianModel schema - definition from
+        EulerianModel.schema() method.
+
+        Args:
+            data : xarray Dataset in expected format
+
+        Returns:
+            None
+
+            Raises a ValueError with details if the input data does not adhere
+            to the EulerianModel schema.
+        """
+        data_schema = EulerianModel.schema()
+        data_schema.validate_data(data)

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -210,7 +210,7 @@ class EulerianModel(BaseStore):
 
         TODO: Decide on data_vars checks as we build up the use of this data_type
         """
-        data_vars = {}
+        data_vars: dict[str, tuple[str, ...]] = {}
         dtypes = {"lat": np.floating, "lon": np.floating, "time": np.datetime64}
 
         data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -207,7 +207,7 @@ class EulerianModel(BaseStore):
 
         Returns:
             DataSchema : Contains dummy schema for EulerianModel.
-        
+
         TODO: Decide on data_vars checks as we build up the use of this data_type
         """
         data_vars = {}


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

At the moment the `EulerianModel` data type class doesn't have an associated schema which is used to check parsed data matches to an expected format.

This PR introduces a basic schema which checks that some of the essential coordinates are present and of an appropriate data_type.

Note that we don't have a lot of examples of Eulerian Model data at the moment and are not sure how we're going to want to use it so at the moment so this doesn't include any data variable checks yet but these can be included if we get more examples of different types of data.

* **Please check if the PR fulfills these requirements**

- [x] Closes #390 and feeds into Issue #1252 by making sure all data types have a schema
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation and tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

Not needed
- ~Added any new requirements to `requirements.txt` and `recipes/meta.yaml`~
