### PR TITLE
Apply chunking schema to Flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored individual `read_file` methods on data_type classes in `openghg.store` to use a central `read_file` method on `BaseStore` parent class (`openghg.store.base`). This centralises the `read_file` functionality and ensures the steps for each subclass are consistent. Each data_type class now requires a `format_inputs` method to apply the formatting steps to the input kwargs when standardising. [PR #1415](https://github.com/openghg/openghg/pull/1415)
  - Allow a data_type to be specified when defining the required attributes. This is a placeholder at the moment as only "surface" details are included but this allows required attributes to specified and checked for other data_types as well. [PR #1443](https://github.com/openghg/openghg/pull/1443)
 - Removed pinning of `icoscp` from 0.17.0 and adding details of how to use the new authentication method to the tutorials. Note this also required explicit inclusion of `numpy>=2.0` otherwise this get downgraded to `numpy<2.0` based on `icoscp` current stated requirements. [PR #1447](https://github.com/openghg/openghg/pull/1447)
+- Added `chunking_schema` for `Flux` data type to make sure the chunks created a < maximum size accepted by Codec (Codec does not support buffers of > 2147483647 bytes). [PR #1434](https://github.com/openghg/openghg/pull/1434)
 
 ## Fixed
 

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -260,4 +260,4 @@ class Flux(BaseStore):
         time_chunk_size = 336  # 336 = 14 * 24 so high res. fp chunks fit evenly
         secondary_vars = ["lat", "lon"]
 
-        return ChunkingSchema(variable=var, chunks={"time": time_chunk_size}, secondary_dims=secondary_vars)        
+        return ChunkingSchema(variable=var, chunks={"time": time_chunk_size}, secondary_dims=secondary_vars)

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -180,14 +180,9 @@ class Flux(BaseStore):
 
         flux_data = parser_fn(**param)
 
-        time_resolved = flux_data[0].metadata.get("time_resolved", False) or flux_data[0].metadata.get(
-            "high_time_resolution", False
-        )
-
         chunks = self.check_chunks(
             ds=flux_data[0].data,
             chunks=None,
-            time_resolved=time_resolved,
             auto_scale_to_fit_max_chunk_size=True,
         )
         if chunks:

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -249,37 +249,15 @@ class Flux(BaseStore):
 
         return data_format
 
-    def chunking_schema(
-        self,
-        time_resolved: bool = False,
-        high_time_resolution: bool = False,
-    ) -> ChunkingSchema:
+    def chunking_schema(self) -> ChunkingSchema:
         """
         Get chunking schema for footprint data.
-
-        Args:
-            time_resolved : Set footprint variable to be high time resolution.
-            high_time_resolution: This argument is deprecated and will be replaced in future versions with time_resolved.
 
         Returns:
             dict: Chunking schema for footprint data.
         """
-
-        if high_time_resolution:
-            warnings.warn(
-                "This argument is deprecated and will be replaced in future versions with time_resolved.",
-                DeprecationWarning,
-            )
-            time_resolved = high_time_resolution
-
         var = "flux"
+        time_chunk_size = 336  # 336 = 14 * 24 so high res. fp chunks fit evenly
+        secondary_vars = ["lat", "lon"]
 
-        if time_resolved:
-            # TODO: check performance of this chunk size
-            time_chunk_size = 336  # 336 = 14 * 24 so high res. fp chunks fit evenly
-            secondary_vars = ["lat", "lon"]
-        else:
-            time_chunk_size = 336  # fits evenly into fp chunk size and works for global edgar...
-            secondary_vars = ["lat", "lon"]
-
-        return ChunkingSchema(variable=var, chunks={"time": time_chunk_size}, secondary_dims=secondary_vars)
+        return ChunkingSchema(variable=var, chunks={"time": time_chunk_size}, secondary_dims=secondary_vars)        

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -619,9 +619,9 @@ class BaseStore:
 
         Args:
             ds: dataset to check
-            variable: Name of the variable that we want to check for max chunksize
-            chunk_dimension: Dimension to chunk over
-            secondary_dimensions: List of secondary dimensions to chunk over
+            chunks: Chunking schema to use when storing data. It expects a dictionary of dimension name and chunk size,
+                    for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
+                    See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
             max_chunk_size: Maximum chunk size in megabytes, defaults to 300 MB
             auto_scale_to_fit_max_chunk_size: Whether to apply automatic chunk rescaling
                 based on the maximum chunk size.
@@ -648,7 +648,7 @@ class BaseStore:
 
         # Make the 'chunks' dict, using dim_sizes for any unspecified dims
         specified_chunks = default_chunks if chunks is None else chunks
-        # TODO - revisit this type hinting
+
         chunks = dim_sizes
         chunks.update(specified_chunks)
 

--- a/openghg/store/base/_base.py
+++ b/openghg/store/base/_base.py
@@ -587,7 +587,8 @@ class BaseStore:
                 for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
                 See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
             max_chunk_size: Maximum chunk size in megabytes, defaults to 300 MB
-            auto_scale_to_fit_max_chunk_size:
+            auto_scale_to_fit_max_chunk_size: Whether to apply automatic chunk rescaling
+                based on the maximum chunk size.
         Returns:
             dict:  Dictionary of chunk sizes
         """
@@ -622,7 +623,8 @@ class BaseStore:
             chunk_dimension: Dimension to chunk over
             secondary_dimensions: List of secondary dimensions to chunk over
             max_chunk_size: Maximum chunk size in megabytes, defaults to 300 MB
-            auto_scale_to_fit_max_chunk_size:
+            auto_scale_to_fit_max_chunk_size: Whether to apply automatic chunk rescaling
+                based on the maximum chunk size.
         Returns:
             Dict: Dictionary of chunk sizes
         """

--- a/openghg/store/storage/__init__.py
+++ b/openghg/store/storage/__init__.py
@@ -1,4 +1,4 @@
-from ._chunking import ChunkingSchema
+from ._chunking import ChunkingSchema, chunk_size_in_megabytes
 from ._store import Store
 from ._localzarrstore import LocalZarrStore
 from ._encoding import get_zarr_encoding

--- a/openghg/store/storage/_chunking.py
+++ b/openghg/store/storage/_chunking.py
@@ -1,4 +1,13 @@
 from dataclasses import dataclass
+import math
+
+
+def chunk_size_in_megabytes(dtype_bytes: int, chunks: dict[str, int]) -> int:
+    """Compute size of chunks (in MB) given number of bytes in scalar value and chunks dict."""
+    MB_to_bytes = 1024**2
+    bytes_to_MB = 1 / MB_to_bytes
+    chunk_bytes = dtype_bytes * math.prod(chunks.values())
+    return int(chunk_bytes * bytes_to_MB)
 
 
 @dataclass(frozen=True)

--- a/openghg/store/storage/_chunking.py
+++ b/openghg/store/storage/_chunking.py
@@ -3,8 +3,18 @@ import math
 
 
 def chunk_size_in_megabytes(dtype_bytes: int, chunks: dict[str, int]) -> int:
-    """Compute size of chunks (in MB) given number of bytes in scalar value and chunks dict."""
-    MB_to_bytes = 1024**2
+    """
+    Compute size of chunks (in MB) given number of bytes in scalar value and chunks dict.
+    
+    Args:
+        dtype_bytes: The number of bytes used by the dtype object
+        chunks: Chunking schema to use when storing data. It expects a dictionary of dimension name and chunk size,
+                for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
+                See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
+    Returns:
+        int: size of the chunk in MB    
+    """
+    MB_to_bytes = 1024 * 1024
     bytes_to_MB = 1 / MB_to_bytes
     chunk_bytes = dtype_bytes * math.prod(chunks.values())
     return int(chunk_bytes * bytes_to_MB)

--- a/openghg/store/storage/_chunking.py
+++ b/openghg/store/storage/_chunking.py
@@ -5,14 +5,14 @@ import math
 def chunk_size_in_megabytes(dtype_bytes: int, chunks: dict[str, int]) -> int:
     """
     Compute size of chunks (in MB) given number of bytes in scalar value and chunks dict.
-    
+
     Args:
         dtype_bytes: The number of bytes used by the dtype object
         chunks: Chunking schema to use when storing data. It expects a dictionary of dimension name and chunk size,
                 for example {"time": 100}. If None then a chunking schema will be set automatically by OpenGHG.
                 See documentation for guidance on chunking: https://docs.openghg.org/tutorials/local/Adding_data/Adding_ancillary_data.html#chunking.
     Returns:
-        int: size of the chunk in MB    
+        int: size of the chunk in MB
     """
     MB_to_bytes = 1024 * 1024
     bytes_to_MB = 1 / MB_to_bytes

--- a/tests/retrieve/icos/test_retrieve_icos.py
+++ b/tests/retrieve/icos/test_retrieve_icos.py
@@ -188,6 +188,7 @@ def mock_retrieve_remote(mocker):
     )
 
 
+@pytest.mark.icos
 def test_retrieved_prevents_storing_twice(mock_retrieve_remote, caplog):
     """Test if retrieving the same data twice issues a warning the second time."""
     clear_test_stores()
@@ -199,6 +200,7 @@ def test_retrieved_prevents_storing_twice(mock_retrieve_remote, caplog):
     assert "Skipping data that overlaps existing data" in caplog.text
 
 
+@pytest.mark.icos
 def test_force_allows_storing_twice(mock_retrieve_remote, caplog):
     """Test if retrieving the same data twice does *not* issue a warning if
     `force=True` is passed to `retrieve_atmospheric` (and hence propegated down
@@ -211,6 +213,7 @@ def test_force_allows_storing_twice(mock_retrieve_remote, caplog):
 
     retrieve_atmospheric(site="tac", store="user", force=True, update_mismatch="metadata")
     assert "Skipping data that overlaps existing data" not in caplog.text
+
 
 @pytest.mark.icos
 def test_retrieve_icos_attr_mismatch_error():
@@ -239,36 +242,3 @@ def test_icos_obspack():
     )
 
     assert "icos_smr" in retrieved_data.data
-
-
-# @pytest.fixture
-# def mock_get_station(mocker):
-
-#     from icoscp.station import Station
-
-#     mocker.patch(
-#         "station.get",
-#         return_value=Station(),
-#     )
-
-#     station.get
-
-
-def test_updated_downloaded_data(caplog):
-    """
-    """
-    clear_test_stores()
-
-    # obsdata = retrieve_atmospheric(site="tac",
-    #                                species="ch4",
-    #                                inlet="185m",
-    #                                store="user")
-
-    obsdata = retrieve_atmospheric(site="BIK",
-                                   species = "CH4",
-                                   data_level=2,
-                                   dataset_source="ICOS Combined",
-                                   update_mismatch="from_source",
-                                   store="user")
-
-    print(obsdata)

--- a/tests/retrieve/icos/test_retrieve_icos.py
+++ b/tests/retrieve/icos/test_retrieve_icos.py
@@ -188,7 +188,6 @@ def mock_retrieve_remote(mocker):
     )
 
 
-@pytest.mark.icos
 def test_retrieved_prevents_storing_twice(mock_retrieve_remote, caplog):
     """Test if retrieving the same data twice issues a warning the second time."""
     clear_test_stores()
@@ -200,7 +199,6 @@ def test_retrieved_prevents_storing_twice(mock_retrieve_remote, caplog):
     assert "Skipping data that overlaps existing data" in caplog.text
 
 
-@pytest.mark.icos
 def test_force_allows_storing_twice(mock_retrieve_remote, caplog):
     """Test if retrieving the same data twice does *not* issue a warning if
     `force=True` is passed to `retrieve_atmospheric` (and hence propegated down
@@ -213,7 +211,6 @@ def test_force_allows_storing_twice(mock_retrieve_remote, caplog):
 
     retrieve_atmospheric(site="tac", store="user", force=True, update_mismatch="metadata")
     assert "Skipping data that overlaps existing data" not in caplog.text
-
 
 @pytest.mark.icos
 def test_retrieve_icos_attr_mismatch_error():
@@ -242,3 +239,36 @@ def test_icos_obspack():
     )
 
     assert "icos_smr" in retrieved_data.data
+
+
+# @pytest.fixture
+# def mock_get_station(mocker):
+
+#     from icoscp.station import Station
+
+#     mocker.patch(
+#         "station.get",
+#         return_value=Station(),
+#     )
+
+#     station.get
+
+
+def test_updated_downloaded_data(caplog):
+    """
+    """
+    clear_test_stores()
+
+    # obsdata = retrieve_atmospheric(site="tac",
+    #                                species="ch4",
+    #                                inlet="185m",
+    #                                store="user")
+
+    obsdata = retrieve_atmospheric(site="BIK",
+                                   species = "CH4",
+                                   data_level=2,
+                                   dataset_source="ICOS Combined",
+                                   update_mismatch="from_source",
+                                   store="user")
+
+    print(obsdata)

--- a/tests/store/storage/test_localzarrstore.py
+++ b/tests/store/storage/test_localzarrstore.py
@@ -113,7 +113,8 @@ def test_bytes_stored_compression(store):
     with xr.open_dataset(datapath) as ds:
         store.add(version="v1", dataset=ds, compressor=None)
         uncompressed_bytes = store.bytes_stored()
-        assert store.bytes_stored() == 444382
+        expected_uncompressed_bytes = 444382
+        np.testing.assert_allclose(uncompressed_bytes, expected_uncompressed_bytes, rtol=0.01)
 
     store.delete_all()
 
@@ -121,7 +122,8 @@ def test_bytes_stored_compression(store):
     with xr.open_dataset(datapath) as ds:
         store.add(version="v1", dataset=ds, compressor=compressor)
         compressed_bytes = store.bytes_stored()
-        assert np.abs((compressed_bytes - 292896) / 292896) < 0.01
+        expected_compressed_bytes = 292896
+        np.testing.assert_allclose(compressed_bytes, expected_compressed_bytes, rtol=0.01)
         assert compressed_bytes < original_size
         assert compressed_bytes < uncompressed_bytes
 

--- a/tests/store/test_flux.py
+++ b/tests/store/test_flux.py
@@ -48,7 +48,8 @@ def test_read_binary_data(mocker, clear_stores):
     assert filt(results, species="co2", source="gpp-cardamom", domain="europe")[0]["new"] is True
 
 
-def test_read_file():
+def test_read_file(caplog):
+    clear_test_stores()
     test_datapath = get_flux_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
 
     proc_results = standardise_flux(
@@ -62,6 +63,9 @@ def test_read_file():
     )
 
     assert len(proc_results) == 1
+
+    assert "Rechunking with chunks" in caplog.text
+    assert "'time': 336" in caplog.text
 
     expected_info = {"species": "co2", "source": "gpp-cardamom", "domain": "europe"}
     assert expected_info.items() <= proc_results[0].items()


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The `Flux` class now has a "chunking schema". This allows ~time resolved~ flux data to be standardised, regardless of the length of the time coordinate in the raw data.

An option to automatically scale the chunk sizes to fit within the maximum (defaults to 300MB) was added, mostly because some flux tests use the global edgar domain, which is very large.

It would make sense to chunk the lat/lon dimensions of the global edgar domain (or any large domain), but that is somewhat beyond what I wanted to achieve in this bug fix.


* **Please check if the PR fulfills these requirements**

- [x] Closes #1431
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature: expanded an existing test to check for the logging messages that show the chunking schema has been applied
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

----
Not needed

- Documentation updated/added
- Tutorials updated/added
- Wiki updated
-  Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
