### PR TITLE
[codex] Add zarr storage compatibility layer

### DIFF
--- a/openghg/storage/_zarr_compat.py
+++ b/openghg/storage/_zarr_compat.py
@@ -1,4 +1,12 @@
-"""Compatibility helpers for zarr-python storage APIs."""
+"""Compatibility helpers for zarr-python storage APIs.
+
+This module centralises the zarr v2/v3 store API differences needed by
+OpenGHG storage. It provides factories for memory and local filesystem stores,
+helpers for key iteration, prefix clearing, empty checks, byte sizing, and a
+copy wrapper. Zarr v3 store methods are asynchronous, so helpers synchronise
+awaitable store operations before returning to the synchronous OpenGHG storage
+API.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +23,13 @@ import zarr.storage
 
 
 class ZarrStoreLike(Protocol):
-    """Common marker protocol for zarr v2 and v3 store objects."""
+    """Minimal mapping protocol for zarr stores used by OpenGHG.
+
+    Zarr v2 stores expose mapping methods directly, while zarr v3 stores expose
+    asynchronous methods for most I/O. Compatibility helpers handle those
+    asynchronous methods where needed; this protocol records the current
+    mapping-shaped surface that xarray and OpenGHG's zarr v2 tests still use.
+    """
 
     def __getitem__(self, key: str) -> Any: ...
 
@@ -117,11 +131,8 @@ def clear_store(store: ZarrStoreLike, prefix: str | None = None) -> None:
     """
     normalised_prefix = _normalise_prefix(prefix)
     rmdir = getattr(store, "rmdir", None)
-    if rmdir is not None:
-        if normalised_prefix is None:
-            rmdir()
-        else:
-            rmdir(normalised_prefix)
+    if normalised_prefix is None and rmdir is not None:
+        rmdir()
         return None
 
     if normalised_prefix is None:
@@ -130,11 +141,6 @@ def clear_store(store: ZarrStoreLike, prefix: str | None = None) -> None:
             _delete_store_keys(store, iter_store_keys(store))
         else:
             _call_maybe_async(clear)
-        return None
-
-    delete_dir = getattr(store, "delete_dir", None)
-    if delete_dir is not None:
-        _call_maybe_async(delete_dir, normalised_prefix)
         return None
 
     _delete_store_keys(store, iter_store_keys(store, prefix=normalised_prefix))
@@ -156,7 +162,8 @@ def iter_store_keys(store: ZarrStoreLike, prefix: str | None = None) -> Iterator
     if normalised_prefix is not None:
         list_prefix = getattr(store, "list_prefix", None)
         if list_prefix is not None:
-            return iter(_collect_iterable(list_prefix(normalised_prefix)))
+            keys = _collect_iterable(list_prefix(normalised_prefix))
+            return (key for key in keys if _key_matches_prefix(key, normalised_prefix))
 
     list_all = getattr(store, "list", None)
     if list_all is not None:
@@ -221,6 +228,7 @@ def copy_store(source: ZarrStoreLike, dest: ZarrStoreLike) -> None:
 
 
 def _normalise_prefix(prefix: str | None) -> str | None:
+    """Normalise empty or slash-delimited prefixes to internal form."""
     if prefix is None:
         return None
 
@@ -229,10 +237,20 @@ def _normalise_prefix(prefix: str | None) -> str | None:
 
 
 def _key_matches_prefix(key: str, prefix: str) -> bool:
+    """Check whether a key is exactly under a normalised prefix."""
     return key == prefix or key.startswith(f"{prefix}/")
 
 
 def _call_maybe_async(func: Any, *args: Any) -> Any:
+    """Call a store method and synchronously resolve awaitable results.
+
+    Args:
+        func: Store method or callable to invoke.
+        args: Positional arguments to pass to ``func``.
+
+    Returns:
+        Direct return value, or awaited return value for asynchronous methods.
+    """
     result = func(*args)
     if inspect.isawaitable(result):
         return _sync(cast(Awaitable[Any], result))
@@ -241,6 +259,14 @@ def _call_maybe_async(func: Any, *args: Any) -> Any:
 
 
 def _collect_iterable(value: Any) -> list[str]:
+    """Collect synchronous or asynchronous store key iterables.
+
+    Args:
+        value: Synchronous iterable or asynchronous iterator of store keys.
+
+    Returns:
+        Store keys converted to strings.
+    """
     if hasattr(value, "__aiter__"):
         return _sync(_collect_async_iterable(cast(AsyncIterator[str], value)))
 
@@ -248,10 +274,17 @@ def _collect_iterable(value: Any) -> list[str]:
 
 
 async def _collect_async_iterable(value: AsyncIterator[str]) -> list[str]:
+    """Collect an asynchronous store key iterator."""
     return [str(item) async for item in value]
 
 
 def _delete_store_keys(store: ZarrStoreLike, keys: Iterable[str]) -> None:
+    """Delete keys from a zarr store.
+
+    Args:
+        store: Zarr store instance.
+        keys: Keys to delete from the store.
+    """
     delete = getattr(store, "delete", None)
     if delete is not None:
         for key in keys:
@@ -264,6 +297,18 @@ def _delete_store_keys(store: ZarrStoreLike, keys: Iterable[str]) -> None:
 
 
 def _sync(awaitable: Awaitable[T]) -> T:
+    """Synchronously wait for an awaitable store operation.
+
+    Uses zarr's own sync helper when available. Otherwise, it runs the awaitable
+    with ``asyncio.run``; if an event loop is already running, the awaitable is
+    resolved in a short-lived worker thread.
+
+    Args:
+        awaitable: Awaitable store operation.
+
+    Returns:
+        Awaited result.
+    """
     try:
         from zarr.core.sync import sync as zarr_sync
     except ImportError:
@@ -282,4 +327,5 @@ def _sync(awaitable: Awaitable[T]) -> T:
 
 
 def _asyncio_run(awaitable: Awaitable[T]) -> T:
+    """Run an awaitable through ``asyncio.run`` with a coroutine cast."""
     return asyncio.run(cast(Coroutine[Any, Any, T], awaitable))

--- a/openghg/storage/_zarr_compat.py
+++ b/openghg/storage/_zarr_compat.py
@@ -1,0 +1,285 @@
+"""Compatibility helpers for zarr-python storage APIs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Coroutine, Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+import inspect
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Protocol, TypeVar, cast
+
+import zarr
+import zarr.storage
+
+
+class ZarrStoreLike(Protocol):
+    """Common marker protocol for zarr v2 and v3 store objects."""
+
+    def __getitem__(self, key: str) -> Any: ...
+
+    def __setitem__(self, key: str, value: Any) -> None: ...
+
+    def __delitem__(self, key: str) -> None: ...
+
+    def __iter__(self) -> Iterator[str]: ...
+
+    def __bool__(self) -> bool: ...
+
+
+T = TypeVar("T")
+
+
+def zarr_version() -> str:
+    """Return the installed zarr package version.
+
+    Returns:
+        Installed zarr version string.
+    """
+    try:
+        return version("zarr")
+    except PackageNotFoundError:
+        return str(zarr.__version__)
+
+
+def zarr_major_version() -> int:
+    """Return the installed zarr major version.
+
+    Returns:
+        Major version number parsed from the installed zarr version.
+    """
+    return int(zarr_version().split(".", maxsplit=1)[0])
+
+
+def zarr_has_async_store_api() -> bool:
+    """Check whether zarr stores use the v3 asynchronous store API.
+
+    Returns:
+        True when the installed zarr version uses the v3 store API.
+    """
+    return zarr_major_version() >= 3
+
+
+def make_memory_store() -> ZarrStoreLike:
+    """Create a zarr memory store for the installed zarr version.
+
+    Returns:
+        Zarr memory store instance.
+    """
+    store_cls = getattr(zarr.storage, "MemoryStore", None) or getattr(zarr, "MemoryStore")
+    return cast(ZarrStoreLike, store_cls())
+
+
+def make_local_store(path: str | Path) -> ZarrStoreLike:
+    """Create a local filesystem zarr store for the installed zarr version.
+
+    Args:
+        path: Filesystem path to the store root.
+
+    Returns:
+        Zarr local filesystem store instance.
+    """
+    store_cls = getattr(zarr.storage, "LocalStore", None)
+    if store_cls is None:
+        store_cls = getattr(zarr.storage, "DirectoryStore", None) or getattr(zarr, "DirectoryStore")
+
+    return cast(ZarrStoreLike, store_cls(path))
+
+
+def store_is_empty(store: ZarrStoreLike, prefix: str | None = None) -> bool:
+    """Check whether a zarr store or prefix contains any keys.
+
+    Args:
+        store: Zarr store instance.
+        prefix: Optional key prefix to check.
+
+    Returns:
+        True if no keys exist in the store or prefix.
+    """
+    normalised_prefix = _normalise_prefix(prefix)
+    is_empty = getattr(store, "is_empty", None)
+    if is_empty is not None:
+        return bool(_call_maybe_async(is_empty, normalised_prefix or ""))
+
+    return not any(iter_store_keys(store, prefix=normalised_prefix))
+
+
+def clear_store(store: ZarrStoreLike, prefix: str | None = None) -> None:
+    """Clear all keys from a zarr store or from a prefix.
+
+    For zarr v2 local stores, clearing the whole store preserves the historical
+    ``DirectoryStore.rmdir()`` behavior, which removes the store directory itself.
+
+    Args:
+        store: Zarr store instance.
+        prefix: Optional key prefix to clear.
+    """
+    normalised_prefix = _normalise_prefix(prefix)
+    rmdir = getattr(store, "rmdir", None)
+    if rmdir is not None:
+        if normalised_prefix is None:
+            rmdir()
+        else:
+            rmdir(normalised_prefix)
+        return None
+
+    if normalised_prefix is None:
+        clear = getattr(store, "clear", None)
+        if clear is None:
+            _delete_store_keys(store, iter_store_keys(store))
+        else:
+            _call_maybe_async(clear)
+        return None
+
+    delete_dir = getattr(store, "delete_dir", None)
+    if delete_dir is not None:
+        _call_maybe_async(delete_dir, normalised_prefix)
+        return None
+
+    _delete_store_keys(store, iter_store_keys(store, prefix=normalised_prefix))
+    return None
+
+
+def iter_store_keys(store: ZarrStoreLike, prefix: str | None = None) -> Iterator[str]:
+    """Iterate keys in a zarr store.
+
+    Args:
+        store: Zarr store instance.
+        prefix: Optional key prefix to filter keys by.
+
+    Returns:
+        Iterator over keys relative to the store root.
+    """
+    normalised_prefix = _normalise_prefix(prefix)
+
+    if normalised_prefix is not None:
+        list_prefix = getattr(store, "list_prefix", None)
+        if list_prefix is not None:
+            return iter(_collect_iterable(list_prefix(normalised_prefix)))
+
+    list_all = getattr(store, "list", None)
+    if list_all is not None:
+        keys = _collect_iterable(list_all())
+    else:
+        keys_method = getattr(store, "keys", None)
+        if keys_method is not None:
+            keys = [str(key) for key in keys_method()]
+        else:
+            keys = [str(key) for key in cast(Iterable[str], store)]
+
+    if normalised_prefix is None:
+        return iter(keys)
+
+    return (key for key in keys if _key_matches_prefix(key, normalised_prefix))
+
+
+def store_byte_size(store: ZarrStoreLike, prefix: str | None = None) -> int:
+    """Return the number of bytes stored in a zarr store or prefix.
+
+    Args:
+        store: Zarr store instance.
+        prefix: Optional key prefix to measure.
+
+    Returns:
+        Total number of stored bytes.
+    """
+    normalised_prefix = _normalise_prefix(prefix)
+    getsize_prefix = getattr(store, "getsize_prefix", None)
+    if normalised_prefix is not None and getsize_prefix is not None:
+        return int(_call_maybe_async(getsize_prefix, normalised_prefix))
+
+    getsize = getattr(store, "getsize", None)
+    if getsize is None:
+        return 0
+
+    total = 0
+    for key in iter_store_keys(store, prefix=normalised_prefix):
+        total += int(_call_maybe_async(getsize, key))
+    return total
+
+
+def copy_store(source: ZarrStoreLike, dest: ZarrStoreLike) -> None:
+    """Copy all zarr store keys from one store to another.
+
+    This currently delegates to zarr-python's copy helper when available. Zarr
+    v3 does not yet provide the same helper, so this wrapper is the compatibility
+    point for the OpenGHG copy implementation planned in the next migration step.
+
+    Args:
+        source: Source zarr store.
+        dest: Destination zarr store.
+
+    Raises:
+        NotImplementedError: If the installed zarr version has no store copy helper.
+    """
+    copy_store_fn = getattr(zarr, "copy_store", None)
+    if copy_store_fn is None:
+        raise NotImplementedError("zarr.copy_store is not available for this zarr version.")
+
+    copy_store_fn(source, dest)
+
+
+def _normalise_prefix(prefix: str | None) -> str | None:
+    if prefix is None:
+        return None
+
+    normalised = prefix.strip("/")
+    return normalised or None
+
+
+def _key_matches_prefix(key: str, prefix: str) -> bool:
+    return key == prefix or key.startswith(f"{prefix}/")
+
+
+def _call_maybe_async(func: Any, *args: Any) -> Any:
+    result = func(*args)
+    if inspect.isawaitable(result):
+        return _sync(cast(Awaitable[Any], result))
+
+    return result
+
+
+def _collect_iterable(value: Any) -> list[str]:
+    if hasattr(value, "__aiter__"):
+        return _sync(_collect_async_iterable(cast(AsyncIterator[str], value)))
+
+    return [str(item) for item in value]
+
+
+async def _collect_async_iterable(value: AsyncIterator[str]) -> list[str]:
+    return [str(item) async for item in value]
+
+
+def _delete_store_keys(store: ZarrStoreLike, keys: Iterable[str]) -> None:
+    delete = getattr(store, "delete", None)
+    if delete is not None:
+        for key in keys:
+            _call_maybe_async(delete, key)
+        return None
+
+    for key in keys:
+        del store[key]
+    return None
+
+
+def _sync(awaitable: Awaitable[T]) -> T:
+    try:
+        from zarr.core.sync import sync as zarr_sync
+    except ImportError:
+        zarr_sync = None
+
+    if zarr_sync is not None:
+        return cast(T, zarr_sync(awaitable))
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return _asyncio_run(awaitable)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(_asyncio_run, awaitable).result()
+
+
+def _asyncio_run(awaitable: Awaitable[T]) -> T:
+    return asyncio.run(cast(Coroutine[Any, Any, T], awaitable))

--- a/openghg/storage/_zarr_store.py
+++ b/openghg/storage/_zarr_store.py
@@ -7,14 +7,21 @@ from typing import Any, cast, Generic, Literal, TypeVar
 import pandas as pd
 import xarray as xr
 import zarr
-import zarr.convenience
-from zarr._storage.store import Store as AbstractZarrStore
 
 from openghg.types import DataOverlapError
 from openghg.util._versioning import SimpleVersioning
 from ._encoding import get_zarr_encoding
 from ._indexing import contiguous_regions, IndexingError, OverlapDeterminer
 from ._store import Store, UpdateError, VersionedStore
+from ._zarr_compat import (
+    ZarrStoreLike,
+    clear_store,
+    copy_store,
+    make_local_store,
+    make_memory_store,
+    store_byte_size,
+    store_is_empty,
+)
 
 logger = logging.getLogger("openghg.storage")
 logger.setLevel(logging.DEBUG)
@@ -29,7 +36,7 @@ def parse_to_zarr_kwargs(to_zarr_kwargs: dict) -> dict:
     return result
 
 
-ZST = TypeVar("ZST", bound=AbstractZarrStore)
+ZST = TypeVar("ZST", bound=ZarrStoreLike)
 
 
 class ZarrStore(Store, Generic[ZST]):
@@ -92,6 +99,10 @@ class ZarrStore(Store, Generic[ZST]):
         return self._store
 
     @property
+    def _xarray_store(self) -> Any:
+        return self.store
+
+    @property
     def index(self) -> pd.Index:
         """Index of append dimension of data.
 
@@ -105,26 +116,20 @@ class ZarrStore(Store, Generic[ZST]):
         return OverlapDeterminer(index=self.index, **self.index_options)
 
     def __bool__(self) -> bool:
-        return bool(self.store)
+        return not store_is_empty(self.store)
 
     def clear(self) -> None:
-        self.store.rmdir()
+        clear_store(self.store)
 
     def bytes_stored(self) -> int:
-        if not hasattr(self.store, "getsize"):
-            return 0
-
-        nbytes = 0
-        for key in self.store:
-            nbytes += self.store.getsize(key)  # type: ignore
-        return nbytes
+        return store_byte_size(self.store)
 
     def _get(self, sort: bool = True) -> xr.Dataset:
         if not bool(self):
             return xr.Dataset()
 
         # need to sort to be consistent with MemoryStore
-        result = xr.open_zarr(self.store, consolidated=True)
+        result = xr.open_zarr(self._xarray_store, consolidated=True)
 
         if sort:
             result = result.sortby(self.append_dim)
@@ -135,11 +140,11 @@ class ZarrStore(Store, Generic[ZST]):
         return self._get(sort=True)
 
     def insert(self, data: xr.Dataset, on_overlap: Literal["error", "ignore"] = "error") -> None:
-        if not self.store:
+        if store_is_empty(self.store):
             encoding = get_zarr_encoding(data.data_vars, self.compressor, self.filters)
             encoding.update(self.encoding)
             data.to_zarr(
-                store=self.store,
+                store=self._xarray_store,
                 mode="w",
                 consolidated=True,
                 compute=True,
@@ -156,7 +161,7 @@ class ZarrStore(Store, Generic[ZST]):
                 data = self._overlap_determiner.select_nonoverlaps(data, self.append_dim)
 
             data.to_zarr(
-                store=self.store,
+                store=self._xarray_store,
                 mode="a",
                 append_dim=self.append_dim,
                 consolidated=True,
@@ -168,7 +173,7 @@ class ZarrStore(Store, Generic[ZST]):
 
     def update(self, data: xr.Dataset, on_nonoverlap: Literal["error", "ignore"] = "error") -> None:
 
-        if not self.store:
+        if store_is_empty(self.store):
             raise UpdateError("Cannot update empty Store.")
         else:
             if self._overlap_determiner.has_nonoverlaps(data.get_index(self.append_dim)):
@@ -185,7 +190,7 @@ class ZarrStore(Store, Generic[ZST]):
 
             try:
                 data.to_zarr(
-                    store=self.store,
+                    store=self._xarray_store,
                     mode="r+",
                     region="auto",
                     consolidated=True,
@@ -220,7 +225,7 @@ class ZarrStore(Store, Generic[ZST]):
 
                 # don't catch any errors here, since these errors are unrelated to alignment
                 data[non_region_vars].to_zarr(
-                    store=self.store,
+                    store=self._xarray_store,
                     mode="r+",
                     region="auto",
                     consolidated=True,
@@ -244,7 +249,7 @@ class ZarrStore(Store, Generic[ZST]):
                 for sregion, tregion in zip(source_regions, target_regions):
                     region = {self.append_dim: slice(tregion[0], tregion[-1] + 1)}
                     res = data.isel({self.append_dim: sregion}).to_zarr(
-                        store=self.store,
+                        store=self._xarray_store,
                         mode="r+",
                         region=region,
                         consolidated=True,
@@ -259,8 +264,8 @@ class ZarrStore(Store, Generic[ZST]):
 
 def get_zarr_directory_store(
     path: Path, append_dim: str = "time", index_options: dict | None = None, **kwargs: Any
-) -> ZarrStore[zarr.DirectoryStore]:
-    """Factory function to create ZarrStore objects based on a zarr.DirectoryStore.
+) -> ZarrStore[ZarrStoreLike]:
+    """Factory function to create ZarrStore objects based on a local zarr store.
 
     Args:
         path: path to Zarr store location.
@@ -271,17 +276,17 @@ def get_zarr_directory_store(
           passed to `xr.Dataset.to_zarr`.
 
     Returns:
-        ZarrStore based on zarr.DirectoryStore.
+        ZarrStore based on a local filesystem store.
 
     """
-    store = zarr.DirectoryStore(path)
-    return ZarrStore[zarr.DirectoryStore](store, append_dim=append_dim, index_options=index_options, **kwargs)
+    store = make_local_store(path)
+    return ZarrStore[ZarrStoreLike](store, append_dim=append_dim, index_options=index_options, **kwargs)
 
 
 def get_zarr_memory_store(
     append_dim: str = "time", index_options: dict | None = None, **kwargs: Any
-) -> ZarrStore[zarr.MemoryStore]:
-    """Factory function to create ZarrStore objects based on a zarr.MemoryStore.
+) -> ZarrStore[ZarrStoreLike]:
+    """Factory function to create ZarrStore objects based on a zarr memory store.
 
     Args:
         append_dim: dimension to append new data along.
@@ -291,11 +296,11 @@ def get_zarr_memory_store(
           passed to `xr.Dataset.to_zarr`.
 
     Returns:
-        ZarrStore based on zarr.MemoryStore.
+        ZarrStore based on a memory store.
 
     """
-    store = zarr.MemoryStore()
-    return ZarrStore[zarr.MemoryStore](store, append_dim=append_dim, index_options=index_options, **kwargs)
+    store = make_memory_store()
+    return ZarrStore[ZarrStoreLike](store, append_dim=append_dim, index_options=index_options, **kwargs)
 
 
 class VersionedZarrStore(VersionedStore, SimpleVersioning[ZST], ZarrStore[ZST]):
@@ -389,7 +394,7 @@ class VersionedZarrStore(VersionedStore, SimpleVersioning[ZST], ZarrStore[ZST]):
         if v not in self.versions:
             self._versions[v] = self.factory(v)
         dest = self._versions[v]
-        zarr.convenience.copy_store(source, dest)
+        copy_store(source, dest)
 
 
 def get_versioned_zarr_directory_store(
@@ -399,8 +404,8 @@ def get_versioned_zarr_directory_store(
     index_options: dict | None = None,
     version_pat: str = r"v\d+",
     **kwargs: Any,
-) -> VersionedZarrStore[zarr.DirectoryStore]:
-    """Factory function to create VersionedZarrStore objects based on a zarr.DirectoryStore.
+) -> VersionedZarrStore[ZarrStoreLike]:
+    """Factory function to create VersionedZarrStore objects based on local zarr stores.
 
     Args:
         path: root path where zarr `DirectoryStore`s will be based.
@@ -413,8 +418,7 @@ def get_versioned_zarr_directory_store(
           passed to `xr.Dataset.to_zarr`.
 
     Returns:
-        VersionedZarrStore object with zarr.DirectoryStore as the underlying
-        storage.
+        VersionedZarrStore object with local filesystem stores as the underlying storage.
 
     """
     versions = set([]) if versions is None else set(versions)
@@ -430,11 +434,11 @@ def get_versioned_zarr_directory_store(
                 versions.add(f.name)
 
     # factory function to create a Directory Stores corresponding to versions
-    def factory(v: str) -> zarr.DirectoryStore:
-        """Factory function to create a Directory Store corresponding to version."""
-        return zarr.DirectoryStore(path / v)
+    def factory(v: str) -> ZarrStoreLike:
+        """Factory function to create a local store corresponding to version."""
+        return make_local_store(path / v)
 
-    return VersionedZarrStore[zarr.DirectoryStore](
+    return VersionedZarrStore[ZarrStoreLike](
         factory=factory,
         versions=versions,
         append_dim=append_dim,
@@ -448,8 +452,8 @@ def get_versioned_zarr_memory_store(
     append_dim: str = "time",
     index_options: dict | None = None,
     **kwargs: Any,
-) -> VersionedZarrStore[zarr.MemoryStore]:
-    """Factory function to create VersionedZarrStore objects based on a zarr.MemoryStore.
+) -> VersionedZarrStore[ZarrStoreLike]:
+    """Factory function to create VersionedZarrStore objects based on zarr memory stores.
 
     Args:
         versions: list of versions to load.
@@ -460,16 +464,15 @@ def get_versioned_zarr_memory_store(
           passed to `xr.Dataset.to_zarr`.
 
     Returns:
-        VersionedZarrStore object with zarr.MemoryStore as the underlying
-        storage.
+        VersionedZarrStore object with memory stores as the underlying storage.
 
     """
 
-    def factory(_: str) -> zarr.MemoryStore:
+    def factory(_: str) -> ZarrStoreLike:
         """Factory for versioning."""
-        return zarr.MemoryStore()
+        return make_memory_store()
 
-    return VersionedZarrStore[zarr.MemoryStore](
+    return VersionedZarrStore[ZarrStoreLike](
         factory=factory,
         versions=versions,
         append_dim=append_dim,

--- a/openghg/storage/_zarr_store.py
+++ b/openghg/storage/_zarr_store.py
@@ -28,6 +28,14 @@ logger.setLevel(logging.DEBUG)
 
 
 def parse_to_zarr_kwargs(to_zarr_kwargs: dict) -> dict:
+    """Filter keyword arguments accepted by xarray's zarr writer.
+
+    Args:
+        to_zarr_kwargs: Candidate keyword arguments for ``xr.Dataset.to_zarr``.
+
+    Returns:
+        Dictionary containing supported zarr writer keyword arguments.
+    """
     accepted_keys = ["write_empty_chunks", "zarr_format", "storage_options"]
     result = {}
     for k, v in to_zarr_kwargs.items():
@@ -100,6 +108,7 @@ class ZarrStore(Store, Generic[ZST]):
 
     @property
     def _xarray_store(self) -> Any:
+        """Return the store using xarray's broader runtime store typing."""
         return self.store
 
     @property
@@ -116,12 +125,15 @@ class ZarrStore(Store, Generic[ZST]):
         return OverlapDeterminer(index=self.index, **self.index_options)
 
     def __bool__(self) -> bool:
+        """Return True if the current underlying zarr store contains data."""
         return not store_is_empty(self.store)
 
     def clear(self) -> None:
+        """Clear all keys from the current underlying zarr store."""
         clear_store(self.store)
 
     def bytes_stored(self) -> int:
+        """Return the number of bytes stored in the current zarr store."""
         return store_byte_size(self.store)
 
     def _get(self, sort: bool = True) -> xr.Dataset:
@@ -137,9 +149,21 @@ class ZarrStore(Store, Generic[ZST]):
         return cast(xr.Dataset, result)
 
     def get(self) -> xr.Dataset:
+        """Return the stored dataset sorted by the append dimension."""
         return self._get(sort=True)
 
     def insert(self, data: xr.Dataset, on_overlap: Literal["error", "ignore"] = "error") -> None:
+        """Insert data into the zarr store.
+
+        Args:
+            data: Dataset to write or append to the store.
+            on_overlap: If "error", raise when new append-dimension values overlap
+                stored values. If "ignore", only non-overlapping values are appended.
+
+        Raises:
+            DataOverlapError: If overlapping values are found and ``on_overlap`` is
+                "error".
+        """
         if store_is_empty(self.store):
             encoding = get_zarr_encoding(data.data_vars, self.compressor, self.filters)
             encoding.update(self.encoding)
@@ -172,6 +196,19 @@ class ZarrStore(Store, Generic[ZST]):
             )
 
     def update(self, data: xr.Dataset, on_nonoverlap: Literal["error", "ignore"] = "error") -> None:
+        """Update existing data in the zarr store.
+
+        Args:
+            data: Dataset containing replacement values.
+            on_nonoverlap: If "error", raise when input append-dimension values do
+                not overlap stored values. If "ignore", only overlapping values are
+                updated.
+
+        Raises:
+            UpdateError: If the store is empty, if non-overlapping values are found
+                and ``on_nonoverlap`` is "error", or if index options map multiple
+                input values to the same stored value.
+        """
 
         if store_is_empty(self.store):
             raise UpdateError("Cannot update empty Store.")

--- a/tests/storage/test_zarr_compat.py
+++ b/tests/storage/test_zarr_compat.py
@@ -1,0 +1,88 @@
+"""Tests for zarr storage compatibility helpers."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import zarr
+
+from openghg.storage._zarr_compat import (
+    clear_store,
+    iter_store_keys,
+    make_local_store,
+    make_memory_store,
+    store_byte_size,
+    store_is_empty,
+    zarr_has_async_store_api,
+    zarr_major_version,
+)
+
+
+def _put_bytes(store: object, key: str, value: bytes) -> None:
+    store[key] = value  # type: ignore[index]
+
+
+def test_zarr_version_capability_detection() -> None:
+    """Check that zarr version helpers reflect the installed package."""
+    assert zarr_major_version() == int(zarr.__version__.split(".", maxsplit=1)[0])
+    assert zarr_has_async_store_api() is (zarr_major_version() >= 3)
+
+
+def test_memory_store_helpers() -> None:
+    """Check memory store creation, key iteration, size, and clearing."""
+    store = make_memory_store()
+
+    assert store_is_empty(store)
+
+    _put_bytes(store, "a", b"abc")
+    _put_bytes(store, "group/b", b"de")
+
+    assert not store_is_empty(store)
+    assert sorted(iter_store_keys(store)) == ["a", "group/b"]
+    assert sorted(iter_store_keys(store, prefix="group")) == ["group/b"]
+    assert store_byte_size(store) == 5
+    assert store_byte_size(store, prefix="group") == 2
+
+    clear_store(store, prefix="group")
+
+    assert sorted(iter_store_keys(store)) == ["a"]
+    assert store_byte_size(store) == 3
+
+    clear_store(store)
+
+    assert store_is_empty(store)
+
+
+def test_local_store_helpers(tmp_path: Path) -> None:
+    """Check local store creation, sizing, and clearing."""
+    store = make_local_store(tmp_path)
+
+    assert store_is_empty(store)
+
+    _put_bytes(store, "data/.zarray", b"{}")
+    _put_bytes(store, "data/0", b"1234")
+
+    assert sorted(iter_store_keys(store)) == ["data/.zarray", "data/0"]
+    assert store_byte_size(store) == 6
+
+    clear_store(store)
+
+    assert store_is_empty(store)
+
+
+def test_zarr_store_uses_compat_layer() -> None:
+    """Check _zarr_store avoids zarr v2-only imports and factories."""
+    source = Path("openghg/storage/_zarr_store.py").read_text()
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_names = {alias.name for alias in node.names}
+            assert "zarr.convenience" not in imported_names
+
+        if isinstance(node, ast.ImportFrom):
+            assert node.module != "zarr._storage.store"
+
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == "zarr":
+            assert node.attr not in {"DirectoryStore", "MemoryStore"}

--- a/tests/storage/test_zarr_compat.py
+++ b/tests/storage/test_zarr_compat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 import zarr
@@ -19,7 +20,34 @@ from openghg.storage._zarr_compat import (
 )
 
 
+class AsyncPrefixStore:
+    """Small v3-style async store fake for prefix helper tests."""
+
+    def __init__(self) -> None:
+        self.values: dict[str, bytes] = {}
+
+    async def list(self) -> AsyncIterator[str]:
+        """Yield all keys."""
+        for key in self.values:
+            yield key
+
+    async def list_prefix(self, prefix: str) -> AsyncIterator[str]:
+        """Yield keys using zarr v3's broad prefix semantics."""
+        for key in self.values:
+            if key.startswith(prefix):
+                yield key
+
+    async def getsize(self, key: str) -> int:
+        """Return the size of a stored byte value."""
+        return len(self.values[key])
+
+    async def delete(self, key: str) -> None:
+        """Delete a stored key."""
+        del self.values[key]
+
+
 def _put_bytes(store: object, key: str, value: bytes) -> None:
+    """Write a byte value to a mapping-like zarr store."""
     store[key] = value  # type: ignore[index]
 
 
@@ -52,6 +80,36 @@ def test_memory_store_helpers() -> None:
     clear_store(store)
 
     assert store_is_empty(store)
+
+
+def test_prefix_helpers_do_not_match_sibling_prefixes() -> None:
+    """Check prefix helpers do not include keys from similarly named siblings."""
+    store = make_memory_store()
+    _put_bytes(store, "group/a", b"a")
+    _put_bytes(store, "grouped/a", b"bb")
+
+    assert sorted(iter_store_keys(store, prefix="group")) == ["group/a"]
+    assert store_byte_size(store, prefix="group") == 1
+
+    clear_store(store, prefix="group")
+
+    assert sorted(iter_store_keys(store)) == ["grouped/a"]
+    assert store_byte_size(store) == 2
+
+
+def test_async_prefix_helpers_filter_v3_prefix_results() -> None:
+    """Check v3-style broad prefix listings are filtered to path boundaries."""
+    store = AsyncPrefixStore()
+    store.values["group/a"] = b"a"
+    store.values["grouped/a"] = b"bb"
+
+    assert sorted(iter_store_keys(store, prefix="group")) == ["group/a"]
+    assert store_byte_size(store, prefix="group") == 1
+
+    clear_store(store, prefix="group")
+
+    assert sorted(iter_store_keys(store)) == ["grouped/a"]
+    assert store_byte_size(store) == 2
 
 
 def test_local_store_helpers(tmp_path: Path) -> None:


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Adds a local zarr compatibility layer for OpenGHG storage as the first step in the zarr v3 migration. The new `openghg.storage._zarr_compat` module centralises zarr version/capability checks, memory/local store creation, empty checks, key iteration, prefix-safe clearing, byte-size calculation, and store copying. `openghg.storage._zarr_store` now uses these helpers instead of importing `zarr.convenience`, the private `zarr._storage.store.Store`, or directly constructing top-level zarr v2 store classes.

This keeps the current pinned zarr v2 behavior intact while creating a single compatibility boundary for later migration work.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1659
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation updated/added

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*

Not needed for this PR:

- Tutorials updated/added: no tutorial-facing behavior changed.
- Wiki updated: no wiki-facing behavior changed.
- CHANGELOG entry: internal compatibility boundary only; no public API or dependency behavior changed.
- Package requirements: no new dependencies were added.

Validation run locally:

- `.venv/bin/python -m pytest tests/storage/test_zarr_compat.py tests/storage/test_store.py tests/store/test_datasource.py` -> 107 passed, 1 xfailed.
- `.venv/bin/python -m black --check openghg/storage/_zarr_compat.py openghg/storage/_zarr_store.py tests/storage/test_zarr_compat.py` -> passed.
- `.venv/bin/python -m flake8 openghg/storage/_zarr_compat.py openghg/storage/_zarr_store.py tests/storage/test_zarr_compat.py` -> passed.
- `.venv/bin/python -m mypy --python-version 3.10 openghg/storage/_zarr_compat.py openghg/storage/_zarr_store.py` -> passed.

Notes:

- `uv run ruff check ...` and `uv run ruff format --check ...` could not run because `ruff` is not installed in the locked environment.
- `copy_store` currently delegates to `zarr.copy_store` when available and raises `NotImplementedError` otherwise; #1660 should replace this with the OpenGHG copy helper for zarr v3.
- `zarr.ThreadSynchronizer()` remains in `_zarr_store.py`; #1662 is expected to remove that and adopt xarray chunk-alignment behavior.