### PR TITLE
[codex] Force synchronous Dask scheduler in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified datasource update/versioning behavior for `if_exists`, `save_current`, and overlap handling, including fixes for copied-version metadata and non-overlapping combine updates. [PR #1614](https://github.com/openghg/openghg/pull/1614)
 - Fixed handling of irregular fp time reindexing and missing "calibration_scale", also added the ability to detect "mf_mod_high_res"  for plot_comparison.[PR #1611](https://github.com/openghg/openghg/pull/1611)
 - Fixed object store search and retrieve results to include datasource-managed metadata without mutating datasource records, while keeping raw metastore descriptor metadata authoritative. [PR #1652](https://github.com/openghg/openghg/pull/1652)
+- Fixed intermittent uv CI hangs by forcing Dask's synchronous scheduler during pytest sessions. [PR #1657](https://github.com/openghg/openghg/pull/1657)
 
 ### Updated
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,14 @@ tmp_store_paths = temporary_store_paths()
 from openghg.store import get_metakey_defaults
 
 
+def _configure_test_dask_scheduler() -> None:
+    """Avoid intermittent threaded Dask deadlocks in xarray/netCDF4 tests."""
+    import dask
+
+    if dask.config.get("scheduler", None) is None:
+        dask.config.set(scheduler="sync")
+
+
 @pytest.fixture(scope="session", autouse=True)
 def mock_configuration_paths() -> dict:
     return {
@@ -110,6 +118,8 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    _configure_test_dask_scheduler()
+
     config.addinivalue_line("markers", "cfchecks: mark test as needing CF related libs to run")
     config.addinivalue_line(
         "markers",


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Bug fix / CI stability update for #1656.

Adds a pytest-session Dask scheduler workaround for the intermittent uv CI hang seen on #1654:

- Sets Dask's scheduler to `sync` during pytest startup when no scheduler has already been configured.
- Keeps the change scoped to tests, leaving production Dask behavior unchanged.
- Mirrors the existing synchronous-scheduler workaround note in `openghg/storage/_convert.py` for prior Dask queue/thread hangs.
- Adds a `CHANGELOG.md` entry under Unreleased / Fixed.

Context: the first uv Python 3.10 job on #1654 hung in Dask worker threads blocked inside xarray/netCDF4 backend locks while running `uv run pytest --run-cfchecks`. The rerun passed, and local hammering did not reproduce the hang, so this is a prophylactic test-session workaround rather than a #1654 fix.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1656
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [ ] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [ ] Documentation updated/added
- [ ] Tutorials updated/added
- [ ] Wiki updated
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Added any new package requirements to `pyproject.toml` [dependencies section] and `recipes/meta.yaml`

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*

Not needed / not run:

- Documentation, tutorials, and wiki updates are not needed: this is a test-session CI stability workaround only.
- No package requirements were added, so `pyproject.toml` and `recipes/meta.yaml` do not need dependency updates.
- Full `mypy` was not run because the change only affects pytest configuration and the local `gh` token is invalid; CI will run the full matrix.
- Plain `flake8 tests/conftest.py` reports the existing E402 import-order pattern in this conftest; CI flake8 currently checks `openghg/` only.

Validation performed:

- `.venv/bin/black --check tests/conftest.py`
- `.venv/bin/flake8 tests/conftest.py --count --statistics --ignore=E402`
- `HOME=/tmp MPLCONFIGDIR=/tmp DYLD_LIBRARY_PATH=/opt/homebrew/opt/udunits/lib UDUNITS2_XML_PATH=/opt/homebrew/opt/udunits/share/udunits/udunits2.xml .venv/bin/pytest --run-cfchecks -q --disable-warnings tests/standardise/surface/test_openghg_surface.py::test_openghg_cf_compliance tests/storage/test_store.py::test_versioned_zarr_bytes_stored_compression tests/store/test_boundary_conditions.py` (`9 passed, 1 xfailed`)
- `HOME=/tmp MPLCONFIGDIR=/tmp DYLD_LIBRARY_PATH=/opt/homebrew/opt/udunits/lib UDUNITS2_XML_PATH=/opt/homebrew/opt/udunits/share/udunits/udunits2.xml .venv/bin/pytest --run-cfchecks -q --disable-warnings tests/standardise/surface/test_agage.py tests/standardise/surface/test_crds.py tests/standardise/surface/test_gcwerks.py tests/standardise/surface/test_noaa.py tests/standardise/surface/test_npl.py tests/standardise/surface/test_openghg_surface.py tests/storage/test_store.py tests/store/test_boundary_conditions.py` (`111 passed, 7 xfailed`)