### PR TITLE
Fix irregular time-resolved flux alignment

### DIFF
--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -187,9 +187,7 @@ def _make_high_freq_flux(
         flux_high_freq = flux_resampler.ffill()
 
     # Fill gaps on the regular, flux-aligned grid before constructing lag windows.
-    full_dates = pd.date_range(
-        flux_high_freq.time.values[0], flux_high_freq.time.values[-1], freq=freq
-    ).to_numpy()
+    full_dates = pd.date_range(flux_high_freq.time.values[0], end, freq=freq, inclusive="left").to_numpy()
     flux_high_freq = flux_high_freq.reindex({"time": full_dates}, method="ffill")
 
     # create rolling windows

--- a/openghg/analyse/_modelled_obs.py
+++ b/openghg/analyse/_modelled_obs.py
@@ -165,19 +165,18 @@ def _make_hf_flux_rolling_avg_array(
 def _make_high_freq_flux(
     flux: xr.DataArray,
     fp: xr.DataArray | xr.Dataset,
-    *,
-    align_to_fp_time: bool = True,
 ) -> xr.DataArray:
     fp_highest_res_hours = _fp_time_and_h_back_freq_gcd(fp)
     start, end = _padded_flux_slice_start_and_end(fp)
-    offset = time_of_day_offset(start)
-
-    # select values with start time padded to include first rolling window backwards in time
-    flux_high_freq = flux.sel(time=slice(start, end))
-
-    # resample flux
-    freq = f"{fp_highest_res_hours}h"
     flux_res_hours = calc_hourly_freq(flux.time, input_nanoseconds=True)
+    offset = time_of_day_offset(flux.time.values[0])
+
+    # Include the flux interval containing the padded start of the rolling window.
+    flux_slice_start = start - np.timedelta64(flux_res_hours, "h")
+    flux_high_freq = flux.sel(time=slice(flux_slice_start, end))
+
+    # Resample on the flux interval grid, not the offset of the first footprint release.
+    freq = f"{fp_highest_res_hours}h"
     flux_resampler = flux_high_freq.resample({"time": freq}, offset=offset)
 
     if flux_res_hours <= fp_highest_res_hours:
@@ -187,25 +186,22 @@ def _make_high_freq_flux(
         # upsampling
         flux_high_freq = flux_resampler.ffill()
 
-    # reindex to align
-    full_dates = pd.date_range(start, end, freq=freq, inclusive="left").to_numpy()
+    # Fill gaps on the regular, flux-aligned grid before constructing lag windows.
+    full_dates = pd.date_range(
+        flux_high_freq.time.values[0], flux_high_freq.time.values[-1], freq=freq
+    ).to_numpy()
     flux_high_freq = flux_high_freq.reindex({"time": full_dates}, method="ffill")
 
     # create rolling windows
     flux_high_freq = _make_hf_flux_rolling_avg_array(flux_high_freq, fp)
 
-    if align_to_fp_time:
-        # reindex to align with fp time coordinates (after creating rolling windows to avoid NaN values at start of time series)
-        fp_index = pd.DatetimeIndex(fp.time.values)
-        flux_index = pd.DatetimeIndex(flux_high_freq.time.values)
-        need_second_reindex = (flux_index.get_indexer(fp_index) < 0).any()
-
-        if need_second_reindex:
-            flux_high_freq = flux_high_freq.reindex(
-                {"time": fp.time},
-                method="ffill",
-                tolerance=pd.Timedelta(hours=fp_highest_res_hours),
-            )
+    # Map each irregular release to the flux interval containing it. Do this after
+    # constructing rolling windows so the first release retains its full lag history.
+    flux_high_freq = flux_high_freq.reindex(
+        {"time": fp.time},
+        method="ffill",
+        tolerance=pd.Timedelta(hours=fp_highest_res_hours),
+    )
 
     flux_high_freq.attrs["units"] = flux.attrs.get("units")
 

--- a/tests/analyse/test_modelled_obs.py
+++ b/tests/analyse/test_modelled_obs.py
@@ -336,7 +336,7 @@ def test_modelled_obs_co2_consistency(model_scenario_co2_dummy, model_scenario_p
 
 
 def test_fp_x_flux_time_resolved_irregular_times_are_ffilled(footprint_paris_co2_dummy, flux_co2_dummy):
-    """High-frequency flux should be forward-filled to irregular fp_time_resolved timestamps."""
+    """Each resolved lag should use its containing flux interval at irregular times."""
     fp = footprint_paris_co2_dummy.data.copy(deep=True)
     fp = fp.isel(time=slice(0, 2), lat=slice(0, 1), lon=slice(0, 1), H_back=slice(0, 2))
     fp["fp_time_resolved"][:] = 1.0
@@ -349,7 +349,7 @@ def test_fp_x_flux_time_resolved_irregular_times_are_ffilled(footprint_paris_co2
     result = fp_x_flux_time_resolved(fp, flux)
 
     expected = xr.DataArray(
-        np.array([2.0, 4.0]).reshape(2, 1, 1),
+        np.array([4.0, 4.0]).reshape(2, 1, 1),
         coords={"time": fp.time, "lat": fp.lat, "lon": fp.lon},
         dims=("time", "lat", "lon"),
     )

--- a/tests/analyse/test_modelled_obs_alignment.py
+++ b/tests/analyse/test_modelled_obs_alignment.py
@@ -30,7 +30,7 @@ def _irregular_time_resolved_fp_and_flux():
     fp.lon.attrs["units"] = "degrees_east"
     fp.H_back.attrs["units"] = "Hours"
 
-    flux_times = pd.date_range("2011-12-31 20:37:00", "2012-01-01 05:37:00", freq="h")
+    flux_times = pd.date_range("2011-12-31 20:00:00", "2012-01-01 05:00:00", freq="h")
     flux_values = np.arange(len(flux_times), dtype=float).reshape(-1, 1, 1)
     flux = xr.DataArray(
         flux_values,
@@ -50,25 +50,11 @@ def _irregular_time_resolved_fp_and_flux():
     return fp, flux, expected
 
 
-def test_fp_x_flux_time_resolved_aligns_all_irregular_footprint_times():
-    """Irregular footprint times should not be dropped by xarray's exact coordinate alignment."""
+def test_fp_x_flux_time_resolved_uses_flux_intervals_for_irregular_footprint_times():
+    """Irregular footprint times should use the containing left-labelled flux intervals."""
     fp, flux, expected = _irregular_time_resolved_fp_and_flux()
 
     result = _modelled_obs.fp_x_flux_time_resolved(fp, flux)
 
-    xr.testing.assert_allclose(result, expected)
-
-
-def test_high_freq_flux_without_second_reindex_reproduces_dropped_times():
-    """Probe the old behaviour: only footprint times already on the generated grid survive."""
-    fp, flux, _ = _irregular_time_resolved_fp_and_flux()
-
-    flux_high_freq = _modelled_obs._make_high_freq_flux(flux, fp, align_to_fp_time=False)
-    result = (flux_high_freq * fp.fp_time_resolved).sum("H_back")
-
-    expected = xr.DataArray(
-        np.array([7.0]).reshape(1, 1, 1),
-        coords={"time": fp.time.isel(time=[0]), "lat": fp.lat, "lon": fp.lon},
-        dims=("time", "lat", "lon"),
-    )
+    xr.testing.assert_identical(result.time, fp.time)
     xr.testing.assert_allclose(result, expected)


### PR DESCRIPTION
* **Summary of changes** (Bug fix)

This separates the irregular-time alignment correction discussed in #1708 from the new Numba implementation. It changes only the existing xarray-based `fp_x_flux_time_resolved` path.

### Previous method

The existing workaround derived the resampling offset from the padded start of the footprint releases. For a satellite footprint released at `00:37`, it therefore built the high-frequency flux grid at `00:37` too.

That avoids losing irregular footprint timestamps during xarray's exact coordinate alignment, but it changes what the flux timestamps mean: native left-labelled flux intervals such as `[01:00, 02:00)` and `[02:00, 03:00)` are effectively shifted onto a footprint-aligned grid. With time-varying flux, the lagged footprint can then receive a value from the wrong averaging interval.

### Corrected method

Flux timestamps remain the starts of their native, half-open averaging intervals. The calculation now:

1. anchors resampling to the first flux timestamp rather than the first footprint release;
2. includes the flux interval containing the padded start needed for the rolling lag window;
3. constructs lag windows on that flux-aligned grid;
4. extends that grid through the padded footprint end so coarse flux supplies a completed window for every release; and
5. forward-fills each completed lag window to the exact irregular footprint release time, with a one-grid-step tolerance.

For example, for a release at `02:37` and hourly flux labelled on the hour, `H_back=0` uses the interval starting at `02:00`, while `H_back=1` uses the interval starting at `01:00`. The flux intervals are not relabelled to `00:37`.

### Footprint/observation timestamps

The footprint is not resampled. After selecting the correct flux intervals, the lagged flux array is assigned the exact original `fp.time` coordinate before multiplication. The returned `fp_x_flux` therefore retains the footprint timestamps, and observations aligned to those footprint timestamps remain unchanged. The regression test asserts this coordinate identity explicitly.

### Coarse-flux end coverage caught by CI

The first draft correctly changed the grid phase, but generated `full_dates` only through the final timestamp emitted by the resampler. When two-hourly flux had its final relevant label at `06:00` and the footprint release was at `07:00`, the upsampled grid therefore stopped at `06:00`. Reindexing the `07:00` release then reused the completed `06:00` lag window:

- correct targets for release `07:00`: `07:00`, `06:00`, `05:00`;
- targets represented by the reused `06:00` window: `06:00`, `05:00`, `04:00`.

The Numba operator uses direct interval membership and correctly exposed this through `test_regular_coarse_flux_matches_existing_time_resolved_method[2]`; its expected values were not changed.

Commit `7e8d34c46` fixes the edge case by retaining the native flux phase while extending `full_dates` through the padded footprint end. This supplies the `07:00` lag window without shifting the native flux intervals. The complete Numba parity file and both irregular-alignment suites now pass locally.

Initial local verification ran only `tests/test_modelled_obs_alignment.py` and `tests/analyse/test_modelled_obs.py`. Those seven tests passed, but that selection omitted the PR #1703 Numba/legacy parity suite in `tests/analyse/test_fp_x_flux.py`, which is why this coarse-flux case was not caught before the first push.

### Scope

This PR deliberately contains no Numba operator or new public API, so the legacy alignment correction can be reviewed independently from #1708.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (no separate issue)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) locally
- [x] Black and flake8 pass locally; mypy passed on the previous CI revision
- [ ] Documentation updated/added
- [ ] Tutorials updated/added
- [ ] Wiki updated
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] No new package requirements

Not needed for this focused internal correction: user documentation, tutorials, wiki, and package requirements.

### Verification

- `.venv/bin/pytest tests/analyse/test_fp_x_flux.py tests/test_modelled_obs_alignment.py tests/analyse/test_modelled_obs.py -q` — 20 passed
- Black and flake8 on the changed implementation
- `git diff --check`
- GitHub Actions for `7e8d34c46` — documentation and both test matrices passed
