### PR TITLE
Clarify datasource versioning and conflict planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unit parsing ambiguities by keeping the Pint registry case-sensitive for SI abbreviations and adding explicit case-variant aliases for coordinate and time units (e.g. `Degrees_North`, `Hours`). [PR #1599](https://github.com/openghg/openghg/pull/1599)
 - Fixed `convert_to_slice` to use `abs(input)` when computing the relative tolerance range, ensuring that negative inlet values (eg. for sites below sea level) are correctly matched during data retrieval. [PR #1605](https://github.com/openghg/openghg/pull/1605)
 - Fixed "xarray fails to decode time" by using pandas datetime conversion and storing as np.datetime64[ns].[PR #1608](https://github.com/openghg/openghg/pull/1608)
+- Clarified datasource update/versioning behavior for `if_exists`, `save_current`, and overlap handling, including fixes for copied-version metadata and non-overlapping combine updates. [PR #1614](https://github.com/openghg/openghg/pull/1614)
 
 ### Added
 

--- a/openghg/objectstore/_legacy_datasource.py
+++ b/openghg/objectstore/_legacy_datasource.py
@@ -367,7 +367,7 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         elif plan.action == "upsert":
             logger.info("Updating store by combining new data with existing.")
             self._store.update(version=version_str, dataset=data, compressor=compressor, filters=filters)
-            date_keys = [get_representative_daterange_str(self.get_data())]
+            date_keys = [get_representative_daterange_str(self.get_data(version=version_str))]
         else:
             raise DataOverlapError(
                 "Unable to add new data, because it overlaps with current data and `if_exists` is set to 'auto'. "

--- a/openghg/objectstore/_legacy_datasource.py
+++ b/openghg/objectstore/_legacy_datasource.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any, cast, Literal
 from typing_extensions import Self
 from types import TracebackType
@@ -24,6 +25,44 @@ logger = logging.getLogger("openghg.objectstore")
 logger.setLevel(logging.DEBUG)
 
 __all___ = ["Datasource"]
+
+
+TimedDataAction = Literal["insert", "copy_insert", "replace", "upsert", "error_overlap"]
+
+
+@dataclass(frozen=True)
+class TimedDataUpdatePlan:
+    """Storage action for adding time-indexed data to a Datasource."""
+
+    action: TimedDataAction
+    new_version: bool
+
+
+def plan_timed_data_update(
+    *,
+    if_exists: str,
+    new_version: bool,
+    has_existing_data: bool,
+    overlapping: bool,
+) -> TimedDataUpdatePlan:
+    """Plan the concrete store operation after overlap detection."""
+    if not has_existing_data:
+        return TimedDataUpdatePlan(action="insert", new_version=True)
+
+    if if_exists == "new":
+        action: TimedDataAction = "insert" if new_version else "replace"
+        return TimedDataUpdatePlan(action=action, new_version=new_version)
+
+    if if_exists == "combine":
+        action = "upsert" if overlapping or not new_version else "copy_insert"
+        return TimedDataUpdatePlan(action=action, new_version=new_version)
+
+    if if_exists == "auto":
+        if overlapping:
+            return TimedDataUpdatePlan(action="error_overlap", new_version=False)
+        return TimedDataUpdatePlan(action="copy_insert" if new_version else "insert", new_version=new_version)
+
+    raise ValueError("Invalid if_exists option. Please use 'auto', 'new', or 'combine'.")
 
 
 class Datasource(AbstractDatasource[xr.Dataset]):
@@ -280,16 +319,8 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         time_coord = "time"
         new_daterange_str = get_representative_daterange_str(dataset=data, period=self.period)
 
-        if self._latest_version and not new_version:
-            version_str = self._latest_version
-        else:
-            version_str = f"v{len(self._data_keys) + 1!s}"
-
         # Save details of current Datasource status
         self._status = {}
-
-        # We'll use this to store the dates covered by this version of the data
-        date_keys = self._data_keys[self._latest_version] if self._data_keys else []
 
         if sort and drop_duplicates:
             data = data.drop_duplicates(time_coord, keep="first").sortby(time_coord)
@@ -298,40 +329,46 @@ class Datasource(AbstractDatasource[xr.Dataset]):
         elif drop_duplicates:
             data = data.drop_duplicates(time_coord, keep="first")
 
-        overlapping = self._store and self._store._vzds._overlap_determiner.has_overlaps(
+        has_existing_data = bool(self._store)
+        overlapping = has_existing_data and self._store._vzds._overlap_determiner.has_overlaps(
             data.get_index(self._store._vzds.append_dim)
         )
+        plan = plan_timed_data_update(
+            if_exists=if_exists,
+            new_version=new_version,
+            has_existing_data=has_existing_data,
+            overlapping=overlapping,
+        )
+
+        if self._latest_version and not plan.new_version:
+            version_str = self._latest_version
+        else:
+            version_str = f"v{len(self._data_keys) + 1!s}"
+
+        current_date_keys = list(self._data_keys[self._latest_version]) if self._data_keys else []
 
         # TODO: what does the following comment mean? (BM Jan 2026)
         # We'll only need to sort the new dataset if the data we add comes before the current data
 
-        # If we don't have any data in this Datasource or we have no overlap we'll just add the new data
-        if not self._store or not overlapping:
+        if plan.action == "insert":
             self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
-            date_keys.append(new_daterange_str)
-        # Otherwise if we have data already stored in the Datasource
-        elif if_exists == "new":
-            # If we have existing data we'll just keep the new data
-            # If new_version is True then we create a new version containing just this data
-            # If new_version is False then we delete the current data and replace it with just the new data
-            logger.info("Updating store to include new added data only.")
-
-            if new_version:
-                self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
+            if has_existing_data and plan.new_version:
+                date_keys = [new_daterange_str]
             else:
-                self._store.overwrite(
-                    version=version_str, dataset=data, compressor=compressor, filters=filters
-                )
-            # Only save the current daterange string for this version
+                date_keys = [*current_date_keys, new_daterange_str]
+        elif plan.action == "copy_insert":
+            self._store._vzds.create_version(version_str, checkout=True, copy_current=True)
+            self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
+            date_keys = [*current_date_keys, new_daterange_str]
+        elif plan.action == "replace":
+            logger.info("Updating store to include new added data only.")
+            self._store.overwrite(version=version_str, dataset=data, compressor=compressor, filters=filters)
             date_keys = [new_daterange_str]
-        elif if_exists == "combine":
+        elif plan.action == "upsert":
             logger.info("Updating store by combining new data with existing.")
             self._store.update(version=version_str, dataset=data, compressor=compressor, filters=filters)
             date_keys = [get_representative_daterange_str(self.get_data())]
-        # If we don't know what (i.e. we've got "auto") to do we'll raise an error
         else:
-            # if_exists == "auto" (or at least... not "new" or "combine"), but we already have data
-            # and the new data overlaps
             raise DataOverlapError(
                 "Unable to add new data, because it overlaps with current data and `if_exists` is set to 'auto'. "
                 "To update current data in object store use `if_exists` input (see options in documentation)."

--- a/openghg/objectstore/_legacy_datasource.py
+++ b/openghg/objectstore/_legacy_datasource.py
@@ -24,7 +24,7 @@ from ._datasource import AbstractDatasource, DatasourceFactory
 logger = logging.getLogger("openghg.objectstore")
 logger.setLevel(logging.DEBUG)
 
-__all___ = ["Datasource"]
+__all__ = ["Datasource"]
 
 
 TimedDataAction = Literal["insert", "copy_insert", "replace", "upsert", "error_overlap"]
@@ -330,9 +330,13 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             data = data.drop_duplicates(time_coord, keep="first")
 
         has_existing_data = bool(self._store)
-        overlapping = has_existing_data and self._store._vzds._overlap_determiner.has_overlaps(
-            data.get_index(self._store._vzds.append_dim)
-        )
+        if has_existing_data:
+            self._store._vzds.checkout_version(self._latest_version)
+            overlapping = self._store._vzds._overlap_determiner.has_overlaps(
+                data.get_index(self._store._vzds.append_dim)
+            )
+        else:
+            overlapping = False
         plan = plan_timed_data_update(
             if_exists=if_exists,
             new_version=new_version,
@@ -357,8 +361,13 @@ class Datasource(AbstractDatasource[xr.Dataset]):
             else:
                 date_keys = [*current_date_keys, new_daterange_str]
         elif plan.action == "copy_insert":
-            self._store._vzds.create_version(version_str, checkout=True, copy_current=True)
-            self._store.add(version=version_str, dataset=data, compressor=compressor, filters=filters)
+            self._store.add(
+                version=version_str,
+                dataset=data,
+                compressor=compressor,
+                filters=filters,
+                copy_current=True,
+            )
             date_keys = [*current_date_keys, new_daterange_str]
         elif plan.action == "replace":
             logger.info("Updating store to include new added data only.")

--- a/openghg/storage/_zarr_store.py
+++ b/openghg/storage/_zarr_store.py
@@ -179,7 +179,7 @@ class ZarrStore(Store, Generic[ZST]):
                 data = self._overlap_determiner.select_overlaps(data, self.append_dim)
 
             # nothing to update
-            if not bool(data):
+            if not bool(data) or data.sizes.get(self.append_dim) == 0:
                 logger.warning("No data to update with.")
                 return None
 

--- a/openghg/store/storage/_localzarrstore.py
+++ b/openghg/store/storage/_localzarrstore.py
@@ -110,6 +110,7 @@ class LocalZarrStore(Store):
         compressor: Any | None = None,
         filters: Any | None = None,
         append_dim: str = "time",
+        copy_current: bool = False,
     ) -> None:
         """Add an xr.Dataset to the zarr store.
 
@@ -119,6 +120,8 @@ class LocalZarrStore(Store):
             compressor: Compression for zarr encoding
             filters: Filters for zarr encoding
             append_dim: Dimension to append to
+            copy_current: Copy the current version before inserting if creating
+                a new version.
 
         Returns:
             None
@@ -148,7 +151,9 @@ class LocalZarrStore(Store):
         else:
             if not self._vzds.versions and version != "v1":
                 raise ValueError("First version must be v1")
-            self._vzds.create_version(version, checkout=True)
+            if copy_current and not self._vzds.versions:
+                raise ValueError("Cannot copy current version when creating the first version.")
+            self._vzds.create_version(version, checkout=True, copy_current=copy_current)
 
         self._vzds.insert(dataset)
 

--- a/tests/store/test_datasource.py
+++ b/tests/store/test_datasource.py
@@ -535,6 +535,24 @@ def test_auto_overlap_does_not_create_orphan_version(datasource, datasets_with_o
     assert not d._store.version_exists("v2")
 
 
+def test_combine_overlapping_new_version_uses_new_version_date_keys(datasource, datasets_with_overlap):
+    data_a, data_b, _ = datasets_with_overlap
+    attributes = create_attributes()
+
+    d = datasource
+
+    d.add_data(metadata=attributes, data=data_a, data_type="surface", new_version=False)
+    d.add_data(metadata=attributes, data=data_b, data_type="surface", if_exists="combine")
+
+    assert d.latest_version == "v2"
+    assert d.all_data_keys()["v1"] == [
+        "2012-01-01-00:00:00+00:00_2012-01-31-00:00:59+00:00",
+    ]
+    assert d.all_data_keys()["v2"] == [
+        "2012-01-01-00:00:00+00:00_2012-04-30-00:00:00+00:00",
+    ]
+
+
 def test_add_data_with_overlap_check_stored_dataset(datasource, datasets_with_overlap):
     """Check that we can add data with overlaps."""
     data_a, data_b, data_c = datasets_with_overlap

--- a/tests/store/test_datasource.py
+++ b/tests/store/test_datasource.py
@@ -8,6 +8,7 @@ from helpers import get_surface_datapath, get_footprint_datapath
 from openghg.objectstore import get_bucket, exists
 from openghg.standardise.surface import parse_crds
 from openghg.objectstore import Datasource
+from openghg.objectstore._legacy_datasource import plan_timed_data_update
 from openghg.types import ObjectStoreError, ZarrStoreError
 from openghg.types._errors import DataOverlapError
 from openghg.util import timestamp_tzaware
@@ -442,6 +443,96 @@ def test_add_data_with_gaps_check_stored_dataset(datasets_with_gaps, datasource)
     with d.get_data(version="latest") as ds:
         assert ds.equals(xr.concat([data_a, data_b, data_c], dim="time"))
         assert ds.time.size == 91
+
+
+def test_plan_timed_data_update_matrix():
+    assert (
+        plan_timed_data_update(
+            if_exists="auto", new_version=False, has_existing_data=True, overlapping=False
+        ).action
+        == "insert"
+    )
+    assert (
+        plan_timed_data_update(
+            if_exists="auto", new_version=True, has_existing_data=True, overlapping=False
+        ).action
+        == "copy_insert"
+    )
+    assert (
+        plan_timed_data_update(
+            if_exists="auto", new_version=False, has_existing_data=True, overlapping=True
+        ).action
+        == "error_overlap"
+    )
+    assert (
+        plan_timed_data_update(
+            if_exists="combine", new_version=True, has_existing_data=True, overlapping=False
+        ).action
+        == "copy_insert"
+    )
+    assert (
+        plan_timed_data_update(
+            if_exists="new", new_version=True, has_existing_data=True, overlapping=True
+        ).action
+        == "insert"
+    )
+    assert (
+        plan_timed_data_update(
+            if_exists="new", new_version=False, has_existing_data=True, overlapping=True
+        ).action
+        == "replace"
+    )
+
+
+def test_combine_nonoverlapping_new_version_copies_current_data(datasource, datasets_with_gaps):
+    data_a, data_b, _ = datasets_with_gaps
+    attributes = create_attributes()
+
+    d = datasource
+
+    d.add_data(metadata=attributes, data=data_a, data_type="surface", new_version=False)
+    d.add_data(metadata=attributes, data=data_b, data_type="surface", if_exists="combine")
+
+    assert d.latest_version == "v2"
+
+    with d.get_data(version="v1").compute() as ds_v1:
+        assert ds_v1.equals(data_a)
+
+    with d.get_data(version="latest").compute() as ds_latest:
+        assert ds_latest.equals(xr.concat([data_a, data_b], dim="time"))
+
+
+def test_new_nonoverlapping_version_does_not_mutate_previous_date_keys(datasource, datasets_with_gaps):
+    data_a, data_b, _ = datasets_with_gaps
+    attributes = create_attributes()
+
+    d = datasource
+
+    d.add_data(metadata=attributes, data=data_a, data_type="surface", new_version=False)
+    v1_date_keys = list(d.all_data_keys()["v1"])
+
+    d.add_data(metadata=attributes, data=data_b, data_type="surface", if_exists="new")
+
+    assert d.all_data_keys()["v1"] == v1_date_keys
+    assert d.all_data_keys()["v2"] == [
+        "2012-04-01-00:00:00+00:00_2012-04-30-00:00:59+00:00",
+    ]
+
+
+def test_auto_overlap_does_not_create_orphan_version(datasource, datasets_with_overlap):
+    data_a, data_b, _ = datasets_with_overlap
+    attributes = create_attributes()
+
+    d = datasource
+
+    d.add_data(metadata=attributes, data=data_a, data_type="surface", new_version=False)
+
+    with pytest.raises(DataOverlapError):
+        d.add_data(metadata=attributes, data=data_b, data_type="surface", if_exists="auto")
+
+    assert d.latest_version == "v1"
+    assert list(d.all_data_keys()) == ["v1"]
+    assert not d._store.version_exists("v2")
 
 
 def test_add_data_with_overlap_check_stored_dataset(datasource, datasets_with_overlap):

--- a/tests/store/test_datasource.py
+++ b/tests/store/test_datasource.py
@@ -502,6 +502,25 @@ def test_combine_nonoverlapping_new_version_copies_current_data(datasource, data
         assert ds_latest.equals(xr.concat([data_a, data_b], dim="time"))
 
 
+def test_combine_nonoverlapping_read_only_does_not_create_version(datasource, datasets_with_gaps):
+    data_a, data_b, _ = datasets_with_gaps
+    attributes = create_attributes()
+
+    d = datasource
+
+    d.add_data(metadata=attributes, data=data_a, data_type="surface", new_version=False)
+    d._store._mode = "r"
+
+    try:
+        with pytest.raises(PermissionError):
+            d.add_data(metadata=attributes, data=data_b, data_type="surface", if_exists="combine")
+
+        assert d.latest_version == "v1"
+        assert not d._store.version_exists("v2")
+    finally:
+        d._store._mode = "rw"
+
+
 def test_new_nonoverlapping_version_does_not_mutate_previous_date_keys(datasource, datasets_with_gaps):
     data_a, data_b, _ = datasets_with_gaps
     attributes = create_attributes()
@@ -551,6 +570,24 @@ def test_combine_overlapping_new_version_uses_new_version_date_keys(datasource, 
     assert d.all_data_keys()["v2"] == [
         "2012-01-01-00:00:00+00:00_2012-04-30-00:00:00+00:00",
     ]
+
+
+def test_overlap_detection_uses_latest_version_after_getting_old_version(datasource, datasets_with_gaps):
+    data_a, data_b, data_c = datasets_with_gaps
+    attributes = create_attributes()
+
+    d = datasource
+
+    d.add_data(metadata=attributes, data=data_a, data_type="surface", new_version=False)
+    d.add_data(metadata=attributes, data=data_b, data_type="surface", if_exists="combine")
+
+    d.get_data(version="v1")
+    d.add_data(metadata=attributes, data=data_c, data_type="surface", new_version=False)
+
+    assert d.latest_version == "v2"
+
+    with d.get_data(version="latest").compute() as ds_latest:
+        assert ds_latest.equals(xr.concat([data_a, data_b, data_c], dim="time"))
 
 
 def test_add_data_with_overlap_check_stored_dataset(datasource, datasets_with_overlap):


### PR DESCRIPTION
## Summary
- Added an explicit timed-data planning helper so `Datasource.add_timed_data()` decides storage behavior after overlap detection.
- Kept version metadata isolated by copying `date_keys` before mutation.
- Tightened Zarr update handling so empty non-overlap selections do not flow into `upsert` as a bogus update.
- Added tests covering the planning matrix, non-overlap combine behavior, metadata isolation, and no-orphan-version overlap handling.

- [x] Closes #1613 
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- Documentation updated/added
- Tutorials updated/added
- Wiki updated
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- Added any new package requirements to `pyproject.toml` [dependencies section] and `recipes/meta.yaml`


## Testing
- `pytest tests/store/test_datasource.py`
- `pytest tests/db_integrity/test_data_updates.py -k "combine or new_version or new_no_version or overlapping"`
- `pytest tests/storage/test_store.py`
- `flake8 openghg/ tests/store/test_datasource.py --count --statistics`
- `mypy --python-version 3.12 openghg/`
- `black --check --line-length 110 openghg/objectstore/_legacy_datasource.py openghg/storage/_zarr_store.py tests/store/test_datasource.py`