### PR TITLE
Route ModelScenario fp x flux through Numba

### DIFF
--- a/openghg/analyse/_fp_x_flux.py
+++ b/openghg/analyse/_fp_x_flux.py
@@ -387,8 +387,7 @@ def _validate_flux_coverage(
     flux_end = flux["time"].values[-1] + np.timedelta64(step_hours, "h")
     if flux_start > start or flux_end <= end:
         raise ValueError(
-            "Flux time coverage must include the complete footprint lag halo "
-            f"from {start} through {end}."
+            "Flux time coverage must include the complete footprint lag halo " f"from {start} through {end}."
         )
 
 

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -1350,6 +1350,8 @@ class ModelScenario:
         flux_ds = self.combine_flux_sources(sources)
 
         if output_fpXflux:
+            # ModelScenario sums selected fluxes first and handles split_by_sectors
+            # by calling this method once per sector, so collapse the operator's source axis.
             fp_x_flux = fp_x_flux_time_resolved_numba(
                 fp.transpose("time", "lat", "lon", "H_back", missing_dims="ignore"), flux_ds
             ).sum("source")

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -73,6 +73,7 @@ from openghg.retrieve import (
 from openghg.util import synonyms, clean_string, format_inlet, verify_site_with_satellite, define_platform
 from openghg.types import SearchError, ReindexMethod
 from ._alignment import combine_datasets, resample_obs_and_other
+from ._fp_x_flux import fp_x_flux_time_resolved_numba
 from ._modelled_baseline import baseline_sensitivities
 from ._utils import match_dataset_dims, stack_datasets
 
@@ -1348,7 +1349,12 @@ class ModelScenario:
 
         flux_ds = self.combine_flux_sources(sources)
 
-        fp_x_flux = fp_x_flux_time_resolved(fp, flux_ds, averaging=averaging)
+        if output_fpXflux:
+            fp_x_flux = fp_x_flux_time_resolved_numba(
+                fp.transpose("time", "lat", "lon", "H_back", missing_dims="ignore"), flux_ds
+            ).sum("source")
+        else:
+            fp_x_flux = fp_x_flux_time_resolved(fp, flux_ds, averaging=averaging)
 
         data = {}
 

--- a/tests/analyse/test_fp_x_flux.py
+++ b/tests/analyse/test_fp_x_flux.py
@@ -104,7 +104,9 @@ def _interval_start_reference(footprint: xr.Dataset, flux: xr.DataArray) -> xr.D
 def test_fp_x_flux_time_resolved_numba_matches_reference_and_preserves_source_metadata() -> None:
     """Match direct values and preserve source metadata coordinates."""
     footprint, flux = _inputs()
-    result = fp_x_flux_time_resolved_numba(footprint, flux, time_chunk=2, lat_chunk=1, lon_chunk=1, source_chunk=1)
+    result = fp_x_flux_time_resolved_numba(
+        footprint, flux, time_chunk=2, lat_chunk=1, lon_chunk=1, source_chunk=1
+    )
 
     assert hasattr(result.data, "__dask_graph__")
     assert result.dims == ("source", "lat", "lon", "time")

--- a/tests/analyse/test_modelled_obs.py
+++ b/tests/analyse/test_modelled_obs.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from openghg.analyse import _scenario as scenario_module
 from openghg.analyse import ModelScenario
 from openghg.analyse._modelled_obs import (
     fp_x_flux_time_resolved,
@@ -357,8 +358,9 @@ def test_fp_x_flux_time_resolved_irregular_times_are_ffilled(footprint_paris_co2
 
 
 # TODO: this test could go elsewhere?
-def test_model_modelled_obs_co2_multisector(model_scenario_co2_dummy, flux_co2_dummy):
+def test_model_modelled_obs_co2_multisector(model_scenario_co2_dummy, flux_co2_dummy, mocker):
     """Test footprints_data_merge with multisector return options"""
+    numba_fp_x_flux = mocker.spy(scenario_module, "fp_x_flux_time_resolved_numba")
     model_scenario_co2_dummy.add_flux(species="co2", flux={"TESTSOURCE2": flux_co2_dummy})
     combined_dataset = model_scenario_co2_dummy.footprints_data_merge(
         calc_fp_x_flux=True, split_by_sectors=True
@@ -369,4 +371,7 @@ def test_model_modelled_obs_co2_multisector(model_scenario_co2_dummy, flux_co2_d
         for dv in ["mf_mod_high_res", "fp_x_flux", "mf_mod_high_res_sectoral", "fp_x_flux_sectoral"]
     )
 
+    assert numba_fp_x_flux.call_count == 3
+    assert combined_dataset.fp_x_flux.dims == ("lat", "lon", "time")
+    assert combined_dataset.fp_x_flux_sectoral.dims == ("source", "lat", "lon", "time")
     assert all(combined_dataset.source.values == ["TESTSOURCE", "TESTSOURCE2"])


### PR DESCRIPTION
## Summary

- route time-resolved `ModelScenario.footprints_data_merge(calc_fp_x_flux=True)` calculations through `fp_x_flux_time_resolved_numba`
- transpose legacy footprint dimensions into the Numba kernel order
- sum the operator-only `source` axis so total output remains `(lat, lon, time)`
- retain the existing sector loop so sectoral output remains `(source, lat, lon, time)`

This is a small follow-up stacked on #1708. Calls that do not request `calc_fp_x_flux` continue to use the existing xarray path.

## Validation

- `test_model_modelled_obs_co2_multisector` passes and verifies three Numba calls plus total/sectoral dimensions
- all 6 tests in `tests/analyse/test_modelled_obs.py` pass across two bounded runs
- Black check passes for both changed files
- Flake8 passes for both changed files
- `git diff --check` passes