### PR TITLE
1716 enforce same max level values for obs and footprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added column `max_level` consistency validation to `ModelScenario` and preserved `max_level` metadata when standardising ACRG and PARIS column footprints, preventing observations and footprints with different vertical extents from being combined. [PR #1718](https://github.com/openghg/openghg/pull/1718)
 - Ensured explicitly integrated CO2 site and satellite footprints are standardised and modelled through the integrated-footprint pathway, while preserving the time-resolved default for CO2 footprints. [PR #1698](https://github.com/openghg/openghg/pull/1698)
 - Added a dimension dtype checker for H_back dimension to "timedelta64[ns]". Bug occured for dimension "resolution" and dtype "resolution".[PR #1671](https://github.com/openghg/openghg/pull/1671)
 - Added config-driven metadata key handling for transformed flux and boundary condition data: removed hard-coded required-key lookups.[PR #1686](https://github.com/openghg/openghg/pull/1686)

--- a/doc/source/tutorials/local/Adding_data/Adding_co2_satellite_data.rst
+++ b/doc/source/tutorials/local/Adding_data/Adding_co2_satellite_data.rst
@@ -92,6 +92,15 @@ calculation from the stored footprint variables: time-resolved data goes through
 the time-resolved CO2 calculation, while ``fp``-only data goes through the
 integrated calculation.
 
+.. important::
+
+   ``max_level`` must match the fixed value used when the column footprint was processed.
+   Using a different value for the column observations places the observations and footprint
+   in different vertical spaces. For an existing footprint, inspect ``footprint.metadata["max_level"]``
+   (or ``footprint.data.attrs["max_level"]``) and use that value when retrieving the column
+   observations and creating ``ModelScenario``. The example footprint below uses
+   ``max_level=17``.
+
 .. code:: ipython3
 
     from openghg.analyse import ModelScenario

--- a/doc/source/tutorials/local/Adding_data/Adding_co2_satellite_data.rst
+++ b/doc/source/tutorials/local/Adding_data/Adding_co2_satellite_data.rst
@@ -94,7 +94,8 @@ integrated calculation.
 
 .. important::
 
-   ``max_level`` must match the fixed value used when the column footprint was processed.
+   For comparison to the modelled observations, ``max_level`` must match the fixed value used
+   when the column footprint was processed.
    Using a different value for the column observations places the observations and footprint
    in different vertical spaces. For an existing footprint, inspect ``footprint.metadata["max_level"]``
    (or ``footprint.data.attrs["max_level"]``) and use that value when retrieving the column

--- a/doc/source/tutorials/local/Analysing_data/Comparing_satellite_observations_with_emissions.rst
+++ b/doc/source/tutorials/local/Analysing_data/Comparing_satellite_observations_with_emissions.rst
@@ -65,11 +65,12 @@ We can now create a ``ModelScenario`` linking satellite observations with ancill
 
 .. important::
 
-   For a column or satellite ``ModelScenario``, the observation ``max_level`` must be the
-   same as the fixed ``max_level`` used to process the footprint. Otherwise, the observations
-   and footprints describe different vertical spaces and the modelled prior contribution can
-   be incorrect. The footprint in this tutorial was processed with ``max_level=17``, so the
-   column observations must also use 17. For previously retrieved objects, these values are
+   For a column or satellite ``ModelScenario``, the ``max_level`` used to retrieve the column
+   observations must be the same as the fixed ``max_level`` used to process the footprint.
+   Otherwise, the observations and footprints describe different vertical spaces and the
+   modelled prior contribution can be incorrect. The footprint in this tutorial was processed
+   with ``max_level=17``, so the value used to retrieve the column observations must also be 17.
+   For previously retrieved objects, these values are
    available from ``obs_column_data.data.attrs["max_level"]`` and
    ``fp_column_data.metadata["max_level"]`` (or ``fp_column_data.data.attrs["max_level"]``).
 
@@ -172,7 +173,7 @@ same data needs to be used for multiple different scenarios.
 
 .. jupyter-execute::
 
-    scenario_direct = ModelScenario(obs_column=obs_column_data, footprint=fp_column_data, flux=flux_data, bc=bc_results, platform="satellite", max_level=17)
+    scenario_direct = ModelScenario(obs_column=obs_column_data, footprint=fp_column_data, flux=flux_data, bc=bc_results, platform="satellite")
 
 .. note::
 

--- a/doc/source/tutorials/local/Analysing_data/Comparing_satellite_observations_with_emissions.rst
+++ b/doc/source/tutorials/local/Analysing_data/Comparing_satellite_observations_with_emissions.rst
@@ -63,6 +63,16 @@ We'll use helper functions from ``openghg.tutorial`` to populate example data:
 
 We can now create a ``ModelScenario`` linking satellite observations with ancillary inputs.
 
+.. important::
+
+   For a column or satellite ``ModelScenario``, the observation ``max_level`` must be the
+   same as the fixed ``max_level`` used to process the footprint. Otherwise, the observations
+   and footprints describe different vertical spaces and the modelled prior contribution can
+   be incorrect. The footprint in this tutorial was processed with ``max_level=17``, so the
+   column observations must also use 17. For previously retrieved objects, these values are
+   available from ``obs_column_data.data.attrs["max_level"]`` and
+   ``fp_column_data.metadata["max_level"]`` (or ``fp_column_data.data.attrs["max_level"]``).
+
 .. jupyter-execute::
 
     from openghg.analyse import ModelScenario
@@ -70,7 +80,7 @@ We can now create a ``ModelScenario`` linking satellite observations with ancill
     scenario = ModelScenario(satellite="gosat",
                    species="ch4",
                    platform="satellite",
-                   max_level=3,
+                   max_level=17,
                    domain="southamerica",
                    obs_region="brazil",
                    source="all")
@@ -137,7 +147,7 @@ same data needs to be used for multiple different scenarios.
 
     obs_column_data = get_obs_column(
         species="ch4",
-        max_level=3,
+        max_level=17,
         satellite=satellite,
         start_date="2016-01-01 14:59:12.500000+00:00",
         end_date="2016-01-01 18:10:16.500000+00:00",
@@ -162,7 +172,7 @@ same data needs to be used for multiple different scenarios.
 
 .. jupyter-execute::
 
-    scenario_direct = ModelScenario(obs_column=obs_column_data, footprint=fp_column_data, flux=flux_data, bc=bc_results, platform="satellite", max_level=3)
+    scenario_direct = ModelScenario(obs_column=obs_column_data, footprint=fp_column_data, flux=flux_data, bc=bc_results, platform="satellite", max_level=17)
 
 .. note::
 

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -156,8 +156,10 @@ class ModelScenario:
         network: Network name e.g. "AGAGE".
         domain: Domain name e.g. "EUROPE".
         platform: Platform name e.g "satellite", "column-insitu".
-        max_level: Maximum level for processing column observations. This must
-            match the ``max_level`` attribute of the column footprint data.
+        max_level: Maximum level for processing column observations. This is required when
+            retrieving column observations. If comparing modelled observations using a
+            footprint, it must match the footprint's ``max_level`` attribute. When supplying
+            an ``ObsColumnData`` object directly, its stored ``max_level`` is used instead.
         obs_region: The geographic region covered by the data ("BRAZIL", "INDIA", "UK").
         selection: For satellite only, identifier for any data selection which has been
             performed on satellite data. This can be based on any form of filtering, binning etc.
@@ -208,9 +210,10 @@ class ModelScenario:
         # For ObsColumn data processing
         if platform in accepted_column_data_types:
             # Add observation column data (directly or through keywords, column or satellite)
-            if max_level is None:
+            if max_level is None and obs_column is None:
                 raise AttributeError(
-                    f"If you are using column-based data (i.e. platform is {accepted_column_data_types}), you need to pass max_level"
+                    "Retrieving column observations for ModelScenario requires max_level. "
+                    f"Column platforms are {accepted_column_data_types}."
                 )
             self.add_obs_column(
                 site=site,

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -314,8 +314,10 @@ class ModelScenario:
             raise ValueError(
                 "Column footprint data must have a 'max_level' attribute before it can be used "
                 "in ModelScenario. Re-standardise the footprint from a source file containing "
-                "max_level, or correct the source metadata, so it can be checked against the "
-                "column observations."
+                "max_level or, for data in a writable object store, add the known footprint "
+                "value using data_manager(...).update_attributes(...). Also use "
+                "update_metadata(...) to keep the stored metadata consistent. Do not infer the "
+                "footprint value from the requested observation level."
             )
 
         try:

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -156,7 +156,8 @@ class ModelScenario:
         network: Network name e.g. "AGAGE".
         domain: Domain name e.g. "EUROPE".
         platform: Platform name e.g "satellite", "column-insitu".
-        max_level: Maximum level for processing.
+        max_level: Maximum level for processing column observations. This must
+            match the ``max_level`` attribute of the column footprint data.
         obs_region: The geographic region covered by the data ("BRAZIL", "INDIA", "UK").
         selection: For satellite only, identifier for any data selection which has been
             performed on satellite data. This can be based on any form of filtering, binning etc.
@@ -265,6 +266,9 @@ class ModelScenario:
             time_resolved=time_resolved,
         )
 
+        if self.platform in accepted_column_data_types and self.footprint is not None:
+            self._check_column_max_level(max_level=max_level)
+
         # Add flux data (directly or through keywords)
         self.add_flux(
             species=species,
@@ -295,6 +299,40 @@ class ModelScenario:
         self.flux_stacked: Dataset | None = None
 
         # TODO: Check species, site etc. values align between inputs?
+
+    def _check_column_max_level(self, max_level: int | None) -> None:
+        """Check that column observations and footprints use the same vertical extent."""
+        if self.footprint is None:
+            return
+
+        obs_max_level = max_level
+        if self.obs is not None:
+            obs_max_level = self.obs.data.attrs.get("max_level", max_level)
+
+        fp_max_level = self.footprint.data.attrs.get("max_level", self.footprint.metadata.get("max_level"))
+        if fp_max_level is None or str(fp_max_level).lower() == "unknown":
+            raise ValueError(
+                "Column footprint data must have a 'max_level' attribute before it can be used "
+                "in ModelScenario. Re-standardise the footprint from a source file containing "
+                "max_level, or correct the source metadata, so it can be checked against the "
+                "column observations."
+            )
+
+        try:
+            obs_max_level = int(obs_max_level) if obs_max_level is not None else None
+            fp_max_level = int(fp_max_level)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "The column observation and footprint 'max_level' attributes must be integers; "
+                f"received {obs_max_level!r} and {fp_max_level!r}."
+            ) from exc
+
+        if obs_max_level != fp_max_level:
+            raise ValueError(
+                "Column observations and footprints must use the same max_level in "
+                f"ModelScenario: observations use {obs_max_level}, while footprints use "
+                f"{fp_max_level}."
+            )
 
     def _get_data(self, keywords: ParamType, data_type: str) -> Any:
         """Use appropriate get function to search for data in object store."""

--- a/openghg/standardise/footprints/_acrg_org.py
+++ b/openghg/standardise/footprints/_acrg_org.py
@@ -221,6 +221,9 @@ def parse_acrg_org(
     if network is not None:
         metadata["network"] = network
 
+    if inlet == "column":
+        metadata["max_level"] = str(fp_data.attrs.get("max_level", "unknown"))
+
     # Check if time has 0-dimensions and, if so, expand this so time is 1D
     if "time" in fp_data.coords:
         fp_data = update_zero_dim(fp_data, dim="time")

--- a/openghg/standardise/footprints/_paris.py
+++ b/openghg/standardise/footprints/_paris.py
@@ -181,8 +181,10 @@ def parse_paris(
     if network is not None:
         metadata["network"] = network
 
-    if site is not None and inlet == "column":
+    if inlet == "column":
         metadata["max_level"] = str(fp_data.attrs.get("max_level", "unknown"))
+
+    if site is not None and inlet == "column":
         metadata["obs_openghg_uuid"] = fp_data.attrs.get("obs_openghg_uuid", None)
 
     # Check if time has 0-dimensions and, if so, expand this so time is 1D

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -1701,7 +1701,7 @@ def test_model_scenario_column_footprint_requires_max_level(satellite_name_store
     fp_column_data.data.attrs.pop("max_level")
     fp_column_data.metadata.pop("max_level")
 
-    with pytest.raises(ValueError, match=r"must have a 'max_level' attribute"):
+    with pytest.raises(ValueError, match=r"data_manager\(\.\.\.\)\.update_attributes"):
         ModelScenario(
             obs_column=obs_column_data,
             footprint=fp_column_data,

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -1553,33 +1553,10 @@ def test_stack_datasets_with_alignment(flux_daily, flux_daily_small_dim_diff):
     np.testing.assert_allclose(output_flux, expected_flux)
 
 
-def test_satellite_scenario_raises_error(satellite_cams_store):
-    """Test that a satellite ModelScenario requires ``max_level``."""
-
-    satellite = "gosat"
-    domain = "SOUTHAMERICA"
-    obs_region = "BRAZIL"
-    species = "ch4"
-
-    obs_column = get_obs_column(
-        species=species,
-        max_level=3,
-        satellite=satellite,
-        selection="land",
-        store=satellite_cams_store,
-    )
-
-    footprint = get_footprint(
-        satellite=satellite,
-        domain=domain,
-        obs_region=obs_region,
-        model="cams",
-        store=satellite_cams_store,
-    )
-
-    with pytest.raises(AttributeError):
-        # checks that ModelScenario fails if passing platform=satellite but not max_level
-        ModelScenario(obs_column=obs_column, footprint=footprint, platform="satellite")
+def test_satellite_scenario_retrieval_requires_max_level():
+    """Retrieving satellite observations through ModelScenario requires ``max_level``."""
+    with pytest.raises(AttributeError, match="requires max_level"):
+        ModelScenario(satellite="gosat", species="ch4", platform="satellite")
 
 
 def test_model_scenario_col_fp_data_merge(satellite_name_store):
@@ -1623,7 +1600,6 @@ def test_model_scenario_col_fp_data_merge(satellite_name_store):
         footprint=fp_column_data,
         flux=flux_data,
         platform="satellite",
-        max_level=17,
     )
 
     # Check values have been stored in ModelScenario object correctly
@@ -1661,7 +1637,6 @@ def test_model_scenario_column_max_level_must_match_footprint(satellite_name_sto
     fp_column_data = get_footprint(
         satellite="gosat",
         domain="southamerica",
-        obs_region="brazil",
         model="name",
         store=satellite_name_store,
     )
@@ -1674,9 +1649,6 @@ def test_model_scenario_column_max_level_must_match_footprint(satellite_name_sto
             obs_column=obs_column_data,
             footprint=fp_column_data,
             platform="satellite",
-            # Deliberately match the footprint to prove that validation uses
-            # the effective value stored on the column observations.
-            max_level=17,
         )
 
 
@@ -1694,7 +1666,6 @@ def test_model_scenario_column_footprint_requires_max_level(satellite_name_store
     fp_column_data = get_footprint(
         satellite="gosat",
         domain="southamerica",
-        obs_region="brazil",
         model="name",
         store=satellite_name_store,
     )
@@ -1706,7 +1677,6 @@ def test_model_scenario_column_footprint_requires_max_level(satellite_name_store
             obs_column=obs_column_data,
             footprint=fp_column_data,
             platform="satellite",
-            max_level=17,
         )
 
 

--- a/tests/analyse/test_scenario.py
+++ b/tests/analyse/test_scenario.py
@@ -1591,7 +1591,7 @@ def test_model_scenario_col_fp_data_merge(satellite_name_store):
 
     obs_column_data = get_obs_column(
         species="ch4",
-        max_level=3,
+        max_level=17,
         satellite=satellite,
         start_date="2016-01-01 14:59:12.500000+00:00",
         end_date="2016-01-01 18:10:16.500000+00:00",
@@ -1607,6 +1607,10 @@ def test_model_scenario_col_fp_data_merge(satellite_name_store):
         model="name",
         store=satellite_name_store,
     )
+
+    assert obs_column_data.data.attrs["max_level"] == 17
+    assert int(fp_column_data.metadata["max_level"]) == 17
+
     flux_data = get_flux(
         species="ch4",
         source="all",
@@ -1619,7 +1623,7 @@ def test_model_scenario_col_fp_data_merge(satellite_name_store):
         footprint=fp_column_data,
         flux=flux_data,
         platform="satellite",
-        max_level=3,
+        max_level=17,
     )
 
     # Check values have been stored in ModelScenario object correctly
@@ -1641,6 +1645,69 @@ def test_model_scenario_col_fp_data_merge(satellite_name_store):
     attributes["model"] == "name"
     attributes["data_type"] == "column"
     len(attributes["heights"]) == 20
+
+
+def test_model_scenario_column_max_level_must_match_footprint(satellite_name_store):
+    """Column observations and footprints must cover the same vertical extent."""
+    obs_column_data = get_obs_column(
+        species="ch4",
+        satellite="gosat",
+        max_level=3,
+        obs_region="brazil",
+        start_date="2016-01-01 14:59:12.500000+00:00",
+        end_date="2016-01-01 18:10:16.500000+00:00",
+        store=satellite_name_store,
+    )
+    fp_column_data = get_footprint(
+        satellite="gosat",
+        domain="southamerica",
+        obs_region="brazil",
+        model="name",
+        store=satellite_name_store,
+    )
+
+    assert obs_column_data.data.attrs["max_level"] == 3
+    assert int(fp_column_data.metadata["max_level"]) == 17
+
+    with pytest.raises(ValueError, match=r"observations use 3, while footprints use 17"):
+        ModelScenario(
+            obs_column=obs_column_data,
+            footprint=fp_column_data,
+            platform="satellite",
+            # Deliberately match the footprint to prove that validation uses
+            # the effective value stored on the column observations.
+            max_level=17,
+        )
+
+
+def test_model_scenario_column_footprint_requires_max_level(satellite_name_store):
+    """A missing footprint max_level must not silently permit incompatible data."""
+    obs_column_data = get_obs_column(
+        species="ch4",
+        satellite="gosat",
+        max_level=17,
+        obs_region="brazil",
+        start_date="2016-01-01 14:59:12.500000+00:00",
+        end_date="2016-01-01 18:10:16.500000+00:00",
+        store=satellite_name_store,
+    )
+    fp_column_data = get_footprint(
+        satellite="gosat",
+        domain="southamerica",
+        obs_region="brazil",
+        model="name",
+        store=satellite_name_store,
+    )
+    fp_column_data.data.attrs.pop("max_level")
+    fp_column_data.metadata.pop("max_level")
+
+    with pytest.raises(ValueError, match=r"must have a 'max_level' attribute"):
+        ModelScenario(
+            obs_column=obs_column_data,
+            footprint=fp_column_data,
+            platform="satellite",
+            max_level=17,
+        )
 
 
 def test_scenario_infer_flux_source_ch4(tac_ch4_store):

--- a/tests/standardise/footprints/test_acrg_org.py
+++ b/tests/standardise/footprints/test_acrg_org.py
@@ -151,3 +151,4 @@ def test_parse_acrg_org_satellite_key():
 
     expected_key = f"{satellite}_{obs_region}_{domain}_{model}_{inlet}"
     assert expected_key in result
+    assert result[expected_key]["metadata"]["max_level"] == "17"

--- a/tests/standardise/footprints/test_paris.py
+++ b/tests/standardise/footprints/test_paris.py
@@ -122,6 +122,9 @@ def test_paris_footprint(site, inlet, model, met_model, domain, species, filenam
 
     assert metadata.items() >= expected_metadata.items()
 
+    if inlet == "column":
+        assert metadata["max_level"] == "24"
+
     # TODO: Add data checks as required (may not be able to easily parameterize)
 
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
The PR implements a `max_level` check during Modelscenario creation.

1. Compares max_level passed to the obs column data selection function (either get_obs_column or ModelScenario directly) with the footprints max_level.
2. Reads the footprint value from dataset attributes, falling back to footprint metadata.
3. Raises a clear error when the values differ.
4. Raises an actionable error when the footprint value is missing or "unknown".
5. Advises users to re-standardise the footprint or use data_manager(...).update_attributes(...) and update_metadata(...) for writable stores.
6. Preserves column-footprint max_level during both ACRG and PARIS standardisation.
7. Prevents the footprint level from being inferred from the requested observation level.

The max_level supplied to get_obs_column(), either directly or through ModelScenario, is used when processing the retrieved column observations. The effective value is recorded in:
ObsColumnData.data.attrs["max_level"]
ModelScenario compares this value with the max_level used to process the footprint. The footprint value is read from its dataset attributes, with footprint metadata used as a fallback.
When an existing ObsColumnData object is supplied directly, an additional max_level argument is not required because the value is read from the object itself.
If the values differ, or the footprint does not contain a valid max_level, ModelScenario raises an error before calculating modelled observations.

**Tests**
9. Added coverage for:
10. Matching observation and footprint levels.
11. Mismatched levels from retrieved objects.
12. Ensuring dataset values are checked rather than only the constructor argument.
13. Missing footprint max_level.
14. Actionable object-store repair guidance.
15. Preservation of max_level by ACRG and PARIS footprint parsers.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1716 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `black --line-length 110` run over code, `mypy` and `flake8` not showing any errors
- [x] Documentation updated/added
- [x] Tutorials updated/added
- [x] Wiki updated
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [x] Added any new package requirements to `pyproject.toml` [dependencies section] and `recipes/meta.yaml`

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*
