### PR TITLE
Added check for negative uncertainties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug causing error due to resampling non-numeric data. [PR #1478](https://github.com/openghg/openghg/pull/1478)
 - Fixed bug in `merge_and_extend_dict` to make sure repeated values in `left` and `right` produce unique values in output and to ensure `left` and `right` are not modified in place. [PR #1477](https://github.com/openghg/openghg/pull/1477)
 
+## Added
+
+- Check for negative uncertainty values (these are converted to NaN). [PR #1480](https://github.com/openghg/openghg/pull/1480)
 
 ## [0.16.0] - 2025-08-29
 

--- a/openghg/retrieve/_access.py
+++ b/openghg/retrieve/_access.py
@@ -210,6 +210,15 @@ def get_obs_surface(
         logger.info("Loading obs data into memory for resampling.")
         data = data.compute()
 
+        # check for negative uncertainties and set to NaN
+        uncertainty_data_vars = [
+            dv
+            for dv in data.data_vars
+            if str(dv).endswith("repeatability") or str(dv).endswith("variability")
+        ]
+        for dv in uncertainty_data_vars:
+            data[dv] = data[dv].where(data[dv] >= 0.0)  # keep data non-negative values, others set to NaN
+
         var_to_delete = []
         for var in data:
             if data[var].isnull().all():


### PR DESCRIPTION
They are converted to NaN before resampling. This only happens if you are resampling the data (I could apply it even if the data isn't resampled, but then the data would need to be loaded into memory.)

* **Summary of changes** (Bug fix, feature, docs update, ...)


* **Please check if the PR fulfills these requirements**

- [x] Closes #1479
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature (tests passed, but no new test added; the change seems to fix the problem with ICOS data with -9.99 in an uncertainty variable)
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- Documentation updated/added
- Tutorials updated/added
- Wiki updated
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*
