### PR TITLE
Removed warning about empty zarr store

### DIFF
--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -376,14 +376,12 @@ def _check_valid_store(store_path: Path) -> bool:
     data_dir = Path(store_path).joinpath("data")
     # Now check if there's a zarr folder in the data directory
     store_dirs = list(data_dir.glob("*"))
-    # Let's take the first data directory and see if there's a zarr folder in it
+
+    # if no store dirs, assume this is an empty zarr store
     if not store_dirs:
-        logger.info(
-            f"No data found in the object store {store_path}, "
-            "so we are treating this empty store as a zarr store."
-        )
         return True
 
+    # Let's take the first data directory and see if there's a zarr folder in it
     store_data_dir = store_dirs[0]
 
     return store_data_dir.joinpath("zarr").exists()


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

If a store is empty, we treat it as a zarr store, for the purpose of checking if a store is in zarr format, or OpenGHG <= 0.7 format.

This message runs every time you fetch data for an inversion, so it really clutters up the inversion logs.

We could switch to `warnings.warn` and set a filter, but I've just opted to remove the warning.


* **Please check if the PR fulfills these requirements**

- Closes #xxxx (Replace xxxx with the Github issue number)
- [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- Documentation updated/added
- Tutorials updated/added
- Wiki updated
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*
