### PR TITLE
Update conda.yaml to use input python versions and a micromamba runner version

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -24,16 +24,17 @@ jobs:
       max-parallel: 3
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
-        # python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
-      - uses: mamba-org/setup-micromamba@8752438cc2755ab7d0de2a8d70b694f5586baae8
+      - uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment-dev.yaml
           cache-environment: true
           post-cleanup: "all"
           init-shell: bash
+          create-args: >-
+            python=${{ matrix.python-version }}
       - name: Install OpenGHG
         run: conda develop .
         shell: micromamba-shell {0}


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

For the conda (micromamba) CI runner, this was not running against the python version specified in the matrix input. This PR updates this to:
 - Make sure the python version is passed to the micromamba runner
 - The CI is run for the same versions as for PyPi (3.10, 3.11, 3.12)
 - The micromamba runner version is updated to `v2` rather than a specific commit hash so this is able to use the latest version of the runner.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1446 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature

Not needed
- All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- Documentation updated/added
- Tutorials updated/added
- Wiki updated
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
