### PR TITLE
Adding in site_filepath option for all functions which grab site_info

### DIFF
--- a/openghg/util/_util.py
+++ b/openghg/util/_util.py
@@ -9,6 +9,7 @@ import pandas as pd
 import logging
 
 from openghg.util import clean_string
+from openghg.types import pathType
 
 logger = logging.getLogger("openghg.util")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -50,11 +51,12 @@ def pairwise(iterable: Iterable) -> Iterator[tuple[Any, Any]]:
     return zip(a, b)
 
 
-def site_code_finder(site_name: str) -> str | None:
+def site_code_finder(site_name: str, site_filepath: pathType | None = None) -> str | None:
     """Find the site code for a given site name.
 
     Args:
         site_name: Site long name
+        site_filepath: Alternative site info file. Defaults to openghg_defs input.
     Returns:
         str or None: Three letter site code if found
     """
@@ -63,7 +65,7 @@ def site_code_finder(site_name: str) -> str | None:
 
     site_name = remove_punctuation(site_name)
 
-    inverted = _create_site_lookup_dict()
+    inverted = _create_site_lookup_dict(site_filepath=site_filepath)
 
     # rapidfuzz 3.9.0 seemed to stop giving type details - ignoring for now.
     matches = process.extract(query=site_name, choices=inverted.keys())  # type:ignore
@@ -120,16 +122,17 @@ def find_matching_site(site_name: str, possible_sites: dict) -> str:
         return f"Unknown site: {site_name}"
 
 
-def _create_site_lookup_dict() -> dict:
+def _create_site_lookup_dict(site_filepath: pathType | None = None) -> dict:
     """Create a dictionary of site name: three letter site code values
 
+    Args:
+        site_filepath: Alternative site info file. Defaults to openghg_defs input.
     Returns:
         dict: Dictionary of site_name: site_code values
     """
-    from openghg_defs import site_info_file
-    from openghg.util import load_json, remove_punctuation
+    from openghg.util import get_site_info, remove_punctuation
 
-    site_info = load_json(path=site_info_file)
+    site_info = get_site_info(site_filepath=site_filepath)
 
     inverted = {}
     for site, site_data in site_info.items():
@@ -152,22 +155,22 @@ def _create_site_lookup_dict() -> dict:
     return inverted
 
 
-def verify_site(site: str) -> str | None:
+def verify_site(site: str, site_filepath: pathType | None = None) -> str | None:
     """Check if the passed site is a valid one and returns the three
     letter site code if found. Otherwise we use fuzzy text matching to suggest
     sites with similar names.
 
     Args:
         site: Three letter site code or site name
+        site_filepath: Alternative site info file. Defaults to openghg_defs input.
     Returns:
         str: Verified three letter site code if valid site
     """
-    from openghg.util import load_json
-    from openghg_defs import site_info_file
+    from openghg.util import get_site_info
 
-    site_data = load_json(path=site_info_file)
+    site_info = get_site_info(site_filepath=site_filepath)
 
-    if site.upper() in site_data:
+    if site.upper() in site_info:
         return site.lower()
     else:
         site_code = site_code_finder(site_name=site)
@@ -176,26 +179,27 @@ def verify_site(site: str) -> str | None:
         return site_code
 
 
-def multiple_inlets(site: str) -> bool:
+def multiple_inlets(site: str, site_filepath: pathType | None = None) -> bool:
     """Check if the passed site has more than one inlet
 
     Args:
         site: Three letter site code
+        site_filepath: Alternative site info file. Defaults to openghg_defs input.
     Returns:
         bool: True if multiple inlets
     """
     from openghg.util import get_site_info
 
-    site_data = get_site_info()
+    site_info = get_site_info(site_filepath=site_filepath)
 
     site = site.upper()
-    network = next(iter(site_data[site]))
+    network = next(iter(site_info[site]))
 
     try:
-        heights = set(site_data[network]["height"])
+        heights = set(site_info[network]["height"])
     except KeyError:
         try:
-            heights = set(site_data[network]["height_name"])
+            heights = set(site_info[network]["height_name"])
         except KeyError:
             return True
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Update functions in `openghg.util` which access `site_info.json` data to use the centralised `get_site_info` function and to allow a customised `site_filepath` to be specified. This makes the functions within the `openghg.util._util.py` file consistent with functions in `openghg.util._site.py`.

*Note: could also move those functions over to _site.py if appropriate*

* **Please check if the PR fulfills these requirements**

- [x] Closes #1432 (and feeds into Issue #1252 and linked PR #1415
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation updated/added

Not needed:
- Tutorials updated/added
- Wiki updated
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
