### PR TITLE
Add tests for irregular modelled obs alignment

### DIFF
--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -156,7 +156,12 @@ def _make_hf_flux_rolling_avg_array(
     return flux_hf_rolling
 
 
-def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> xr.DataArray:
+def _make_high_freq_flux(
+    flux: xr.DataArray,
+    fp: xr.DataArray | xr.Dataset,
+    *,
+    align_to_fp_time: bool = True,
+) -> xr.DataArray:
     fp_highest_res_hours = _fp_time_and_h_back_freq_gcd(fp)
     start, end = _padded_flux_slice_start_and_end(fp)
     offset = time_of_day_offset(start)
@@ -183,17 +188,18 @@ def _make_high_freq_flux(flux: xr.DataArray, fp: xr.DataArray | xr.Dataset) -> x
     # create rolling windows
     flux_high_freq = _make_hf_flux_rolling_avg_array(flux_high_freq, fp)
 
-    # reindex to align with fp time coordinates (after creating rolling windows to avoid NaN values at start of time series)
-    fp_index = pd.DatetimeIndex(fp.time.values)
-    flux_index = pd.DatetimeIndex(flux_high_freq.time.values)
-    need_second_reindex = (flux_index.get_indexer(fp_index) < 0).any()
+    if align_to_fp_time:
+        # reindex to align with fp time coordinates (after creating rolling windows to avoid NaN values at start of time series)
+        fp_index = pd.DatetimeIndex(fp.time.values)
+        flux_index = pd.DatetimeIndex(flux_high_freq.time.values)
+        need_second_reindex = (flux_index.get_indexer(fp_index) < 0).any()
 
-    if need_second_reindex:
-        flux_high_freq = flux_high_freq.reindex(
-            {"time": fp.time},
-            method="ffill",
-            tolerance=pd.Timedelta(hours=fp_highest_res_hours),
-        )
+        if need_second_reindex:
+            flux_high_freq = flux_high_freq.reindex(
+                {"time": fp.time},
+                method="ffill",
+                tolerance=pd.Timedelta(hours=fp_highest_res_hours),
+            )
 
     flux_high_freq.attrs["units"] = flux.attrs.get("units")
 

--- a/tests/test_modelled_obs_alignment.py
+++ b/tests/test_modelled_obs_alignment.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from openghg.analyse import _modelled_obs
+
+
+def _irregular_time_resolved_fp_and_flux():
+    lat = [1.0]
+    lon = [10.0]
+    h_back = np.array([0, 1])
+    fp_times = pd.to_datetime(
+        [
+            "2012-01-01 00:37:00",
+            "2012-01-01 01:44:00",
+            "2012-01-01 02:51:00",
+            "2012-01-01 03:58:00",
+        ]
+    )
+    fp = xr.Dataset(
+        {
+            "fp_time_resolved": (("time", "lat", "lon", "H_back"), np.ones((4, 1, 1, 2))),
+            "fp_residual": (("time", "lat", "lon"), np.zeros((4, 1, 1))),
+        },
+        coords={"time": fp_times, "lat": lat, "lon": lon, "H_back": h_back},
+    )
+    fp.fp_time_resolved.attrs["units"] = "m2 s mol-1"
+    fp.fp_residual.attrs["units"] = "m2 s mol-1"
+    fp.lat.attrs["units"] = "degrees_north"
+    fp.lon.attrs["units"] = "degrees_east"
+    fp.H_back.attrs["units"] = "Hours"
+
+    flux_times = pd.date_range("2011-12-31 20:37:00", "2012-01-01 05:37:00", freq="h")
+    flux_values = np.arange(len(flux_times), dtype=float).reshape(-1, 1, 1)
+    flux = xr.DataArray(
+        flux_values,
+        coords={"time": flux_times, "lat": lat, "lon": lon},
+        dims=("time", "lat", "lon"),
+        attrs={"units": "mol m-2 s-1"},
+    )
+    flux.lat.attrs["units"] = "degrees_north"
+    flux.lon.attrs["units"] = "degrees_east"
+
+    expected = xr.DataArray(
+        np.array([7.0, 9.0, 11.0, 13.0]).reshape(4, 1, 1),
+        coords={"time": fp.time, "lat": fp.lat, "lon": fp.lon},
+        dims=("time", "lat", "lon"),
+    )
+
+    return fp, flux, expected
+
+
+def test_fp_x_flux_time_resolved_aligns_all_irregular_footprint_times():
+    """Irregular footprint times should not be dropped by xarray's exact coordinate alignment."""
+    fp, flux, expected = _irregular_time_resolved_fp_and_flux()
+
+    result = _modelled_obs.fp_x_flux_time_resolved(fp, flux)
+
+    xr.testing.assert_allclose(result, expected)
+
+
+def test_high_freq_flux_without_second_reindex_reproduces_dropped_times():
+    """Probe the old behaviour: only footprint times already on the generated grid survive."""
+    fp, flux, _ = _irregular_time_resolved_fp_and_flux()
+
+    flux_high_freq = _modelled_obs._make_high_freq_flux(flux, fp, align_to_fp_time=False)
+    result = (flux_high_freq * fp.fp_time_resolved).sum("H_back")
+
+    expected = xr.DataArray(
+        np.array([7.0]).reshape(1, 1, 1),
+        coords={"time": fp.time.isel(time=[0]), "lat": fp.lat, "lon": fp.lon},
+        dims=("time", "lat", "lon"),
+    )
+    xr.testing.assert_allclose(result, expected)


### PR DESCRIPTION
## Summary

Adds focused regression tests for the irregular high-time-resolution footprint alignment issue addressed in PR #1611.

The new synthetic test data uses irregular footprint release times and varying hourly flux values so the expected `fp_x_flux_time_resolved` output checks the actual aligned H_back windows, not just that non-null points are produced.

## Details

- Adds an end-to-end test showing `fp_x_flux_time_resolved` preserves all irregular footprint times and returns expected values `[7, 9, 11, 13]`.
- Adds a probe for the pre-fix behavior by allowing `_make_high_freq_flux` to skip the second footprint-time alignment step; this reproduces the dropped-time result where only the first matching timestamp remains.
- Keeps the production default unchanged: `_make_high_freq_flux` still performs the PR's second alignment by default.

## Validation

- `HOME=/tmp MPLCONFIGDIR=/tmp .venv/bin/pytest tests/test_modelled_obs_alignment.py -q`
- `HOME=/tmp MPLCONFIGDIR=/tmp .venv/bin/pytest tests/analyse/test_modelled_obs.py -k irregular_times_are_ffilled -q`
- `HOME=/tmp MPLCONFIGDIR=/tmp .venv/bin/python -m py_compile openghg/analyse/_modelled_obs.py tests/test_modelled_obs_alignment.py`
- pre-commit on commit: black, flake8, mypy passed
