### PR TITLE
Typo for calculating mfs / fluxXfp for multiple sources

### DIFF
--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -1094,7 +1094,7 @@ class ModelScenario:
             for source in sources:
                 if self.species == "co2":
                     mod_obs = self._calc_modelled_obs_HiTRes(
-                        sources=sources,
+                        sources=source,
                         output_TS=True,
                         ts_name="mf_mod_high_res_sectoral",
                         output_fpXflux=output_fp_x_flux,
@@ -1102,7 +1102,7 @@ class ModelScenario:
                     )
                 else:
                     mod_obs = self._calc_modelled_obs_integrated(
-                        sources=sources,
+                        sources=source,
                         output_TS=True,
                         ts_name="mf_mod_sectoral",
                         output_fpXflux=output_fp_x_flux,


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Typo in for loop in _scenario was calculating total mole fraction contributions and fp_x_flux for all flux sectors rather than individually as intended. 

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
