### PR TITLE
Removing delete test from test_obssurface - this was an xfail and no longer functions as expected anyway

### DIFF
--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -500,39 +500,6 @@ def test_read_noaa_metastorepack(bucket):
         ch4_data["ch4_variability"][0] == pytest.approx(1.668772e-09)
 
 
-@pytest.mark.xfail(reason="Deleting datasources will be handled by ObjectStore objects - links to issue #727")
-def test_delete_Datasource(bucket):  # TODO: revive/move this test when `ObjectStore` class created
-    data_filepath = get_surface_datapath(
-        filename="DECC-picarro_TAC_20130131_co2-185m-20220928.nc", source_format="OPENGHG"
-    )
-
-    standardise_surface(
-        store="user",
-        filepath=data_filepath,
-        source_format="OPENGHG",
-        site="tac",
-        network="DECC",
-        instrument="picarro",
-        sampling_period="1h",
-        update_mismatch="attributes",
-        if_exists="new",
-        sort_files=True,
-    )
-
-    with open_object_store(data_type="surface", bucket=bucket) as objstore:
-        uuid = objstore.uuids[0]
-        datasource = objstore.get_datasource(uuid=uuid)
-        data_keys = datasource.data_keys()
-        key = data_keys[0]
-
-        assert exists(bucket=bucket, key=key)
-
-        objstore.delete(uuid)
-
-        assert uuid not in objstore.uuids
-        assert not exists(bucket=bucket, key=key)
-
-
 def test_add_new_data_correct_datasource():
     clear_test_stores()
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

As a comment in #727 and linked to a comment on previously merged PR [#771](https://github.com/openghg/openghg/pull/771#discussion_r1320158176), there was a plan to refactor a test around deletion of data from a Datasource.

When this test ran previously, this test used the `ObsSurface.delete` method (which no longer exists). This was updated to be `ObjectStore.delete` method but this doesn't pass anyway as this is reliant on old behaviour (currently marked as xfail).

This PR removes this test as this is not useful anymore and checking equivalent functionality would be better as a new test.

* **Please check if the PR fulfills these requirements**

- [x] Tracked using #727 but does not close this
- [x] [Xfail test removed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors

Not needed
- Documentation updated/added
- Tutorials updated/added
- Wiki updated
- Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
