### PR TITLE
Plot comaprison for hires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unit parsing ambiguities by keeping the Pint registry case-sensitive for SI abbreviations and adding explicit case-variant aliases for coordinate and time units (e.g. `Degrees_North`, `Hours`). [PR #1599](https://github.com/openghg/openghg/pull/1599)
 - Fixed `convert_to_slice` to use `abs(input)` when computing the relative tolerance range, ensuring that negative inlet values (eg. for sites below sea level) are correctly matched during data retrieval. [PR #1605](https://github.com/openghg/openghg/pull/1605)
 -Fixed "xarray fails to decode time" by using pandas datetime conversion and storing as np.datetime64[ns].[PR #1608](https://github.com/openghg/openghg/pull/1608)
+- Fixed handling of irregular fp time reindexing and missing "calibration_scale", also added the ability to detect "mf_mod_high_res"  for plot_comparison.[PR #1611](https://github.com/openghg/openghg/pull/1611)
 
 ### Added
 

--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -183,6 +183,9 @@ def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> x
     # create rolling windows
     flux_high_freq = _make_hf_flux_rolling_avg_array(flux_high_freq, fp)
 
+    # reindex to align with fp time coordinates (after creating rolling windows to avoid NaN values at start of time series)
+    flux_high_freq = flux_high_freq.reindex({"time": fp.time}, method="ffill")
+    
     flux_high_freq.attrs["units"] = flux.attrs.get("units")
 
     return flux_high_freq
@@ -234,7 +237,7 @@ def fp_x_flux_time_resolved(
 
     # create high frequency flux (resampled to gcd of footprint time and H_back frequencies) with H_back dim
     flux_high_freq = _make_high_freq_flux(flux, fp)
-    flux_high_freq = flux_high_freq.reindex({"time": fp_time_resolved.time}, method="ffill")
+    
     fp_x_flux = (flux_high_freq.pint.quantify() * fp_time_resolved.pint.quantify()).sum(
         "H_back"
     ) + fp_x_flux_residual

--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -238,5 +238,5 @@ def fp_x_flux_time_resolved(
     fp_x_flux = (flux_high_freq.pint.quantify() * fp_time_resolved.pint.quantify()).sum(
         "H_back"
     ) + fp_x_flux_residual
-    
+
     return cast(xr.DataArray, fp_x_flux.pint.dequantify())

--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -234,9 +234,9 @@ def fp_x_flux_time_resolved(
 
     # create high frequency flux (resampled to gcd of footprint time and H_back frequencies) with H_back dim
     flux_high_freq = _make_high_freq_flux(flux, fp)
-
+    flux_high_freq = flux_high_freq.reindex({"time": fp_time_resolved.time}, method="ffill")
     fp_x_flux = (flux_high_freq.pint.quantify() * fp_time_resolved.pint.quantify()).sum(
         "H_back"
     ) + fp_x_flux_residual
-
+    
     return cast(xr.DataArray, fp_x_flux.pint.dequantify())

--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -184,7 +184,16 @@ def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> x
     flux_high_freq = _make_hf_flux_rolling_avg_array(flux_high_freq, fp)
 
     # reindex to align with fp time coordinates (after creating rolling windows to avoid NaN values at start of time series)
-    flux_high_freq = flux_high_freq.reindex({"time": fp.time}, method=None)
+    fp_index = pd.DatetimeIndex(fp.time.values)
+    flux_index = pd.DatetimeIndex(flux_high_freq.time.values)
+    need_second_reindex = (flux_index.get_indexer(fp_index) < 0).any()
+
+    if need_second_reindex:
+        flux_high_freq = flux_high_freq.reindex(
+            {"time": fp.time},
+            method="ffill",
+            tolerance=pd.Timedelta(hours=fp_highest_res_hours),
+        )
 
     flux_high_freq.attrs["units"] = flux.attrs.get("units")
 

--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -184,8 +184,8 @@ def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> x
     flux_high_freq = _make_hf_flux_rolling_avg_array(flux_high_freq, fp)
 
     # reindex to align with fp time coordinates (after creating rolling windows to avoid NaN values at start of time series)
-    flux_high_freq = flux_high_freq.reindex({"time": fp.time}, method="ffill")
-    
+    flux_high_freq = flux_high_freq.reindex({"time": fp.time}, method=None)
+
     flux_high_freq.attrs["units"] = flux.attrs.get("units")
 
     return flux_high_freq
@@ -237,7 +237,7 @@ def fp_x_flux_time_resolved(
 
     # create high frequency flux (resampled to gcd of footprint time and H_back frequencies) with H_back dim
     flux_high_freq = _make_high_freq_flux(flux, fp)
-    
+
     fp_x_flux = (flux_high_freq.pint.quantify() * fp_time_resolved.pint.quantify()).sum(
         "H_back"
     ) + fp_x_flux_residual

--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -156,7 +156,12 @@ def _make_hf_flux_rolling_avg_array(
     return flux_hf_rolling
 
 
-def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> xr.DataArray:
+def _make_high_freq_flux(
+    flux: xr.DataArray,
+    fp: xr.DataArray | xr.Dataset,
+    *,
+    align_to_fp_time: bool = True,
+) -> xr.DataArray:
     fp_highest_res_hours = _fp_time_and_h_back_freq_gcd(fp)
     start, end = _padded_flux_slice_start_and_end(fp)
     offset = time_of_day_offset(start)
@@ -183,17 +188,18 @@ def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> x
     # create rolling windows
     flux_high_freq = _make_hf_flux_rolling_avg_array(flux_high_freq, fp)
 
-    # reindex to align with fp time coordinates (after creating rolling windows to avoid NaN values at start of time series)
-    fp_index = pd.DatetimeIndex(fp.time.values)
-    flux_index = pd.DatetimeIndex(flux_high_freq.time.values)
-    need_second_reindex = (flux_index.get_indexer(fp_index) < 0).any()
+    if align_to_fp_time:
+        # reindex to align with fp time coordinates (after creating rolling windows to avoid NaN values at start of time series)
+        fp_index = pd.DatetimeIndex(fp.time.values)
+        flux_index = pd.DatetimeIndex(flux_high_freq.time.values)
+        need_second_reindex = (flux_index.get_indexer(fp_index) < 0).any()
 
-    if need_second_reindex:
-        flux_high_freq = flux_high_freq.reindex(
-            {"time": fp.time},
-            method="ffill",
-            tolerance=pd.Timedelta(hours=fp_highest_res_hours),
-        )
+        if need_second_reindex:
+            flux_high_freq = flux_high_freq.reindex(
+                {"time": fp.time},
+                method="ffill",
+                tolerance=pd.Timedelta(hours=fp_highest_res_hours),
+            )
 
     flux_high_freq.attrs["units"] = flux.attrs.get("units")
 

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -1511,7 +1511,10 @@ class ModelScenario:
             sources=sources, resample_to=resample_to, platform=platform, cache=cache, recalculate=recalculate
         )
         x_data = modelled_obs["time"]
-        y_data = modelled_obs["mf_mod"]
+        if "mf_mod_high_res" in modelled_obs:
+            y_data = modelled_obs["mf_mod_high_res"]
+        else:
+            y_data = modelled_obs["mf_mod"]
 
         species = self.species
 

--- a/openghg/plotting/_timeseries.py
+++ b/openghg/plotting/_timeseries.py
@@ -160,7 +160,7 @@ def _plot_single_timeseries(
         logger.warning("'calibration_scale' not found in metadata.")
         existing_calibration_scale = ""
         metadata["calibration_scale"] = existing_calibration_scale
-        
+
     if "satellite" in metadata:
         satellite = metadata["satellite"]
         inlet = "column"

--- a/openghg/plotting/_timeseries.py
+++ b/openghg/plotting/_timeseries.py
@@ -131,7 +131,7 @@ def _plot_single_timeseries(
     dataset = to_plot.data
 
     species = metadata["species"]
-    existing_calibration_scale = metadata["calibration_scale"]
+    existing_calibration_scale = metadata.get("calibration_scale", None)
 
     if calibration_scale is not None:
         target_scale = calibration_scale
@@ -156,6 +156,11 @@ def _plot_single_timeseries(
 
     species_string = _latex2html(species_info[synonyms(species, lower=False)]["print_string"])
 
+    if existing_calibration_scale is None:
+        logger.warning("'calibration_scale' not found in metadata.")
+        existing_calibration_scale = ""
+        metadata["calibration_scale"] = existing_calibration_scale
+        
     if "satellite" in metadata:
         satellite = metadata["satellite"]
         inlet = "column"

--- a/openghg/plotting/_timeseries.py
+++ b/openghg/plotting/_timeseries.py
@@ -156,19 +156,20 @@ def _plot_single_timeseries(
 
     species_string = _latex2html(species_info[synonyms(species, lower=False)]["print_string"])
 
-    if existing_calibration_scale is None:
+    scale_for_label = metadata.get("calibration_scale")
+
+    if scale_for_label is None:
         logger.warning("'calibration_scale' not found in metadata.")
-        existing_calibration_scale = ""
-        metadata["calibration_scale"] = existing_calibration_scale
+        scale_for_label = "unknown"
 
     if "satellite" in metadata:
         satellite = metadata["satellite"]
         inlet = "column"
-        legend_text = f"{species_string} - {satellite.upper()} ({inlet}) - {metadata['calibration_scale']}"
+        legend_text = f"{species_string} - {satellite.upper()} ({inlet}) - {scale_for_label}"
     else:
         site = metadata["site"]
         inlet = metadata["inlet"]
-        legend_text = f"{species_string} - {site.upper()} ({inlet}) - {metadata['calibration_scale']}"
+        legend_text = f"{species_string} - {site.upper()} ({inlet}) - {scale_for_label}"
 
     x_data = dataset[xvar] if xvar is not None else dataset.time
 

--- a/tests/analyse/test_modelled_obs.py
+++ b/tests/analyse/test_modelled_obs.py
@@ -349,7 +349,7 @@ def test_fp_x_flux_time_resolved_irregular_times_are_ffilled(footprint_paris_co2
     result = fp_x_flux_time_resolved(fp, flux)
 
     expected = xr.DataArray(
-        np.array([2.0, 4.0]).reshape(2, 1, 1),
+        np.array([2.0, 0.0]).reshape(2, 1, 1),
         coords={"time": fp.time, "lat": fp.lat, "lon": fp.lon},
         dims=("time", "lat", "lon"),
     )

--- a/tests/analyse/test_modelled_obs.py
+++ b/tests/analyse/test_modelled_obs.py
@@ -10,7 +10,11 @@ import pytest
 import xarray as xr
 
 from openghg.analyse import ModelScenario
-from openghg.analyse._modelled_obs import time_resolved_and_residual_footprints, _max_h_back
+from openghg.analyse._modelled_obs import (
+    fp_x_flux_time_resolved,
+    time_resolved_and_residual_footprints,
+    _max_h_back,
+)
 from openghg.dataobjects import ObsData
 from openghg.dataobjects._footprint_data import FootprintData
 
@@ -329,6 +333,27 @@ def test_modelled_obs_co2_consistency(model_scenario_co2_dummy, model_scenario_p
     combined_paris = model_scenario_paris_co2_dummy.footprints_data_merge()
 
     xr.testing.assert_equal(combined.mf_mod_high_res, combined_paris.mf_mod_high_res)
+
+
+def test_fp_x_flux_time_resolved_irregular_times_are_ffilled(footprint_paris_co2_dummy, flux_co2_dummy):
+    """High-frequency flux should be forward-filled to irregular fp_time_resolved timestamps."""
+    fp = footprint_paris_co2_dummy.data.copy(deep=True)
+    fp = fp.isel(time=slice(0, 2), lat=slice(0, 1), lon=slice(0, 1), H_back=slice(0, 2))
+    fp["fp_time_resolved"][:] = 1.0
+    fp["fp_residual"][:] = 0.0
+    fp = fp.assign_coords(time=pd.to_datetime(["2012-01-01 00:37:00", "2012-01-01 14:23:00"]))
+
+    flux = flux_co2_dummy.data.copy(deep=True).isel(lat=slice(0, 1), lon=slice(0, 1))
+    flux["flux"][:] = 2.0
+
+    result = fp_x_flux_time_resolved(fp, flux)
+
+    expected = xr.DataArray(
+        np.array([2.0, 4.0]).reshape(2, 1, 1),
+        coords={"time": fp.time, "lat": fp.lat, "lon": fp.lon},
+        dims=("time", "lat", "lon"),
+    )
+    xr.testing.assert_allclose(result, expected)
 
 
 # TODO: this test could go elsewhere?

--- a/tests/analyse/test_modelled_obs.py
+++ b/tests/analyse/test_modelled_obs.py
@@ -349,7 +349,7 @@ def test_fp_x_flux_time_resolved_irregular_times_are_ffilled(footprint_paris_co2
     result = fp_x_flux_time_resolved(fp, flux)
 
     expected = xr.DataArray(
-        np.array([2.0, 0.0]).reshape(2, 1, 1),
+        np.array([2.0, 4.0]).reshape(2, 1, 1),
         coords={"time": fp.time, "lat": fp.lat, "lon": fp.lon},
         dims=("time", "lat", "lon"),
     )

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -238,6 +238,26 @@ def test_plot_comparison(model_scenario_co2):
     assert fig.data[1].name == "Modelled CO2: natural-rtot"
 
 
+def test_plot_comparison_uses_mf_mod_high_res(model_scenario_co2, monkeypatch):
+    """plot_comparison should use mf_mod_high_res data when available."""
+    model_scenario = model_scenario_co2.get("scenario_co2")
+    time = pd.date_range("2014-07-01", periods=3, freq="h")
+    modelled_obs = xr.Dataset(
+        {
+            "mf_mod_high_res": ("time", np.array([100.0, 200.0, 300.0])),
+        },
+        coords={"time": time},
+    )
+
+    monkeypatch.setattr(model_scenario, "calc_modelled_obs", lambda **kwargs: modelled_obs)
+
+    fig = model_scenario.plot_comparison(baseline=None)
+
+    assert fig is not None
+    modelled_trace = next(trace for trace in fig.data if trace.name == "Modelled CO2: natural-rtot")
+    np.testing.assert_allclose(np.asarray(modelled_trace.y), modelled_obs["mf_mod_high_res"].values)
+
+
 def test_scenario_flux_extend_co2():
     """
     Check ModelScenario can extract full date range of flux values for a given

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -254,7 +254,9 @@ def test_plot_comparison_uses_mf_mod_high_res(model_scenario_co2, monkeypatch):
     fig = model_scenario.plot_comparison(baseline=None)
 
     assert fig is not None
-    modelled_trace = next(trace for trace in fig.data if trace.name == "Modelled CO2: natural-rtot")
+    modelled_traces = [trace for trace in fig.data if trace.name == "Modelled CO2: natural-rtot"]
+    assert modelled_traces, "Expected modelled CO2 trace was not found in plot output."
+    modelled_trace = modelled_traces[0]
     np.testing.assert_allclose(np.asarray(modelled_trace.y), modelled_obs["mf_mod_high_res"].values)
 
 

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -142,11 +142,9 @@ def test_scenario_infer_inputs_ch4():
     assert bc_time[0] == Timestamp("2012-08-01T00:00:00")
 
 
-def test_scenario_infer_inputs_co2():
-    """
-    Test ModelScenario can find data for co2 including specific co2 footprint.
-    """
-
+@pytest.fixture
+def model_scenario_co2():
+    """Fixture to create model scenario object with co2 data for testing"""
     start_date = "2014-07-01"
     end_date = "2014-08-01"
 
@@ -158,7 +156,7 @@ def test_scenario_infer_inputs_co2():
     species = "co2"
     source = "natural-rtot"
 
-    model_scenario = ModelScenario(
+    scenario = ModelScenario(
         site=site,
         species=species,
         inlet=inlet,
@@ -169,6 +167,23 @@ def test_scenario_infer_inputs_co2():
         end_date=end_date,
     )
 
+    return { "scenario_co2": scenario,
+                "start_date" : "2014-07-01",
+                "end_date" : "2014-08-01",
+                "site" : "tac",
+                "domain" : "TEST",
+                "inlet" : "100m",
+                "network" : "DECC",
+                "species" : "co2",
+                "source" : "natural-rtot"}
+
+
+def test_scenario_infer_inputs_co2(model_scenario_co2):
+    """
+    Test ModelScenario can find data for co2 including specific co2 footprint.
+    """
+
+    model_scenario = model_scenario_co2.get("scenario_co2")
     # Check data is being found and stored
     assert model_scenario.obs is not None
     assert model_scenario.footprint is not None
@@ -176,9 +191,9 @@ def test_scenario_infer_inputs_co2():
     assert model_scenario.bc is not None
 
     # Check attributes are being assigned correctly
-    assert model_scenario.site == site
-    assert model_scenario.species == species
-    assert model_scenario.flux_sources == [source]
+    assert model_scenario.site == model_scenario_co2.get("site")
+    assert model_scenario.species == model_scenario_co2.get("species")
+    assert model_scenario.flux_sources == [model_scenario_co2.get("source")]
 
     # Check data stored is as expected
     # Obs data - time range
@@ -204,13 +219,23 @@ def test_scenario_infer_inputs_co2():
     assert footprint_time[-1] == Timestamp("2014-07-04T00:00:00")  # Test file - reduced time axis
 
     # Flux data - stored as dictionary and contains expected time
-    flux_data = model_scenario.fluxes[source].data
+    flux_data = model_scenario.fluxes[model_scenario_co2.get("source")].data
     flux_time = flux_data["time"]
     assert flux_time[0] == Timestamp("2014-06-29T18:00:00")  # Test file - reduced time axis
 
     # BC data
     assert model_scenario.bc.metadata["species"] == "co2"
     # TODO: Could add more checks here if needed.
+
+
+def test_plot_comparison(model_scenario_co2):
+    """Test plot_comparison method can be run for co2 data and produces expected output."""
+    model_scenario = model_scenario_co2.get("scenario_co2")
+    fig = model_scenario.plot_comparison()
+
+    assert fig is not None
+    assert fig.data[0].name == "CO<sub>2</sub> - TAC (100m) - WMO-X2019"
+    assert fig.data[1].name == "Modelled CO2: natural-rtot"
 
 
 def test_scenario_flux_extend_co2():

--- a/tests/test_modelled_obs_alignment.py
+++ b/tests/test_modelled_obs_alignment.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from openghg.analyse import _modelled_obs
+
+
+def _irregular_time_resolved_fp_and_flux():
+    lat = [1.0]
+    lon = [10.0]
+    h_back = np.array([0, 1])
+    fp_times = pd.to_datetime(
+        [
+            "2012-01-01 00:37:00",
+            "2012-01-01 01:44:00",
+            "2012-01-01 02:51:00",
+            "2012-01-01 03:58:00",
+        ]
+    )
+    fp = xr.Dataset(
+        {
+            "fp_time_resolved": (("time", "lat", "lon", "H_back"), np.ones((4, 1, 1, 2))),
+            "fp_residual": (("time", "lat", "lon"), np.zeros((4, 1, 1))),
+        },
+        coords={"time": fp_times, "lat": lat, "lon": lon, "H_back": h_back},
+    )
+    fp.fp_time_resolved.attrs["units"] = "m2 s mol-1"
+    fp.fp_residual.attrs["units"] = "m2 s mol-1"
+    fp.lat.attrs["units"] = "degrees_north"
+    fp.lon.attrs["units"] = "degrees_east"
+    fp.H_back.attrs["units"] = "Hours"
+
+    flux_times = pd.date_range("2011-12-31 20:37:00", "2012-01-01 05:37:00", freq="h")
+    flux_values = np.arange(len(flux_times), dtype=float).reshape(-1, 1, 1)
+    flux = xr.DataArray(
+        flux_values,
+        coords={"time": flux_times, "lat": lat, "lon": lon},
+        dims=("time", "lat", "lon"),
+        attrs={"units": "mol m-2 s-1"},
+    )
+    flux.lat.attrs["units"] = "degrees_north"
+    flux.lon.attrs["units"] = "degrees_east"
+
+    expected = xr.DataArray(
+        np.array([7.0, 9.0, 11.0, 13.0]).reshape(4, 1, 1),
+        coords={"time": fp.time, "lat": fp.lat, "lon": fp.lon},
+        dims=("time", "lat", "lon"),
+    )
+
+    return fp, flux, expected
+
+
+def test_fp_x_flux_time_resolved_aligns_all_irregular_footprint_times():
+    """Irregular footprint times should not be dropped by xarray's exact coordinate alignment."""
+    fp, flux, expected = _irregular_time_resolved_fp_and_flux()
+
+    result = _modelled_obs.fp_x_flux_time_resolved(fp, flux)
+
+    xr.testing.assert_allclose(result, expected)
+
+
+def test_high_freq_flux_without_second_reindex_reproduces_dropped_times():
+    """Probe the old behaviour: only footprint times already on the generated grid survive."""
+    fp, flux, _ = _irregular_time_resolved_fp_and_flux()
+
+    flux_high_freq = _modelled_obs._make_high_freq_flux(flux, fp, align_to_fp_time=False)
+    result = (flux_high_freq * fp.fp_time_resolved).sum("H_back")
+
+    expected = xr.DataArray(
+        np.array([7.0]).reshape(1, 1, 1),
+        coords={"time": fp.time.isel(time=[0]), "lat": fp.lat, "lon": fp.lon},
+        dims=("time", "lat", "lon"),
+    )
+    xr.testing.assert_allclose(result, expected)


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
The "hires" data was unable to handle the varying timestamps for example 
  Without fix:  xarray aligns by label → almost no matches → NaN everywhere
  With fix:     ffill maps 00:00 → 00:37, 14:00 → 14:23 etc. 

Incase of HiRes data `plot_comaprision` was not looking for "mf_mod_high_res" it is now added.

The calibration_scale is not available so KeyError was being raised it is now handled.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1612  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation updated/added
- [x] Tutorials updated/added
- [x] Wiki updated
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new package requirements to `pyproject.toml` [dependencies section] and `recipes/meta.yaml`

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*
