### PR TITLE
Return bc sensitivities from `footprints_data_merge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `standardise_flux`, `standardise_bc`, `standardise_eulerian` and `standardise_column` can now all accept a list of input netcdf files for filepath (rather than just a single file). This pre-processes the data and concatenates the files when opening them. [PR #1393](https://github.com/openghg/openghg/pull/1393)
 - Ability to pass the non configured path to the store argument directly for get_* functions. Also added the ability add the store to config using openghg --register-store command. [PR #1389](https://github.com/openghg/openghg/pull/1389)
 - Add basic schema for EulerianModel data type. This currently checks appropriate coordinates and types are included. [PR #1414](https://github.com/openghg/openghg/pull/1414)
+- Unit tracking with pint to ModelScenario. [PR #1417](https://github.com/openghg/openghg/pull/1417)
 
 ### Updated
 

--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -6,7 +6,7 @@ import pandas as pd
 import xarray as xr
 
 from openghg.analyse._alignment import time_of_day_offset
-from openghg.analyse._utils import match_dataset_dims, reindex_on_dims
+from openghg.analyse._utils import reindex_on_dims
 
 
 def fp_x_flux_integrated(footprint: xr.Dataset, flux: xr.Dataset) -> xr.DataArray:
@@ -20,14 +20,14 @@ def fp_x_flux_integrated(footprint: xr.Dataset, flux: xr.Dataset) -> xr.DataArra
         DataArray containing footprint times flux.
 
     """
-    footprint, flux = match_dataset_dims([footprint, flux], dims=["lat", "lon"])
+    flux = reindex_on_dims(flux, footprint, ["lat", "lon"])
 
     # align separately on time
     # TODO: if method="nearest" was acceptable, then we could align all coordinates at once with reindex_like
     flux = flux.reindex_like(footprint, method="ffill")
 
-    result = cast(xr.DataArray, footprint.fp * flux.flux)
-    return result
+    result = footprint.fp.pint.quantify() * flux.flux.pint.quantify()
+    return cast(xr.DataArray, result.pint.dequantify())
 
 
 # helper functions for time-resolved calculation
@@ -142,6 +142,7 @@ def _make_hf_flux_rolling_avg_array(
     flux_hf_rolling = flux_hf_rolling.assign_coords(
         {"H_back": np.arange(0, max_h_back, highest_res_h, dtype=h_back_type)[::-1]}
     )
+    flux_hf_rolling.H_back.attrs["units"] = fp_high_time_res.H_back.attrs.get("units")
 
     # select subsequence of H_back times to match high res fp (i.e. fp without max H_back coord)
     flux_hf_rolling = flux_hf_rolling.sel(H_back=fp_high_time_res.H_back)
@@ -176,6 +177,8 @@ def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> x
     # create rolling windows
     flux_high_freq = _make_hf_flux_rolling_avg_array(flux_high_freq, fp)
 
+    flux_high_freq.attrs["units"] = flux.attrs.get("units")
+
     return flux_high_freq
 
 
@@ -183,7 +186,6 @@ def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> x
 def fp_x_flux_time_resolved(
     fp: xr.DataArray | xr.Dataset, flux: xr.DataArray | xr.Dataset, averaging: str | None = None
 ) -> xr.DataArray:
-
     if isinstance(flux, xr.Dataset):
         flux = flux.flux
         flux = cast(xr.DataArray, flux)
@@ -211,18 +213,24 @@ def fp_x_flux_time_resolved(
 
     # create low res. (monthly) flux and calculate low res. fp x flux
     flux_low_freq = _make_low_freq_flux(flux, fp)
-    fp_x_flux_residual = fp_residual * flux_low_freq
+    fp_x_flux_residual = fp_residual.pint.quantify() * flux_low_freq.pint.quantify()
 
     # Calculate time resolution for flux
     flux_res_hours = calc_hourly_freq(flux.time, input_nanoseconds=True)
 
     # if resolution coarser than "H_back" dimension, just sum over "H_back" and use low freq. flux
     if flux_res_hours > _max_h_back(fp):
-        return fp_time_resolved.sum("H_back") * flux_low_freq + fp_x_flux_residual
+        result = (
+            fp_time_resolved.sum("H_back").pint.quantify() * flux_low_freq.pint.quantify()
+            + fp_x_flux_residual
+        )
+        return cast(xr.DataArray, result.pint.dequantify())
 
     # create high frequency flux (resampled to gcd of footprint time and H_back frequencies) with H_back dim
     flux_high_freq = _make_high_freq_flux(flux, fp)
 
-    fp_x_flux = (flux_high_freq * fp_time_resolved).sum("H_back") + fp_x_flux_residual
+    fp_x_flux = (flux_high_freq.pint.quantify() * fp_time_resolved.pint.quantify()).sum(
+        "H_back"
+    ) + fp_x_flux_residual
 
-    return fp_x_flux
+    return cast(xr.DataArray, fp_x_flux.pint.dequantify())

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -79,6 +79,13 @@ def _get_generic(
     else:
         result = retrieved_data
 
+    # TODO: make sure lat and lon have units when stadardising
+    # make sure lat and lon units are set
+    if "lat" in result.data.dims and result.data.lat.attrs.get("units") is None:
+        result.data.lat.attrs["units"] = "degrees_north"
+    if "lon" in result.data.dims and result.data.lon.attrs.get("units") is None:
+        result.data.lon.attrs["units"] = "degrees_east"
+
     return result
 
 

--- a/openghg/util/_units.py
+++ b/openghg/util/_units.py
@@ -55,6 +55,7 @@ def openghg_format(unit, registry):  # type: ignore
 
 
 cf_ureg.formatter.default_format = "openghg"
+cf_ureg.case_sensitive = False
 
 
 def convert_units(ds: xr.Dataset, target_units: dict) -> None:

--- a/tests/analyse/test_modelled_obs.py
+++ b/tests/analyse/test_modelled_obs.py
@@ -103,6 +103,13 @@ def footprint_co2_dummy():
         coords={"lat": lat, "lon": lon, "time": time, "H_back": H_back},
     )
 
+    # set units for testing with pint
+    data.fp.attrs["units"] = "m2 s mol-1"
+    data.fp_HiTRes.attrs["units"] = "m2 s mol-1"
+    data.lat.attrs["units"] = "degrees_north"
+    data.lon.attrs["units"] = "degrees_east"
+    data.H_back.attrs["units"] = "Hours"
+
     # Potential metadata:
     # - site, inlet, domain, model, network, start_date, end_date, heights, ...
     # - species (if applicable)
@@ -148,6 +155,11 @@ def flux_co2_dummy():
     flux = xr.Dataset(
         {"flux": (("time", "lat", "lon"), values)}, coords={"lat": lat, "lon": lon, "time": time}
     )
+
+    # add units for testing with pint
+    flux.flux.attrs["units"] = "mol m-2 s-1"
+    flux.lat.attrs["units"] = "degrees_north"
+    flux.lon.attrs["units"] = "degrees_east"
 
     # Potential metadata:
     # - title, author, date_creaed, prior_file_1, species, domain, source, heights, ...
@@ -314,8 +326,7 @@ def test_model_modelled_obs_co2_multisector(model_scenario_co2_dummy, flux_co2_d
     """Test footprints_data_merge with multisector return options"""
     model_scenario_co2_dummy.add_flux(species="co2", flux={"TESTSOURCE2": flux_co2_dummy})
     combined_dataset = model_scenario_co2_dummy.footprints_data_merge(calc_fp_x_flux=True, split_by_sectors=True)
-    print(combined_dataset)
-    print(combined_dataset.data_vars)
+
     assert all(dv in combined_dataset for dv in ["mf_mod_high_res", "fp_x_flux", "mf_mod_high_res_sectoral", "fp_x_flux_sectoral"])
 
     assert all(combined_dataset.source.values == ["TESTSOURCE", "TESTSOURCE2"])

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -957,7 +957,7 @@ def calc_expected_baseline(footprint: Dataset, bc: Dataset, lifetime_hrs: Option
 
 def test_modelled_baseline_ch4(model_scenario_ch4_dummy, footprint_dummy, bc_ch4_dummy):
     """Test expected modelled baseline with known dummy data"""
-    modelled_baseline = model_scenario_ch4_dummy.calc_modelled_baseline(output_units=1)
+    modelled_baseline = model_scenario_ch4_dummy.calc_modelled_baseline(output_units=1).bc_mod
 
     aligned_time = modelled_baseline["time"]
     assert aligned_time[0] == Timestamp("2012-01-01T00:00:00")
@@ -976,6 +976,13 @@ def test_modelled_baseline_ch4(model_scenario_ch4_dummy, footprint_dummy, bc_ch4
 
     assert np.allclose(modelled_baseline, expected_modelled_baseline)
 
+
+def test_bc_sensitivity_ch4(model_scenario_ch4_dummy):
+    """Check that bc sensitivity for each NESW curtain is available."""
+    bc_sensitivity = model_scenario_ch4_dummy.calc_modelled_baseline(output_units=1, output_sensitivity=True)
+
+    for d in "nesw":
+        assert f"bc_{d}" in bc_sensitivity
 
 # %% Test alignment when using platform keyword with dummy data (CH4)
 #  - flask data
@@ -1158,7 +1165,7 @@ def model_scenario_radon_dummy(obs_radon_dummy, footprint_radon_dummy, bc_radon_
 
 def test_modelled_baseline_radon(model_scenario_radon_dummy, footprint_radon_dummy, bc_radon_dummy):
     """Test expected modelled baseline for Rn (short-lived species) with known dummy data"""
-    modelled_baseline = model_scenario_radon_dummy.calc_modelled_baseline(output_units=1)
+    modelled_baseline = model_scenario_radon_dummy.calc_modelled_baseline(output_units=1).bc_mod
 
     aligned_time = modelled_baseline["time"]
     assert aligned_time[0] == Timestamp("2012-01-01T00:00:00")
@@ -1233,7 +1240,7 @@ def test_modelled_baseline_short_life(
     model_scenario_short_life_dummy, footprint_short_life_dummy, bc_short_life_dummy
 ):
     """Test expected modelled baseline for short-lived species 'HFO-1234zee' with known dummy data"""
-    modelled_baseline = model_scenario_short_life_dummy.calc_modelled_baseline(output_units=1)
+    modelled_baseline = model_scenario_short_life_dummy.calc_modelled_baseline(output_units=1).bc_mod
 
     aligned_time = modelled_baseline["time"]
     assert aligned_time[0] == Timestamp("2012-01-01T00:00:00")

--- a/tests/analyse/test_utils.py
+++ b/tests/analyse/test_utils.py
@@ -1,0 +1,156 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from openghg.analyse._utils import stack_datasets
+from openghg.util import cf_ureg
+
+
+@pytest.fixture
+def flux_co2_dummy():
+    """
+    Create example FluxData object with dummy data
+     - Species is carbon dioxide (co2)
+     - Data is 2-hourly from 2011-12-31 - 2012-01-02 (inclusive)
+     - Small lat, lon (TEST_DOMAIN)
+     - "flux" values are in a range from 1, ntime+1, different along the time axis.
+    """
+    from openghg.dataobjects import FluxData
+
+    time = pd.date_range("2011-12-31", "2012-01-02", freq="2h")
+    lat = [1.0, 2.0]
+    lon = [10.0, 20.0]
+
+    nlat, nlon, ntime = len(lat), len(lon), len(time)
+    shape = (ntime, nlat, nlon)
+    values = np.arange(1.0, ntime + 1, 1.0)
+
+    expand_axes = (1, 2)
+    values = np.expand_dims(values, axis=expand_axes)
+    for j in expand_axes:
+        values = np.repeat(values, shape[j], axis=j)
+
+    flux = xr.Dataset(
+        {"flux": (("time", "lat", "lon"), values)}, coords={"lat": lat, "lon": lon, "time": time}
+    )
+
+    # add units for testing with pint
+    flux.flux.attrs["units"] = "mol m-2 s-1"
+    flux.lat.attrs["units"] = "degrees_north"
+    flux.lon.attrs["units"] = "degrees_east"
+
+    # Potential metadata:
+    # - title, author, date_creaed, prior_file_1, species, domain, source, heights, ...
+    # - data_type?
+    species = "co2"
+    metadata = {"species": species, "source": "TESTSOURCE", "domain": "TESTDOMAIN"}
+
+    fluxdata = FluxData(data=flux, metadata=metadata)
+
+    return fluxdata
+
+
+@pytest.fixture
+def flux_co2_dummy_1h():
+    """
+    Create example FluxData object with dummy data
+     - Species is carbon dioxide (co2)
+     - Data is 2-hourly from 2011-12-31 - 2012-01-02 (inclusive)
+     - Small lat, lon (TEST_DOMAIN)
+     - "flux" values are in a range from 1, ntime+1, different along the time axis.
+    """
+    from openghg.dataobjects import FluxData
+
+    time = pd.date_range("2011-12-31", "2012-01-02", freq="1h")
+    lat = [1.0, 2.0]
+    lon = [10.0, 20.0]
+
+    nlat, nlon, ntime = len(lat), len(lon), len(time)
+    shape = (ntime, nlat, nlon)
+    values = np.arange(1.0, ntime + 1, 1.0)
+
+    expand_axes = (1, 2)
+    values = np.expand_dims(values, axis=expand_axes)
+    for j in expand_axes:
+        values = np.repeat(values, shape[j], axis=j)
+
+    flux = xr.Dataset(
+        {"flux": (("time", "lat", "lon"), values)}, coords={"lat": lat, "lon": lon, "time": time}
+    )
+
+    # add units for testing with pint
+    flux.flux.attrs["units"] = "mol m-2 s-1"
+    flux.lat.attrs["units"] = "degrees_north"
+    flux.lon.attrs["units"] = "degrees_east"
+
+    # Potential metadata:
+    # - title, author, date_creaed, prior_file_1, species, domain, source, heights, ...
+    # - data_type?
+    species = "co2"
+    metadata = {"species": species, "source": "TESTSOURCE", "domain": "TESTDOMAIN"}
+
+    fluxdata = FluxData(data=flux, metadata=metadata)
+
+    return fluxdata
+
+
+def test_stack_datasets(flux_co2_dummy):
+    """Check that stacking the same data twice is equivalent to doubling the values."""
+    fluxes = [flux_co2_dummy.data, flux_co2_dummy.data]
+
+    stacked = stack_datasets(fluxes)
+
+    xr.testing.assert_equal(stacked, 2 * fluxes[0])
+
+
+def test_stack_datasets_different_frequencies(flux_co2_dummy, flux_co2_dummy_1h):
+    """Check that stacking the same data twice is equivalent to doubling the values."""
+    fluxes = [flux_co2_dummy.data, flux_co2_dummy_1h.data]
+
+    stacked = stack_datasets(fluxes)
+    stacked_values = stacked.flux.values[:, 0, 0]
+
+    flux_1h_values = np.arange(1.0, len(fluxes[1].time) + 1, 1.0)
+
+    # make indices to forward fill
+    ffill_indices = []
+    for i in range(len(fluxes[0].time)):
+        ffill_indices.append(i)
+        ffill_indices.append(i)
+
+    ffill_indices = ffill_indices[:-1]  # last value is not filled
+
+    flux_2h_values_filled = np.arange(1.0, len(fluxes[0].time) + 1, 1.0)[ffill_indices]
+    expected_values = flux_1h_values + flux_2h_values_filled
+
+    assert np.all(stacked_values == expected_values)
+
+
+def test_stack_datasets_units(flux_co2_dummy):
+    """Check that stacking preserves units."""
+    fluxes = [flux_co2_dummy.data, flux_co2_dummy.data]
+    stacked = stack_datasets(fluxes)
+
+    assert stacked.flux.attrs.get("units") == fluxes[0].flux.attrs["units"]
+
+
+def test_stack_datasets_with_different_units(flux_co2_dummy):
+    """Check that stacking fluxes with different units."""
+    flux_ds = flux_co2_dummy.data
+    flux_ds_ppb = flux_ds.pint.quantify().pint.to("ppb mol m-2 s-1").pint.dequantify()
+
+    fluxes = [flux_ds, flux_ds_ppb]
+    stacked = stack_datasets(fluxes)
+
+    # Check for equality after converting to expected units; we do not know ahead of time
+    # which units will be used (it depends on the order of the fluxes and their units)
+    # so we convert in both test cases
+
+    # if we convert stacked to mol m-2 s-1, it should equal twice the first flux
+    xr.testing.assert_allclose(stacked.pint.quantify().pint.to("mol m-2 s-1"), 2 * fluxes[0].pint.quantify())
+
+    # if we convert stack to ppb mol m-2 s-1, it should equal twice the second flux
+    xr.testing.assert_allclose(
+        stacked.pint.quantify().pint.to("ppb mol m-2 s-1"), 2 * fluxes[1].pint.quantify()
+    )


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

An option has been added to include BC sensitivities in the result of
`footprints_data_merge`.

This will allow use to compute BC basis functions without having to
duplicate code in OpenGHG inversions.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1329 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

