### PR TITLE
Drop pin for icoscp and update authentication details in the docs

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["test", "docs", "release_testpypi"]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') && contains(github.ref_name, '.')
-    environment: 
+    environment:
       name: pypi
       url: https://pypi.org/p/openghg
     permissions:
@@ -176,5 +176,5 @@ jobs:
           BUILD=$(find "$BUILD_DIR" -name '*.tar.bz2')
           anaconda --token "$ANACONDA_TOKEN" upload --user openghg --label main "$BUILD"
         env:
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN_EXP_2025_08_14 }}
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN_EXP_2030_08_29 }}
           GIT_TAG: ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.16.0...HEAD)
 
+## Updated
+
+- Removed pinning of `icoscp` from 0.17.0 and adding details of how to use the new authentication method to the tutorials. [PR #1447](https://github.com/openghg/openghg/pull/1447)
+
 ## [0.16.0] - 2025-08-29
 
 ### Added

--- a/doc/source/tutorials/local/Exploring_data/Retrieving_remote_data.rst
+++ b/doc/source/tutorials/local/Exploring_data/Retrieving_remote_data.rst
@@ -21,11 +21,36 @@ object store.
 1. ICOS
 -------
 
-It's easy to retrieve atmospheric gas measurements from the `ICOS Carbon
+Atmospheric gas measurements can be retrieved from the `ICOS Carbon
 Portal`_  using OpenGHG. To do so we'll use the ``retrieve_atmospheric``
 function from ``openghg.retrieve.icos``.
 
 .. _`ICOS Carbon Portal`: https://www.icos-cp.eu/observations/carbon-portal
+
+Authentication
+~~~~~~~~~~~~~~
+
+To access the ICOS Carbon Portal we use the `icoscp` module which requires
+an account to have been set up and some authentication steps to be followed: 
+https://icos-carbon-portal.github.io/pylib/icoscp/authentication/.
+
+As of 02/09/2025 (icoscp v0.2.2), this can be set up once by creating a personal account
+(not an institutional account) which has a username and password and running the
+following:
+
+.. ipython::
+   :verbatim:
+
+   from icoscp_core.icos import auth
+   auth.init_config_file()
+
+This should prompt the user to supply their username and password and should only need to be run once.
+Note that the credentials (API key) to access your ICOS account will be refreshed
+every 27 hours but running the above lines of code should allow this to be automatically resfreshed.
+
+*If after running these lines of code, an `AuthenticationError` is received when
+accessing the functions in the `openghg.retrieve.icos` module please check the latest
+Authentication details from icoscp and follow any instructions provided.*
 
 Checking available data
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -91,8 +116,8 @@ Let's say we want to look at the ICOS dataset, we can select that first dataset
 
     In [9]: sac_data_icos = sac_data[0]
 
-    In [11]: sac_data_icos
-    Out[11]:
+    In [10]: sac_data_icos
+    Out[10]:
     ObsData(data=<xarray.Dataset>
     Dimensions:                     (time: 40510)
     Coordinates:
@@ -130,11 +155,11 @@ in the ``instrument_data`` section of the metadata
 .. ipython::
     :verbatim:
 
-    In [14]: metadata = sac_data_icos.metadata
+    In [11]: metadata = sac_data_icos.metadata
 
-    In [15]: metadata["instrument_data"]
+    In [12]: metadata["instrument_data"]
 
-    In [16]: metadata["citation_string"]
+    In [13]: metadata["citation_string"]
 
 Here we get the instrument name and a link to the instrument data on the
 ICOS Carbon Portal.
@@ -151,7 +176,7 @@ As with any ``ObsData`` object we can quickly plot it to have a look.
 .. ipython::
     :verbatim:
 
-    In [17]:  sac_data_icos.plot_timeseries()
+    In [14]:  sac_data_icos.plot_timeseries()
 
 Data levels
 ~~~~~~~~~~~
@@ -176,11 +201,11 @@ Below we'll retrieve some more recent data from **SAC**.
 .. ipython::
     :verbatim:
 
-    In [2]: sac_data_level1 = retrieve_atmospheric(site="SAC", species="CH4", sampling_height="100m", data_level=1, dataset_source="icos")
+    In [15]: sac_data_level1 = retrieve_atmospheric(site="SAC", species="CH4", sampling_height="100m", data_level=1, dataset_source="icos")
 
-    In [4]: sac_data_level1.data.time[0]
+    In [16]: sac_data_level1.data.time[0]
 
-    In [7]: sac_data_level1.data.time[-1]
+    In [17]: sac_data_level1.data.time[-1]
 
 You can see that we've now got quite recent data, usually up until a day or so before these docs were built. The
 ability to retrieve different level data has been added for convenience, choose the best option for your workflow.
@@ -188,7 +213,7 @@ ability to retrieve different level data has been added for convenience, choose 
 .. ipython::
     :verbatim:
 
-    In [10]: sac_data_level1.plot_timeseries(title="SAC - Level 1 data")
+    In [18]: sac_data_level1.plot_timeseries(title="SAC - Level 1 data")
 
 Forcing retrieval
 ~~~~~~~~~~~~~~~~~
@@ -203,7 +228,7 @@ portal) you can force a retrieval using ``force_retrieval``.
 .. ipython::
     :verbatim:
 
-    In [11]: new_data = retrieve_atmospheric(site="SAC", species="CH4", data_level=1, force_retrieval=True)
+    In [19]: new_data = retrieve_atmospheric(site="SAC", species="CH4", data_level=1, force_retrieval=True)
 
 Here we get a message telling us there is no new data to
 process, this will depend on the rate at which datasets are updated on the ICOS Carbon Portal.

--- a/doc/source/tutorials/local/Exploring_data/Retrieving_remote_data.rst
+++ b/doc/source/tutorials/local/Exploring_data/Retrieving_remote_data.rst
@@ -41,16 +41,15 @@ following:
 .. ipython::
    :verbatim:
 
-   from icoscp_core.icos import auth
-   auth.init_config_file()
+   In [1]: from icoscp_core.icos import auth
+   Out [1]: auth.init_config_file()
 
 This should prompt the user to supply their username and password and should only need to be run once.
 Note that the credentials (API key) to access your ICOS account will be refreshed
-every 27 hours but running the above lines of code should allow this to be automatically resfreshed.
+every 27 hours but running the above lines of code should allow this to be automatically refreshed.
 
 *If after running these lines of code, an `AuthenticationError` is received when
-accessing the functions in the `openghg.retrieve.icos` module please check the latest
-Authentication details from icoscp and follow any instructions provided.*
+accessing the functions in the `openghg.retrieve.icos` module please check the latest Authentication details from icoscp and follow any instructions provided.*
 
 Checking available data
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/environment.yaml
+++ b/environment.yaml
@@ -44,4 +44,4 @@ dependencies:
   - networkx
   - openghg_calscales
   - pip:
-    - icoscp<=0.1.17
+    - icoscp

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
   - netcdf4
   - nbformat
   - numexpr
-  - numpy
+  - numpy  # Note numpy >= 2.0 is currently included as a pip requirement below
   - nc-time-axis
   - openghg_defs
   - openpyxl
@@ -45,3 +45,6 @@ dependencies:
   - openghg_calscales
   - pip:
     - icoscp
+    - numpy >= 2.0
+# numpy >= 2.0 is included in pip requirements because icoscp will try and downgrade numpy to <2.0
+# - can remove and use definition above again when https://github.com/ICOS-Carbon-Portal/data/issues/391 is resolved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openghg"
-version = "0.15.0"
+version = "0.16.0"
 description = "OpenGHG: A platform for greenhouse​ gas data analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 "filelock",
 "flox",
 "h5netcdf",
-"icoscp <= 0.1.17",
+"icoscp",
 "ipywidgets",
 "matplotlib",
 "msgpack",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 "nc-time-axis",
 "netcdf4",
 "numexpr",
-"numpy",
+"numpy >= 2.0",
 "openghg_defs",
 "openpyxl",
 "pandas >= 2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dask
 filelock
 flox
 h5netcdf
-icoscp <= 0.1.17
+icoscp
 ipywidgets
 matplotlib
 msgpack

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ numcodecs < 0.16
 nc-time-axis
 netcdf4
 numexpr
-numpy
+numpy >= 2.0
 openghg_defs
 openpyxl
 pandas >= 2.0


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The authentication steps for icoscp have been updated and this PR is to bring the docs in line with this. This also drops the current pinning of `icoscp` to 0.17.0 within the requirements as this no longer works with the latest authentication method.

Updated to also ensure `numpy>=2.0` as `icoscp` is currently pinned to `numpy<2.0` but our current code seems to work ok with this.

*As long as this works ok for others, this supercedes PR #1139 - here we move to putting the onus on the icoscp docs to tell us how to authenticate rather than needing to maintain an internal authentication method in openghg. If this PR is merged, that PR can be closed.*

* **Please check if the PR fulfills these requirements**

- [x] Closes #612 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Tutorials updated/added
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new requirements to `requirements.txt`, `environment.yaml` and `pyproject.toml`

Not needed
- Documentation updated/added
- Wiki updated
