### PR TITLE
flux and bc to use required_keys from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added a dimension dtype checker for H_back dimension to "timedelta64[ns]". Bug occured for dimension "resolution" and dtype "resolution".[PR #1671](https://github.com/openghg/openghg/pull/1671)
+- Added config-driven metadata key handling for transformed flux and boundary condition data: removed hard-coded required-key lookups.[PR #1686](https://github.com/openghg/openghg/pull/1686)
 
 ### Updated
 

--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -173,13 +173,13 @@ class BoundaryConditions(BaseStore):
         parser_fn = load_transform_parser(data_type=self._data_type, source_format=database)
 
         # Define parameters to pass to the parser function and remaining keys
-        parser_input_parameters, additional_input_parameters = split_function_inputs(
+        fn_input_parameters, additional_input_parameters = split_function_inputs(
             fn_input_parameters, parser_fn
         )
 
         # Call appropriate standardisation function with input parameters
         try:
-            bc_data = parser_fn(**parser_input_parameters)
+            bc_data = parser_fn(**fn_input_parameters)
         except (TypeError, ValueError) as err:
             msg = f"Error during transformation of data(s): {datapath}. Error: {err}"
             logger.exception(msg)
@@ -189,18 +189,8 @@ class BoundaryConditions(BaseStore):
         for mdd in bc_data:
             BoundaryConditions.validate_data(mdd.data)
 
-        required_keys = ("species", "bc_input", "domain")
-
-        if info_metadata:
-            common_keys = set(required_keys) & set(info_metadata.keys())
-
-            if common_keys:
-                raise ValueError(
-                    f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
-                )
-            else:
-                for parsed_data in bc_data:
-                    parsed_data.metadata.update(info_metadata)
+        # Check to ensure no required keys are being passed through info_metadata dict
+        self.check_info_keys(info_metadata)
 
         # Mop up and add additional keys to metadata which weren't passed to the parser
         bc_data = self.update_metadata(
@@ -211,7 +201,6 @@ class BoundaryConditions(BaseStore):
             data=bc_data,
             if_exists=if_exists,
             new_version=new_version,
-            required_keys=required_keys,
             compressor=compressor,
             filters=filters,
         )

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -146,9 +146,8 @@ class Flux(BaseStore):
 
         TODO: Could allow Callable[..., Dataset] type for a pre-defined function be passed
         """
-        import inspect
         from openghg.store.spec import define_transform_parsers
-        from openghg.util import load_transform_parser, check_if_need_new_version
+        from openghg.util import load_transform_parser, check_if_need_new_version, split_function_inputs
 
         if overwrite and if_exists == "auto":
             logger.warning(
@@ -159,7 +158,9 @@ class Flux(BaseStore):
 
         new_version = check_if_need_new_version(if_exists, save_current)
 
-        datapath = Path(datapath)
+        # Format input parameters (specific to data_type)
+        fn_input_parameters = self.format_inputs(**kwargs)
+        fn_input_parameters["datapath"] = Path(datapath)
 
         transform_parsers = define_transform_parsers()[self._data_type]
 
@@ -171,14 +172,12 @@ class Flux(BaseStore):
         # Load the data retrieve object
         parser_fn = load_transform_parser(data_type=self._data_type, source_format=database)
 
-        # Find all parameters that can be accepted by parse function
-        all_param = list(inspect.signature(parser_fn).parameters.keys())
+        # Define parameters to pass to the parser function and remaining keys
+        fn_input_parameters, additional_input_parameters = split_function_inputs(
+            fn_input_parameters, parser_fn
+        )
 
-        # Define parameters to pass to the parser function from kwargs
-        param: dict[Any, Any] = {key: value for key, value in kwargs.items() if key in all_param}
-        param["datapath"] = datapath  # Add datapath explicitly (for now)
-
-        flux_data = parser_fn(**param)
+        flux_data = parser_fn(**fn_input_parameters)
 
         chunks = self.check_chunks(
             ds=flux_data[0].data,
@@ -194,32 +193,26 @@ class Flux(BaseStore):
                 mdd.data = mdd.data.chunk(chunks)
             Flux.validate_data(mdd.data)
 
-        required_keys = ("species", "source", "domain")
+        # Check to ensure no required keys are being passed through info_metadata dict
+        self.check_info_keys(info_metadata)
 
-        if info_metadata:
-            common_keys = set(required_keys) & set(info_metadata.keys())
-
-            if common_keys:
-                raise ValueError(
-                    f"The following optional metadata keys are already present in required keys: {', '.join(common_keys)}"
-                )
-            else:
-                for parsed_data in flux_data:
-                    parsed_data.metadata.update(info_metadata)
+        # Mop up and add additional keys to metadata which weren't passed to the parser
+        flux_data = self.update_metadata(
+            flux_data, additional_input_parameters, additional_metadata=info_metadata
+        )
 
         datasource_uuids = self.assign_data(
             data=flux_data,
             if_exists=if_exists,
             new_version=new_version,
-            required_keys=required_keys,
             compressor=compressor,
             filters=filters,
         )
 
         # "date" used to be part of the "keys" in the old datasource_uuids format
-        if "date" in param:
+        if "date" in fn_input_parameters:
             for du in datasource_uuids:
-                du["date"] = param["date"]
+                du["date"] = fn_input_parameters["date"]
 
         return datasource_uuids
 

--- a/tests/store/test_flux.py
+++ b/tests/store/test_flux.py
@@ -465,7 +465,7 @@ def test_transform_and_add_edgar_database(clear_stores):
     species = "ch4"
     default_source = "anthro"
 
-    expected_info = {"species": species, "source": default_source, "domain": domain, "date": date}
+    expected_info = {"species": species, "source": default_source, "domain": domain.lower(), "date": date}
     assert len(proc_results) == 1
     assert expected_info.items() <= proc_results[0].items()
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Restored config-driven metadata key handling for transformed flux and boundary condition data: removed hard-coded required-key lookups in store transform paths and now rely on BaseStore metadata/update flow so required and optional lookup keys are taken from object-store metakey config defaults/custom config. Also aligned transform parser input preparation to consistently use fn_input_parameters before split_function_inputs

* **Please check if the PR fulfills these requirements**

- [x] Closes #1381 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*
