### PR TITLE
Created util._logging submodule and made log location configurable via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unit parsing ambiguities by keeping the Pint registry case-sensitive for SI abbreviations and adding explicit case-variant aliases for coordinate and time units (e.g. `Degrees_North`, `Hours`). [PR #1599](https://github.com/openghg/openghg/pull/1599)
 - Fixed `convert_to_slice` to use `abs(input)` when computing the relative tolerance range, ensuring that negative inlet values (eg. for sites below sea level) are correctly matched during data retrieval. [PR #1605](https://github.com/openghg/openghg/pull/1605)
 
+### Added
+
+- Option to set location of openghg log via an environment variable `OPENGHG_LOG_PATH`. [PR #1607](https://github.com/openghg/openghg/pull/1607)
+
 ## [0.18.0] - 2026-02-18
 
 ### Added

--- a/openghg/__init__.py
+++ b/openghg/__init__.py
@@ -1,8 +1,5 @@
-import logging
 import sys as _sys
-from pathlib import Path as _Path
 
-from rich.logging import RichHandler as _RichHandler
 from . import (
     analyse,
     dataobjects,
@@ -16,6 +13,8 @@ from . import (
     tutorial,
     util,
 )
+from openghg.util._logging import configure_logger
+from openghg.util._user import get_dot_openghg_path
 
 __all__ = [
     "analyse",
@@ -49,27 +48,8 @@ __branch__ = None
 __repository__ = None
 __revisionid__ = None
 
-# Start module level logging
-logger = logging.getLogger("openghg")
-logger.setLevel(logging.DEBUG)
-logging.captureWarnings(capture=True)
-
-logfile_path = str(_Path.home().joinpath("openghg.log"))
-
-# Create file handler for log file - set to DEBUG (maximum detail)
-fileHandler = logging.FileHandler(logfile_path)  # May want to update this to user area
-fileFormatter = logging.Formatter(
-    "%(asctime)s:%(levelname)s:%(name)s:%(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"
-)
-fileHandler.setFormatter(fileFormatter)
-fileHandler.setLevel(logging.DEBUG)
-logger.addHandler(fileHandler)
-
-# Create console handler - set to WARNING (lower level)
-consoleHandler = _RichHandler()
-consoleFormatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z")
-consoleHandler.setFormatter(consoleFormatter)
-consoleHandler.setLevel(logging.INFO)
-logger.addHandler(consoleHandler)
-
-del logfile_path
+# Configure the logger
+# the log files live in subdir "logs" of the path where
+# the OpenGHG config is stored.
+default_log_path = get_dot_openghg_path() / "logs"
+logger = configure_logger(default_log_path)

--- a/openghg/util/_logging.py
+++ b/openghg/util/_logging.py
@@ -1,0 +1,90 @@
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from rich.logging import RichHandler
+
+
+def _get_logfile_path(default_log_dir: Path | None = None) -> Path:
+    """Return the log file path for OpenGHG.
+
+    Args:
+        default_log_dir: optional default for logs. This is passed as an argument
+            because the location of the openghg config dir is set in util._user.
+
+    Returns:
+        Path to log file.
+    """
+    env_path = os.environ.get("OPENGHG_LOG_PATH")
+    if env_path:
+        return Path(env_path).expanduser()
+
+    default_log_dir = default_log_dir or Path.home()  # fall back to $HOME
+    return default_log_dir / "openghg.log"
+
+
+def _has_file_handler_for_path(logger: logging.Logger, logfile_path: Path) -> bool:
+    """Return True if logger already has a file handler for logfile_path."""
+    target_path = logfile_path.resolve()
+
+    for handler in logger.handlers:
+        if isinstance(handler, logging.FileHandler):
+            handler_path = getattr(handler, "baseFilename", None)
+            if handler_path is not None and Path(handler_path).resolve() == target_path:
+                return True
+
+    return False
+
+
+def _has_rich_handler(logger: logging.Logger) -> bool:
+    """Return True if logger already has a Rich console handler."""
+    return any(isinstance(handler, RichHandler) for handler in logger.handlers)
+
+
+def configure_logger(default_log_dir: Path | None = None) -> logging.Logger:
+    """Configure and return the OpenGHG logger.
+
+    This is safe to call multiple times. Repeated calls reuse the same named
+    logger and avoid adding duplicate handlers.
+
+    Args:
+        default_log_dir: optional default for logs. This is passed as an argument
+            because the location of the openghg config dir is set in util._user.
+
+    Returns:
+        Configured logger.
+    """
+    logger = logging.getLogger("openghg")
+    logger.setLevel(logging.DEBUG)
+    logging.captureWarnings(capture=True)
+
+    logfile_path = _get_logfile_path(default_log_dir)
+    logfile_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not _has_file_handler_for_path(logger, logfile_path):
+        file_handler = RotatingFileHandler(
+            logfile_path,
+            maxBytes=10 * 1024 * 1024,  # 10MiB limit
+            backupCount=10,
+            encoding="utf-8",
+        )
+        file_formatter = logging.Formatter(
+            "%(asctime)s:%(levelname)s:%(name)s:%(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+        file_handler.setFormatter(file_formatter)
+        file_handler.setLevel(logging.DEBUG)
+        logger.addHandler(file_handler)
+
+    if not _has_rich_handler(logger):
+        console_handler = RichHandler()
+        console_formatter = logging.Formatter(
+            "%(levelname)s:%(name)s:%(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+        console_handler.setFormatter(console_formatter)
+        console_handler.setLevel(logging.INFO)
+        logger.addHandler(console_handler)
+
+    return logger

--- a/openghg/util/_user.py
+++ b/openghg/util/_user.py
@@ -34,16 +34,15 @@ def get_default_objectstore_path() -> Path:
     return Path.home().joinpath("openghg_store").absolute()
 
 
-# @lru_cache
-def get_user_config_path() -> Path:
-    """Returns path to user config file.
+def get_dot_openghg_path() -> Path:
+    """Returns path to the user OpenGHG configuration directory.
 
-    This file is created in the user's home directory
-    in  ~/.ghgconfig/openghg/user.conf on Linux / macOS or
-    in LOCALAPPDATA/openghg/openghg.conf on Windows.
+    This directory is created in the user's home directory
+    as ~/.openghg on Linux / macOS or in LOCALAPPDATA/openghg
+    on Windows.
 
     Returns:
-        pathlib.Path: Path to user config file
+        pathlib.Path: Path to the user OpenGHG configuration directory
     """
     user_platform = platform.system()
 
@@ -52,13 +51,26 @@ def get_user_config_path() -> Path:
         if appdata_path is None:
             raise ValueError("Unable to read LOCALAPPDATA environment variable.")
 
-        config_path = Path(appdata_path).joinpath("openghg", openghg_config_filename)
+        config_dir = Path(appdata_path).joinpath("openghg")
     elif user_platform in ("Linux", "Darwin"):
-        config_path = Path.home().joinpath(".openghg", openghg_config_filename)
+        config_dir = Path.home().joinpath(".openghg")
     else:
         raise ValueError(f"Unknown platform: {user_platform}")
 
-    return config_path
+    return config_dir
+
+
+def get_user_config_path() -> Path:
+    """Returns path to user config file.
+
+    This file is created in the user's home directory
+    in ~/.openghg/openghg.conf on Linux / macOS or
+    in LOCALAPPDATA/openghg/openghg.conf on Windows.
+
+    Returns:
+        pathlib.Path: Path to user config file
+    """
+    return get_dot_openghg_path().joinpath(openghg_config_filename)
 
 
 def create_config(silent: bool = False) -> None:

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -1,0 +1,127 @@
+import logging
+from pathlib import Path
+
+import pytest
+from rich.logging import RichHandler
+
+import openghg.util._logging as logging_module
+
+
+def _clear_openghg_logger() -> None:
+    """Remove and close all handlers from the openghg logger."""
+    logger = logging.getLogger("openghg")
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+
+
+def _reload_logging_module():
+    """Import and reload the logging module after environment changes."""
+    logging_module.configure_logger()
+
+
+def _get_file_handlers() -> list[logging.FileHandler]:
+    """Return file handlers attached to the openghg logger."""
+    logger = logging.getLogger("openghg")
+    return [handler for handler in logger.handlers if isinstance(handler, logging.FileHandler)]
+
+
+def _get_rich_handlers() -> list[RichHandler]:
+    """Return Rich handlers attached to the openghg logger."""
+    logger = logging.getLogger("openghg")
+    return [handler for handler in logger.handlers if isinstance(handler, RichHandler)]
+
+
+@pytest.fixture(autouse=True)
+def clean_logger_state():
+    """Ensure tests do not leak logger handlers into each other."""
+    _clear_openghg_logger()
+    yield
+    _clear_openghg_logger()
+
+
+def test_logging_default_path_uses_home(monkeypatch, tmp_path):
+    """Default log path should resolve to ~/openghg.log when no env var is set."""
+    monkeypatch.delenv("OPENGHG_LOG_PATH", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    _reload_logging_module()
+
+    file_handlers = _get_file_handlers()
+    assert len(file_handlers) == 1
+    assert Path(file_handlers[0].baseFilename) == tmp_path / "openghg.log"
+
+
+def test_logging_env_override(monkeypatch, tmp_path):
+    """OPENGHG_LOG_PATH should override the default log location."""
+    log_path = tmp_path / "logs" / "custom.log"
+    monkeypatch.setenv("OPENGHG_LOG_PATH", str(log_path))
+
+    _reload_logging_module()
+
+    file_handlers = _get_file_handlers()
+    assert len(file_handlers) == 1
+    assert Path(file_handlers[0].baseFilename) == log_path
+    assert log_path.parent.exists()
+
+
+def test_logging_adds_console_handler(monkeypatch, tmp_path):
+    """A Rich console handler should be attached."""
+    monkeypatch.setenv("OPENGHG_LOG_PATH", str(tmp_path / "openghg.log"))
+
+    _reload_logging_module()
+
+    rich_handlers = _get_rich_handlers()
+    assert len(rich_handlers) == 1
+    assert rich_handlers[0].level == logging.INFO
+
+
+def test_logging_does_not_duplicate_handlers_on_reload(monkeypatch, tmp_path):
+    """Repeated imports/reloads should not duplicate file or console handlers."""
+    monkeypatch.setenv("OPENGHG_LOG_PATH", str(tmp_path / "openghg.log"))
+
+    _reload_logging_module()
+    logger = logging.getLogger("openghg")
+    first_handler_count = len(logger.handlers)
+    first_file_handler_count = len(_get_file_handlers())
+    first_rich_handler_count = len(_get_rich_handlers())
+
+    _reload_logging_module()
+    logger = logging.getLogger("openghg")
+    second_handler_count = len(logger.handlers)
+    second_file_handler_count = len(_get_file_handlers())
+    second_rich_handler_count = len(_get_rich_handlers())
+
+    assert second_handler_count == first_handler_count
+    assert second_file_handler_count == first_file_handler_count == 1
+    assert second_rich_handler_count == first_rich_handler_count == 1
+
+
+def test_logging_writes_message_to_file(monkeypatch, tmp_path):
+    """Messages logged through the openghg logger should be written to the file."""
+    log_path = tmp_path / "openghg.log"
+    monkeypatch.setenv("OPENGHG_LOG_PATH", str(log_path))
+
+    _reload_logging_module()
+
+    logger = logging.getLogger("openghg")
+    test_message = "test message from pytest"
+    logger.info(test_message)
+
+    for handler in logger.handlers:
+        if hasattr(handler, "flush"):
+            handler.flush()
+
+    assert log_path.exists()
+    contents = log_path.read_text(encoding="utf-8")
+    assert test_message in contents
+
+
+def test_logging_logger_level_is_debug(monkeypatch, tmp_path):
+    """The openghg logger should be configured at DEBUG level."""
+    monkeypatch.setenv("OPENGHG_LOG_PATH", str(tmp_path / "openghg.log"))
+
+    _reload_logging_module()
+
+    logger = logging.getLogger("openghg")
+    assert logger.level == logging.DEBUG


### PR DESCRIPTION
The log location can be set using the environment variable OPENGHG_LOG_PATH.

The default is now ~/.openghg/logs/openghg.log

Log files are rotated after they reach 10MB. Ten backup logs will be kept, so you can have up to 100MB of logs before they start getting deleted.

A test suite was added to check that setting the environment variable works.

* **Summary of changes** (Bug fix, feature, docs update, ...)


* **Please check if the PR fulfills these requirements**

- Closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- Documentation updated/added
- Tutorials updated/added
- Wiki updated
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new package requirements to `pyproject.toml` [dependencies section] and `recipes/meta.yaml`

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*
