### PR TITLE
Speed up object-store-heavy tests

### DIFF
--- a/tests/analyse/conftest.py
+++ b/tests/analyse/conftest.py
@@ -1,274 +1,276 @@
+"""Explicit object-store data bundles for analyse integration tests.
+
+Fixtures in this module populate the default ``user`` store and return that
+store name so consumers can pass it to retrieval functions. Request the
+narrowest bundle that supplies a test's stored-data requirements:
+
+* ``tac_surface_store``: TAC 2012 CRDS surface observations (CH4 and CO2).
+* ``tac_ch4_store``: TAC surface, anthropogenic and waste fluxes, boundary
+  conditions, and the European footprint.
+* ``tac_co2_store``: TAC surface, natural and ocean fluxes, boundary
+  conditions, and the CO2 footprint.
+* ``wao_radon_store``: WAO radon surface observations and footprint.
+* ``satellite_cams_store``: GOSAT column observations and CAMS footprint.
+* ``satellite_name_store``: GOSAT column observations, NAME footprint, and
+  South American flux.
+
+Synthetic tests should not request any of these fixtures. The bundles are
+session-scoped and intended for read-only consumers, so tests that clear or
+mutate an object store must use isolated store configuration rather than
+invalidating them.
+"""
+
 import pytest
 from helpers import (
-    clear_test_stores,
     get_bc_datapath,
+    get_column_datapath,
     get_flux_datapath,
     get_footprint_datapath,
     get_surface_datapath,
-    get_column_datapath,
 )
+
 from openghg.standardise import (
     standardise_bc,
+    standardise_column,
     standardise_flux,
     standardise_footprint,
     standardise_surface,
-    standardise_column,
 )
 
 
-@pytest.fixture(scope="module", autouse=True)
-def data_read():
+@pytest.fixture(scope="session")
+def tac_surface_store(default_test_store: str) -> str:
+    """Populate the default session store with TAC 2012 surface observations.
+
+    Args:
+        default_test_store: Writable store name to populate.
+
+    Returns:
+        The populated store name.
     """
-    Data set up for running tests for these sets of modules.
+    filepath = get_surface_datapath(filename="tac.picarro.1minute.100m.201208.dat", source_format="CRDS")
+    standardise_surface(
+        store=default_test_store,
+        filepath=filepath,
+        source_format="CRDS",
+        site="tac",
+        network="DECC",
+    )
+    return default_test_store
+
+
+@pytest.fixture(scope="session")
+def tac_ch4_store(tac_surface_store: str) -> str:
+    """Extend the TAC surface store with the CH4 scenario data.
+
+    Args:
+        tac_surface_store: Session store containing TAC surface observations.
+
+    Returns:
+        The populated store name.
     """
-    clear_test_stores()
+    store = tac_surface_store
+    for source, filename in (
+        ("anthro", "ch4-anthro_EUROPE_2012.nc"),
+        ("waste", "ch4-ukghg-waste_EUROPE_2012.nc"),
+    ):
+        standardise_flux(
+            store=store,
+            filepath=get_flux_datapath(filename),
+            species="ch4",
+            source=source,
+            domain="EUROPE",
+            time_resolved=False,
+        )
 
-    # Files for creating forward model (mf_mod) for methane and carbon dioxide at TAC site
-
-    # Observation data
-    #  - TAC at 100m for 201208 and 201407
-    #  - Includes CH4 and CO2 data
-    site1 = "tac"
-    network1 = "DECC"
-    source_format1 = "CRDS"
-
-    tac_path1 = get_surface_datapath(filename="tac.picarro.1minute.100m.201208.dat", source_format="CRDS")
-    tac_path2 = get_surface_datapath(filename="tac.picarro.1minute.100m.201407.dat", source_format="CRDS")
-    tac_filepaths = [tac_path1, tac_path2]
-
-    # WAO data for radon from 2021-12-04 (data level 1 (NRT product) from ICOS)
-    # - This has been standardised through openghg already from download.
-    # - This data was then output to a netcdf file we can read.
-    site2 = "wao"
-    network2 = "ICOS"
-    source_format2 = "OPENGHG"
-
-    wao_path = get_surface_datapath(
-        filename="wao_rn_icos_standardised_2021-12-04.nc", source_format="OPENGHG"
-    )
-
-    standardise_surface(
-        store="user", filepath=tac_filepaths, source_format=source_format1, site=site1, network=network1
-    )
-    standardise_surface(
-        store="user",
-        filepath=wao_path,
-        source_format=source_format2,
-        site=site2,
-        network=network2,
-        inlet="10m",
-        update_mismatch="metadata",
-    )
-
-    # Emissions / Flux data
-    # Anthropogenic ch4 (methane) data from 2012 for EUROPE
-    source1 = "anthro"
-    domain = "EUROPE"
-    flux_datapath1 = get_flux_datapath("ch4-anthro_EUROPE_2012.nc")
-
-    standardise_flux(
-        store="user",
-        filepath=flux_datapath1,
-        species="ch4",
-        source=source1,
-        domain=domain,
-        high_time_resolution=False,
-    )
-
-    # Waste data for CH4 (from UKGHG model)
-    source2 = "waste"
-    flux_datapath2 = get_flux_datapath("ch4-ukghg-waste_EUROPE_2012.nc")
-
-    standardise_flux(
-        store="user",
-        filepath=flux_datapath2,
-        species="ch4",
-        source=source2,
-        domain=domain,
-        high_time_resolution=False,
-    )
-
-    # Natural sources for CO2 (R-total from Cardamom)
-    #  - 2 hourly (high resolution?)
-    source3 = "natural-rtot"
-    flux_datapath3 = get_flux_datapath("co2-rtot-cardamom-2hr_TEST_2014.nc")
-
-    standardise_flux(
-        filepath=flux_datapath3,
-        species="co2",
-        source=source3,
-        domain="TEST",
-        time_resolved=True,
-        store="user",
-    )
-
-    # Ocean flux for CO2
-    #  - monthly (cut down data to 1 month)
-    source4 = "ocean"
-
-    flux_datapath4a = get_flux_datapath("co2-nemo-ocean-mth_TEST_2013.nc")
-    flux_datapath4b = get_flux_datapath("co2-nemo-ocean-mth_TEST_2014.nc")
-
-    standardise_flux(
-        filepath=flux_datapath4a,
-        species="co2",
-        source=source4,
-        domain="TEST",
-        time_resolved=False,
-        period="1 month",
-        store="user",
-    )
-
-    standardise_flux(
-        filepath=flux_datapath4b,
-        species="co2",
-        source=source4,
-        domain="TEST",
-        time_resolved=False,
-        period="1 month",
-        store="user",
-    )
-
-    # Boundary conditions data
-    # CH4
-    bc_filepath1 = get_bc_datapath("ch4_EUROPE_201208.nc")
     standardise_bc(
-        store="user",
-        filepath=bc_filepath1,
+        store=store,
+        filepath=get_bc_datapath("ch4_EUROPE_201208.nc"),
         species="ch4",
         domain="EUROPE",
         bc_input="MOZART",
         period="monthly",
     )
+    standardise_footprint(
+        store=store,
+        filepath=get_footprint_datapath("TAC-100magl_EUROPE_201208.nc"),
+        site="tac",
+        model="NAME",
+        network="DECC",
+        height="100m",
+        domain="EUROPE",
+    )
+    return store
 
-    # CO2
-    bc_filepath1 = get_bc_datapath("co2_TEST_201407.nc")
+
+@pytest.fixture(scope="session")
+def tac_co2_store(default_test_store: str) -> str:
+    """Populate the default session store with the TAC CO2 scenario data.
+
+    Args:
+        default_test_store: Writable store name to populate.
+
+    Returns:
+        The populated store name.
+    """
+    store = default_test_store
+    standardise_surface(
+        store=store,
+        filepath=get_surface_datapath(filename="tac.picarro.1minute.100m.201407.dat", source_format="CRDS"),
+        source_format="CRDS",
+        site="tac",
+        network="DECC",
+    )
+
+    standardise_flux(
+        store=store,
+        filepath=get_flux_datapath("co2-rtot-cardamom-2hr_TEST_2014.nc"),
+        species="co2",
+        source="natural-rtot",
+        domain="TEST",
+        time_resolved=True,
+    )
+    for filename in (
+        "co2-nemo-ocean-mth_TEST_2013.nc",
+        "co2-nemo-ocean-mth_TEST_2014.nc",
+    ):
+        standardise_flux(
+            store=store,
+            filepath=get_flux_datapath(filename),
+            species="co2",
+            source="ocean",
+            domain="TEST",
+            time_resolved=False,
+            period="1 month",
+        )
+
     standardise_bc(
-        store="user",
-        filepath=bc_filepath1,
+        store=store,
+        filepath=get_bc_datapath("co2_TEST_201407.nc"),
         species="co2",
         domain="TEST",
         bc_input="MOZART",
         period="monthly",
     )
-
-    # Footprint data
-    # TAC footprint from 2012-08 - 2012-09 at 100m
-    height1 = "100m"
-    model1 = "NAME"
-
-    fp_datapath1 = get_footprint_datapath("TAC-100magl_EUROPE_201208.nc")
     standardise_footprint(
-        store="user",
-        filepath=fp_datapath1,
-        site=site1,
-        model=model1,
-        network=network1,
-        height=height1,
-        domain=domain,
-    )
-
-    # TAC footprint from 2014-07 - 2014-09 at 100m for CO2 (high time resolution)
-    fp_datapath2 = get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc")
-    standardise_footprint(
-        store="user",
-        filepath=fp_datapath2,
-        site=site1,
-        model=model1,
-        network=network1,
+        store=store,
+        filepath=get_footprint_datapath("TAC-100magl_UKV_co2_TEST_201407.nc"),
+        site="tac",
+        model="NAME",
+        network="DECC",
         met_model="UKV",
-        height=height1,
+        height="100m",
         domain="TEST",
         species="co2",
     )
+    return store
 
-    # WAO radon footprint from 2021-12-04
-    # - cut down from full file to one day
-    # - cut down to only include TEST domain rather than full EUROPE
-    fp_height2 = "20m"
-    model2 = "NAME"
-    domain2 = "TEST"
-    species2 = "rn"  # Species-specific footprint for short-lived species.
 
-    fp_datapath2 = get_footprint_datapath("WAO-20magl_UKV_rn_TEST_202112.nc")
-    standardise_footprint(
-        store="user",
-        filepath=fp_datapath2,
-        site=site2,
-        model=model2,
-        network=network2,
-        height=fp_height2,
-        domain=domain2,
-        species=species2,
-    )
+@pytest.fixture(scope="session")
+def wao_radon_store(default_test_store: str) -> str:
+    """Populate the default session store with WAO radon data.
 
-    # Populating with satellite data for ObsColumn
-    filepath = get_column_datapath(filename="gosat-fts_gosat_20170318_ch4-column.nc")
+    Args:
+        default_test_store: Writable store name to populate.
 
-    satellite = "GOSAT"
-    selection = "LAND"
-    species = "CH4"
-    obs_region = "BRAZIL"
-    domain = "SOUTHAMERICA"
-
-    standardise_column(
-        filepath=filepath,
+    Returns:
+        The populated store name.
+    """
+    store = default_test_store
+    standardise_surface(
+        store=store,
+        filepath=get_surface_datapath(
+            filename="wao_rn_icos_standardised_2021-12-04.nc", source_format="OPENGHG"
+        ),
         source_format="OPENGHG",
-        satellite=satellite,
-        species=species,
-        obs_region=obs_region,
-        selection=selection,
-        store="user",
+        site="wao",
+        network="ICOS",
+        inlet="10m",
+        update_mismatch="metadata",
     )
-
-    # Populating with satellite data for footprints
-    datapath = get_footprint_datapath("GOSAT-BRAZIL-column_SOUTHAMERICA_201004_compressed.nc")
-
-    satellite = "GOSAT"
-    network = "GOSAT"
-    domain = "SOUTHAMERICA"
-    obs_region = "BRAZIL"
-
     standardise_footprint(
-        filepath=datapath,
-        satellite=satellite,
-        network=network,
+        store=store,
+        filepath=get_footprint_datapath("WAO-20magl_UKV_rn_TEST_202112.nc"),
+        site="wao",
+        model="NAME",
+        network="ICOS",
+        height="20m",
+        domain="TEST",
+        species="rn",
+    )
+    return store
+
+
+@pytest.fixture(scope="session")
+def satellite_cams_store(default_test_store: str) -> str:
+    """Populate the default session store with GOSAT/CAMS validation data.
+
+    Args:
+        default_test_store: Writable store name to populate.
+
+    Returns:
+        The populated store name.
+    """
+    store = default_test_store
+    standardise_column(
+        store=store,
+        filepath=get_column_datapath(filename="gosat-fts_gosat_20170318_ch4-column.nc"),
+        source_format="OPENGHG",
+        satellite="GOSAT",
+        species="CH4",
+        obs_region="BRAZIL",
+        selection="LAND",
+    )
+    standardise_footprint(
+        store=store,
+        filepath=get_footprint_datapath("GOSAT-BRAZIL-column_SOUTHAMERICA_201004_compressed.nc"),
+        satellite="GOSAT",
+        network="GOSAT",
         model="CAMS",
         inlet="column",
         period="1S",
-        domain=domain,
-        obs_region=obs_region,
+        domain="SOUTHAMERICA",
+        obs_region="BRAZIL",
         selection="LAND",
-        store="user",
         continuous=False,
     )
+    return store
 
-    # Testing footprint realignment with obs column data
 
-    col_filepath = get_column_datapath("gosat-fts_gosat_20160101_ch4-column.nc")
-    col_fp_filepath = get_footprint_datapath("GOSAT-BRAZIL-column_SOUTHAMERICA_201601.nc")
-    flux_filepath = get_flux_datapath(
-        "ch4-all_SOUTHAMERICA_2016_SWAMPS-v32-5_Saunois-Annual-Mean_20160101.nc"
-    )
+@pytest.fixture(scope="session")
+def satellite_name_store(default_test_store: str) -> str:
+    """Populate the default session store with GOSAT/NAME merge data.
 
+    Args:
+        default_test_store: Writable store name to populate.
+
+    Returns:
+        The populated store name.
+    """
+    store = default_test_store
     standardise_column(
-        filepath=col_filepath,
+        store=store,
+        filepath=get_column_datapath("gosat-fts_gosat_20160101_ch4-column.nc"),
         species="ch4",
         platform="satellite",
         satellite="gosat",
         obs_region="brazil",
         network="gosat",
-        store="user",
     )
-
     standardise_footprint(
-        filepath=col_fp_filepath,
+        store=store,
+        filepath=get_footprint_datapath("GOSAT-BRAZIL-column_SOUTHAMERICA_201601.nc"),
         model="name",
         domain="southamerica",
         satellite="gosat",
         obs_region="brazil",
         inlet="column",
-        store="user",
     )
-
-    standardise_flux(filepath=flux_filepath, species="ch4", source="all", domain="southamerica", store="user")
+    standardise_flux(
+        store=store,
+        filepath=get_flux_datapath("ch4-all_SOUTHAMERICA_2016_SWAMPS-v32-5_Saunois-Annual-Mean_20160101.nc"),
+        species="ch4",
+        source="all",
+        domain="southamerica",
+    )
+    return store

--- a/tests/analyse/test_alignment.py
+++ b/tests/analyse/test_alignment.py
@@ -3,16 +3,17 @@ import pandas as pd
 import pytest
 
 from openghg.analyse._alignment import (
+    _buffer_start_and_end_dates,
     _extract_obs_freq,
     infer_freq_in_seconds,
     time_overlap,
-    _buffer_start_and_end_dates,
 )
-from openghg.retrieve import get_obs_surface, get_footprint
+from openghg.retrieve import get_obs_surface
 
 
 @pytest.fixture
-def obs_data():
+def obs_data(tac_surface_store):
+    """Return TAC observations from the explicitly populated user store."""
     start_date = "2012-01-01"
     end_date = "2013-01-01"
 
@@ -22,27 +23,19 @@ def obs_data():
     inlet = "100m"
 
     obs_surface = get_obs_surface(
-        site=site, species=species, start_date=start_date, end_date=end_date, inlet=inlet, network=network
+        site=site,
+        species=species,
+        start_date=start_date,
+        end_date=end_date,
+        inlet=inlet,
+        network=network,
+        store=tac_surface_store,
     )
     return obs_surface
 
 
-@pytest.fixture
-def footprint_data():
-    start_date = "2012-01-01"
-    end_date = "2013-01-01"
-
-    site = "tac"
-    domain = "EUROPE"
-    inlet = "100m"
-
-    footprint = get_footprint(
-        site=site, domain=domain, height=inlet, start_date=start_date, end_date=end_date
-    )
-    return footprint
-
-
 def test_extract_obs_freq(obs_data):
+    """Test extracting a declared sampling frequency from real observations."""
     # this obs data has "sampling period" attribute:
     assert _extract_obs_freq(obs_data.data) == 60.0
 

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -4,15 +4,15 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from helpers import clear_test_stores
-from openghg.analyse import ModelScenario, calc_dim_resolution, match_dataset_dims, stack_datasets
-from openghg.dataobjects import ObsData
-from openghg.retrieve import get_bc, get_flux, get_footprint, get_obs_surface, get_obs_column
 from pandas import Timestamp
 from xarray import Dataset
 
+from openghg.analyse import ModelScenario, calc_dim_resolution, match_dataset_dims, stack_datasets
+from openghg.dataobjects import ObsData
+from openghg.retrieve import get_bc, get_flux, get_footprint, get_obs_column, get_obs_surface
 
-def test_scenario_direct_objects():
+
+def test_scenario_direct_objects(tac_ch4_store):
     """
     Test ModelScenario class can be created with direct objects
     (ObsData, FootprintData, FluxData)
@@ -36,15 +36,21 @@ def test_scenario_direct_objects():
         inlet=inlet,
         network=network,
         target_units={"mf_variability": "ppm"},
+        store=tac_ch4_store,
     )
 
     footprint = get_footprint(
-        site=site, domain=domain, height=inlet, start_date=start_date, end_date=end_date
+        site=site,
+        domain=domain,
+        height=inlet,
+        start_date=start_date,
+        end_date=end_date,
+        store=tac_ch4_store,
     )
 
-    flux = get_flux(species=species, domain=domain, source=source)
+    flux = get_flux(species=species, domain=domain, source=source, store=tac_ch4_store)
 
-    bc = get_bc(species=species, domain=domain, bc_input=bc_input)
+    bc = get_bc(species=species, domain=domain, bc_input=bc_input, store=tac_ch4_store)
 
     model_scenario = ModelScenario(obs=obs_surface, footprint=footprint, flux=flux, bc=bc)
 
@@ -61,7 +67,7 @@ def test_scenario_direct_objects():
     xr.testing.assert_equal(model_scenario.bc.data, bc.data)
 
 
-def test_scenario_infer_inputs_ch4():
+def test_scenario_infer_inputs_ch4(tac_ch4_store):
     """
     Test ModelScenario can find underlying data based on keyword inputs.
     """
@@ -88,6 +94,7 @@ def test_scenario_infer_inputs_ch4():
         bc_input=bc_input,
         start_date=start_date,
         end_date=end_date,
+        store=tac_ch4_store,
     )
 
     # Check data is being found and stored
@@ -143,8 +150,8 @@ def test_scenario_infer_inputs_ch4():
 
 
 @pytest.fixture
-def model_scenario_co2():
-    """Fixture to create model scenario object with co2 data for testing"""
+def model_scenario_co2(tac_co2_store):
+    """Create a CO2 model scenario from the explicitly populated user store."""
     start_date = "2014-07-01"
     end_date = "2014-08-01"
 
@@ -165,17 +172,20 @@ def model_scenario_co2():
         sources=source,
         start_date=start_date,
         end_date=end_date,
+        store=tac_co2_store,
     )
 
-    return { "scenario_co2": scenario,
-                "start_date" : "2014-07-01",
-                "end_date" : "2014-08-01",
-                "site" : "tac",
-                "domain" : "TEST",
-                "inlet" : "100m",
-                "network" : "DECC",
-                "species" : "co2",
-                "source" : "natural-rtot"}
+    return {
+        "scenario_co2": scenario,
+        "start_date": "2014-07-01",
+        "end_date": "2014-08-01",
+        "site": "tac",
+        "domain": "TEST",
+        "inlet": "100m",
+        "network": "DECC",
+        "species": "co2",
+        "source": "natural-rtot",
+    }
 
 
 def test_scenario_infer_inputs_co2(model_scenario_co2):
@@ -260,7 +270,7 @@ def test_plot_comparison_uses_mf_mod_high_res(model_scenario_co2, monkeypatch):
     np.testing.assert_allclose(np.asarray(modelled_trace.y), modelled_obs["mf_mod_high_res"].values)
 
 
-def test_scenario_flux_extend_co2():
+def test_scenario_flux_extend_co2(tac_co2_store):
     """
     Check ModelScenario can extract full date range of flux values for a given
     source.
@@ -289,6 +299,7 @@ def test_scenario_flux_extend_co2():
         sources=source,
         start_date=start_date,
         end_date=end_date,
+        store=tac_co2_store,
     )
 
     # Check data is being found and stored
@@ -303,7 +314,7 @@ def test_scenario_flux_extend_co2():
     assert flux_time[1] == Timestamp("2014-07-01T00:00:00")  # From test file 2 - reduced time axis
 
 
-def test_scenario_infer_inlet():
+def test_scenario_infer_inlet(tac_ch4_store):
     """
     Test ModelScenario can find underlying data for both observations and
     footprint when omitting the inlet label. This should be inferred from the
@@ -319,7 +330,13 @@ def test_scenario_infer_inlet():
 
     # Explicitly not including inlet to test this can be inferred from obs data.
     model_scenario = ModelScenario(
-        site=site, species=species, domain=domain, sources=source, start_date=start_date, end_date=end_date
+        site=site,
+        species=species,
+        domain=domain,
+        sources=source,
+        start_date=start_date,
+        end_date=end_date,
+        store=tac_ch4_store,
     )
 
     assert model_scenario.obs is not None
@@ -330,7 +347,7 @@ def test_scenario_infer_inlet():
     assert model_scenario.fp_inlet == "100m"
 
 
-def test_scenario_mult_fluxes():
+def test_scenario_mult_fluxes(tac_ch4_store):
     """
     Extract multiple flux sources at once from available data
     """
@@ -352,6 +369,7 @@ def test_scenario_mult_fluxes():
         sources=sources,
         start_date=start_date,
         end_date=end_date,
+        store=tac_ch4_store,
     )
 
     for source in sources:
@@ -371,7 +389,7 @@ def test_scenario_too_few_inputs():
     assert model_scenario.footprint is None
 
 
-def test_scenario_uses_fp_inlet():
+def test_scenario_uses_fp_inlet(tac_ch4_store):
     """
     Test ModelScenario is using fp_inlet in place of inlet if this is passed.
     In this case we expect the observation data to be found but the footprint
@@ -394,6 +412,7 @@ def test_scenario_uses_fp_inlet():
         fp_inlet=fp_inlet,
         start_date=start_date,
         end_date=end_date,
+        store=tac_ch4_store,
     )
 
     # Expect observation data to be found
@@ -404,7 +423,7 @@ def test_scenario_uses_fp_inlet():
     assert model_scenario.footprint is None
 
 
-def test_scenario_matches_fp_inlet():
+def test_scenario_matches_fp_inlet(wao_radon_store):
     """
     Test ModelScenario is able to use "height_name" data from site_info file to
     map between different inlet values for observation data and footprints.
@@ -428,7 +447,13 @@ def test_scenario_matches_fp_inlet():
     inlet = "10m"
 
     model_scenario = ModelScenario(
-        site=site, species=species, inlet=inlet, domain=domain, start_date=start_date, end_date=end_date
+        site=site,
+        species=species,
+        inlet=inlet,
+        domain=domain,
+        start_date=start_date,
+        end_date=end_date,
+        store=wao_radon_store,
     )
 
     expected_obs_inlet = inlet  # inlet for observation data
@@ -444,7 +469,7 @@ def test_scenario_matches_fp_inlet():
     assert model_scenario.fp_inlet == expected_fp_inlet
 
 
-def test_add_data():
+def test_add_data(tac_ch4_store):
     """
     Test add_* functions can be used to add new data after initalisation step.
     """
@@ -457,10 +482,21 @@ def test_add_data():
 
     model_scenario = ModelScenario()
 
-    model_scenario.add_obs(site=site, species=species, inlet=inlet)
-    model_scenario.add_footprint(site=site, inlet=inlet, domain=domain, species=species)
-    model_scenario.add_flux(species=species, domain=domain, sources=source)
-    model_scenario.add_bc(species=species, domain=domain)
+    model_scenario.add_obs(site=site, species=species, inlet=inlet, store=tac_ch4_store)
+    model_scenario.add_footprint(
+        site=site,
+        inlet=inlet,
+        domain=domain,
+        species=species,
+        store=tac_ch4_store,
+    )
+    model_scenario.add_flux(
+        species=species,
+        domain=domain,
+        sources=source,
+        store=tac_ch4_store,
+    )
+    model_scenario.add_bc(species=species, domain=domain, store=tac_ch4_store)
 
     assert model_scenario.obs is not None
     assert model_scenario.footprint is not None
@@ -469,8 +505,8 @@ def test_add_data():
 
 
 @pytest.fixture(scope="function")
-def model_scenario_1():
-    """Create model scenario as fixture for data in object store"""
+def model_scenario_1(tac_ch4_store):
+    """Create a CH4 model scenario from the explicitly populated user store."""
 
     start_date = "2012-01-01"
     end_date = "2013-01-01"
@@ -493,6 +529,7 @@ def model_scenario_1():
         bc_input=bc_input,
         start_date=start_date,
         end_date=end_date,
+        store=tac_ch4_store,
     )
 
     return model_scenario
@@ -556,13 +593,18 @@ def test_calc_modelled_obs_period(model_scenario_1):
         # Could add more checks here but may be better doing this with mocked data
 
 
-def test_add_multiple_flux(model_scenario_1):
+def test_add_multiple_flux(model_scenario_1, tac_ch4_store):
     """Test multiple flux sources can be added."""
     species = "ch4"
     source = "waste"
     domain = "EUROPE"
 
-    model_scenario_1.add_flux(species=species, sources=source, domain=domain)
+    model_scenario_1.add_flux(
+        species=species,
+        sources=source,
+        domain=domain,
+        store=tac_ch4_store,
+    )
 
     expected_sources = ["anthro", source]
 
@@ -573,13 +615,18 @@ def test_add_multiple_flux(model_scenario_1):
         assert metadata["source"] == source
 
 
-def test_combine_flux_sources(model_scenario_1):
+def test_combine_flux_sources(model_scenario_1, tac_ch4_store):
     """Test fluxes can be combined to produce a stacked output"""
     species = "ch4"
     source = "waste"
     domain = "EUROPE"
 
-    model_scenario_1.add_flux(species=species, sources=source, domain=domain)
+    model_scenario_1.add_flux(
+        species=species,
+        sources=source,
+        domain=domain,
+        store=tac_ch4_store,
+    )
 
     flux_stacked = model_scenario_1.combine_flux_sources()
 
@@ -628,7 +675,7 @@ def test_footprints_data_merge(model_scenario_1):
     assert error_in_mod_obs < error_threshold
 
 
-def test_combine_obs_sampling_period_infer():
+def test_combine_obs_sampling_period_infer(wao_radon_store):
     """
     If the sampling_period is "NOT_SET" then when combining obs and footprints
     this should infer the sampling period from the frequency of the data but this
@@ -646,7 +693,13 @@ def test_combine_obs_sampling_period_infer():
     inlet = "10m"
 
     model_scenario = ModelScenario(
-        site=site, species=species, inlet=inlet, domain=domain, start_date=start_date, end_date=end_date
+        site=site,
+        species=species,
+        inlet=inlet,
+        domain=domain,
+        start_date=start_date,
+        end_date=end_date,
+        store=wao_radon_store,
     )
 
     obs_data_1 = model_scenario.obs.data
@@ -1495,8 +1548,8 @@ def test_stack_datasets_with_alignment(flux_daily, flux_daily_small_dim_diff):
     np.testing.assert_allclose(output_flux, expected_flux)
 
 
-def test_satellite_scenario_raises_error():
-    """Test to ensure ModelScenario instance raises error if max_level is not passed when platform argument is satellite"""
+def test_satellite_scenario_raises_error(satellite_cams_store):
+    """Test that a satellite ModelScenario requires ``max_level``."""
 
     satellite = "gosat"
     domain = "SOUTHAMERICA"
@@ -1504,20 +1557,28 @@ def test_satellite_scenario_raises_error():
     species = "ch4"
 
     obs_column = get_obs_column(
-        species=species, max_level=3, satellite=satellite, selection="land", store="user"
+        species=species,
+        max_level=3,
+        satellite=satellite,
+        selection="land",
+        store=satellite_cams_store,
     )
 
     footprint = get_footprint(
-        satellite=satellite, domain=domain, obs_region=obs_region, model="cams", store="user"
+        satellite=satellite,
+        domain=domain,
+        obs_region=obs_region,
+        model="cams",
+        store=satellite_cams_store,
     )
 
     with pytest.raises(AttributeError):
         # checks that ModelScenario fails if passing platform=satellite but not max_level
-        model_scenario = ModelScenario(obs_column=obs_column, footprint=footprint, platform="satellite")
+        ModelScenario(obs_column=obs_column, footprint=footprint, platform="satellite")
 
 
-def test_model_scenario_col_fp_data_merge():
-    """This is to test satellite data aligns fp to obs and satifies the fp_data_merge functionality"""
+def test_model_scenario_col_fp_data_merge(satellite_name_store):
+    """Test that satellite observations and footprints align during ``footprints_data_merge``."""
 
     satellite = "gosat"
     domain = "southamerica"
@@ -1530,7 +1591,7 @@ def test_model_scenario_col_fp_data_merge():
         start_date="2016-01-01 14:59:12.500000+00:00",
         end_date="2016-01-01 18:10:16.500000+00:00",
         obs_region="brazil",
-        store="user",
+        store=satellite_name_store,
     )
     fp_column_data = get_footprint(
         satellite=satellite,
@@ -1539,9 +1600,14 @@ def test_model_scenario_col_fp_data_merge():
         start_date="2016-01-01 14:59:12.500000+00:00",
         end_date="2016-01-01 19:10:16.500000+00:00",
         model="name",
-        store="user",
+        store=satellite_name_store,
     )
-    flux_data = get_flux(species="ch4", source="all", domain="southamerica")
+    flux_data = get_flux(
+        species="ch4",
+        source="all",
+        domain="southamerica",
+        store=satellite_name_store,
+    )
 
     satellite_scenario = ModelScenario(
         obs_column=obs_column_data,
@@ -1572,16 +1638,18 @@ def test_model_scenario_col_fp_data_merge():
     len(attributes["heights"]) == 20
 
 
-def test_scenario_infer_flux_source_ch4():
+def test_scenario_infer_flux_source_ch4(tac_ch4_store):
     """
     Test ModelScenario can find the source of a flux
     if only a single flux matches the given metadata
     and source is in the flux metadata.
     """
-    from openghg.objectstore import get_readable_buckets
-    from openghg.retrieve import get_flux
-
-    result = get_flux(species="ch4", domain="europe", source="waste")
+    result = get_flux(
+        species="ch4",
+        domain="europe",
+        source="waste",
+        store=tac_ch4_store,
+    )
 
     model_scenario = ModelScenario()
     model_scenario.add_flux(flux=result)
@@ -1590,8 +1658,14 @@ def test_scenario_infer_flux_source_ch4():
     assert "waste" in model_scenario.fluxes
 
 
-def test_modelscenario_doesnt_error_empty_objectstore():
-    clear_test_stores()
+def test_modelscenario_doesnt_error_empty_objectstore(monkeypatch):
+    """Test that an empty retrieval boundary produces an empty scenario."""
+
+    def no_data(_self, _keywords, **_kwargs):
+        """Represent an object-store retrieval that found no matching data."""
+        return None
+
+    monkeypatch.setattr(ModelScenario, "_get_data", no_data)
 
     site = "TAC"
     domain = "EUROPE"
@@ -1612,6 +1686,3 @@ def test_modelscenario_doesnt_error_empty_objectstore():
     )
 
     assert not scenario
-
-
-# NOTE: the test store is modified by the last two tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,21 @@ def mock_configuration_paths() -> dict:
     }
 
 
+@pytest.fixture(scope="session")
+def default_test_store() -> str:
+    """Return the default writable object store for tests.
+
+    Test data fixtures should populate the ``user`` store and return this value
+    to consumers. Tests should pass the returned name to retrieval functions so
+    that they do not accidentally search the readable ``group`` or ``shared``
+    stores. Use another named store only when that distinction is under test.
+
+    Returns:
+        The writable store name, ``"user"``.
+    """
+    return "user"
+
+
 @pytest.fixture(scope="session", autouse=True)
 def default_session_fixture(mock_configuration_paths) -> Iterator[None]:
     with patch("openghg.objectstore._local_store.read_local_config", return_value=mock_configuration_paths):

--- a/tests/standardise/test_standardise.py
+++ b/tests/standardise/test_standardise.py
@@ -1211,10 +1211,8 @@ def test_standardise_co2_games_using_dataset():
     assert retrieved_data.metadata["dataset_source"] == "PTEN"
 
 
-def test_standardise_6km_footprints():
-    """Test standardisation of 6km resolution footprints with associated metadata keys."""
-
-    filepath = get_footprint_datapath("IMP-26magl_NAME_UKV_EUROPE-6km_co2_202301.nc")
+def test_standardise_6km_footprints(tmp_path):
+    """Test a synthetic PARIS 6 km footprint retains inner-domain metadata on retrieval."""
     site = "IMP"
     model = "NAME"
     network = "UKV"
@@ -1223,6 +1221,27 @@ def test_standardise_6km_footprints():
     inner_domain = "6km"
     source_format = "paris"
     store = "user"
+    latitude, longitude = find_domain(f"{domain}-{inner_domain}")[:2]
+    filepath = tmp_path / "IMP-26magl_NAME_UKV_EUROPE-6km_co2_202301.nc"
+    shape = (2, latitude.size, longitude.size)
+    footprint = xr.Dataset(
+        data_vars={
+            "srr": (("time", "latitude", "longitude"), np.ones(shape, dtype=np.float32)),
+            "srr_time_resolved": (
+                ("time", "latitude", "longitude", "resolution"),
+                np.ones((*shape, 1), dtype=np.float32),
+            ),
+            "srr_residual": (("time", "latitude", "longitude"), np.zeros(shape, dtype=np.float32)),
+        },
+        coords={
+            "time": np.array(["2023-01-01T00:00", "2023-01-01T01:00"], dtype="datetime64[ns]"),
+            "latitude": latitude,
+            "longitude": longitude,
+            "resolution": np.array([1.0], dtype=np.float32),
+        },
+        attrs={"lpdm_native_output_unit": "ppm s"},
+    )
+    footprint.to_netcdf(filepath)
     results = standardise_footprint(
         filepath=filepath,
         site=site,
@@ -1237,7 +1256,7 @@ def test_standardise_6km_footprints():
         chunks={"time": 200, "lat": 200, "lon": 200},
     )
 
-    assert "co2" == results[0].get("species")
+    assert results[0].get("species") == "co2"
     assert "europe-6km" in results[0].get("domain")
 
     retrieved_data = get_footprint(


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Speeds up object-store-heavy tests by tightening the `analyse` fixture bundles and replacing one oversized standardisation input with synthetic data.

The previous `analyse` fixture cleared and rebuilt all stored datasets once per test module, including synthetic-only modules. Four setup phases accounted for 139.16 seconds of a 176.99-second local `tests/analyse` run.

This PR:

- adds a documented `default_test_store` fixture using the normal `user` store;
- replaces the `analyse` autouse fixture with six explicit, session-scoped data bundles;
- documents which bundle developers should request for each data family;
- makes real-data tests request only the bundle they use and pass the returned store name explicitly;
- keeps synthetic tests independent of object-store setup;
- removes duplicate CO₂ flux standardisation and an unused alignment footprint fixture;
- isolates the empty-store regression by mocking the retrieval boundary instead of clearing shared session data;
- replaces the 81.7 MB 6 km footprint NetCDF (about 18 GB logical arrays) with a temporary synthetic PARIS inner-domain dataset preserving the real coordinate grid and metadata/retrieval assertions.

Performance:

- local `tests/analyse`: 176.99s → 52.06s (about 71% faster, 3.4x);
- `test_standardise_6km_footprints` call: about 96s → 0.2–0.3s;
- local `tests/standardise/test_standardise.py`: 41 passed in 70.14s after the replacement, versus 129.65s immediately before it;
- CI showed the `analyse` section falling from roughly 155–235s to about 68–71s across Python 3.10–3.12;
- a Python 3.12 rerun reduced full pytest time from 9:14 to 7:09, confirming substantial runner/suite variability outside `analyse`.

Related umbrella: #1699.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1700
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] Documentation updated/added

Validation:

- `uv run pytest tests/analyse -q --durations=10`: 57 passed
- `.venv/bin/pytest tests/standardise/test_standardise.py -q --durations=10`: 41 passed
- focused synthetic 6 km regression: passed after deleting the vendored fixture
- Black checks on changed Python files: passed
- focused Ruff E/F checks and format check for the standardisation change: passed
- Flake8 on the changed `analyse` files: passed
- `git diff --check`: passed
- repository pre-commit whitespace, EOF, debug-statement, and line-ending checks: passed

*Not needed for this test-only performance refactor:*

- Production-code `mypy` validation
- Tutorial updates
- Wiki updates
- Changelog entry
- Package requirement changes
