### PR TITLE
Refactor DataSchema with xarray-validate

### DIFF
--- a/doc/source/development/specifications/data_spec.rst
+++ b/doc/source/development/specifications/data_spec.rst
@@ -4,6 +4,52 @@ Data Specification
 
 Here we set out the specfication for the data we expect for the different storage classes.
 
+Schema validation
+-----------------
+
+Each storage class exposes its internal xarray format through ``schema()``.
+The returned :class:`openghg.store.DataSchema` records required data variables,
+their dimensions, and NumPy data types. For example:
+
+.. code-block:: python
+
+    from openghg.store import Flux
+
+    schema = Flux.schema()
+    schema.validate_data(dataset)
+
+Storage classes also provide ``validate_data()`` as a convenient class-level
+entry point:
+
+.. code-block:: python
+
+    Flux.validate_data(dataset)
+
+Validation is implemented by ``xarray-validate`` behind the existing
+``DataSchema`` API. Schema-library failures are exposed as OpenGHG
+``ValidationError`` exceptions, so callers do not need to depend on the
+validation library directly. For compatibility, a missing dimension on a
+required variable continues to raise ``ValueError``.
+
+When adding or changing an internal format, define required variables and
+data types in the storage class's ``schema()`` method:
+
+.. code-block:: python
+
+    import numpy as np
+
+    from openghg.store import DataSchema
+
+    DataSchema(
+        data_vars={"example": ("time",)},
+        dtypes={"example": np.floating, "time": np.datetime64},
+    )
+
+Extra variables remain allowed, and dimensions listed for a required variable
+must be present but may appear in a different order. Dtype constraints for
+coordinates remain optional when the coordinate is absent, matching the
+historical OpenGHG schema behaviour.
+
 ObsSurface
 ----------
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - python>=3.10
   - addict
+  - attrs>=22
   - cf_xarray
   - dask<2025.10
   - h5netcdf>=1.0.0,<=1.6.4
@@ -46,5 +47,6 @@ dependencies:
   - pip:
     - icoscp
     - numpy>=2.0,<=2.3.3
+    - xarray-validate==0.0.5
 # numpy >= 2.0 is included in pip requirements because icoscp will try and downgrade numpy to <2.0
 # - can remove and use definition above again when https://github.com/ICOS-Carbon-Portal/data/issues/391 is resolved.

--- a/openghg/store/_data_schema.py
+++ b/openghg/store/_data_schema.py
@@ -1,146 +1,62 @@
-from dataclasses import dataclass
-import logging
+from dataclasses import dataclass, field
+from functools import partial
+
 import numpy as np
-from xarray import Dataset
+from xarray import DataArray, Dataset
+import xarray_validate as xv  # type: ignore[import-untyped]
 
 from openghg.types import ValidationError
-
-logger = logging.getLogger("openghg.store")
-logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
 __all__ = ["DataSchema"]
 
 
+def _check_dims(expected: tuple[str, ...], data: DataArray) -> None:
+    for dim in expected:
+        if dim not in data.dims:
+            raise ValueError(
+                f"Missing dimension for data variable: {data.name}, {dim}. Current dims: {data.dims}"
+            )
+
+
 @dataclass
 class DataSchema:
-    """
-    Create schema for a data type based on inputs for components of the data.
-    Expected format is based against an xarray Dataset.
-
-    Example inputs:
-        DataSchema(
-            data_vars = {"fp": ("time", "lat", "lon"), ...},
-            dtypes = {"fp" : np.floating, ...},
-            dims = ["time", "lat", "lon", ...]
-        )
-    """
-
-    # TODO : Change or add additional checks as needed
+    """OpenGHG compatibility wrapper around :mod:`xarray_validate` schemas."""
 
     data_vars: dict[str, tuple[str, ...]] | None = None
     dtypes: dict[str, type] | None = None
     dims: list[str] | None = None
+    _schema: xv.DatasetSchema = field(init=False, repr=False, compare=False)
 
-    def _check_data_vars(self, data: Dataset) -> None:
-        """
-        Check data variables and their dimensions of data against the schema.
+    def __post_init__(self) -> None:
+        variables: dict[str, xv.DataArraySchema] = {}
+        for name, dims in (self.data_vars or {}).items():
+            variables[name] = xv.DataArraySchema(
+                dtype=(self.dtypes or {}).get(name),
+                checks=[partial(_check_dims, dims)],
+            )
 
-        Args:
-            data : xarray Dataset to be checked
-        Returns:
-            None
+        self._schema = xv.DatasetSchema(
+            data_vars=variables or None,
+            allow_extra_keys=True,
+            checks=[self._check_remaining_constraints],
+        )
 
-            Raises a ValueError with details if expected data variable is
-            not present or expected dimensions are not present for a data variable
-            based on the DataSchema object.
-        """
-        expected_data_vars = self.data_vars
-        if expected_data_vars is None:
-            logger.debug("No data variables to check against schema")
-            return None
-        else:
-            expected_dv = expected_data_vars.keys()
+    def _check_remaining_constraints(self, data: Dataset) -> None:
+        """Retain the old optional-coordinate dtype and dataset-dimension checks."""
+        for dim in self.dims or []:
+            if dim not in data.dims:
+                raise xv.SchemaError(f"Expected dimension: {dim} not present in standardised data")
 
-        data_vars = data.data_vars
+        required_vars = self.data_vars or {}
+        for name, dtype in (self.dtypes or {}).items():
+            if name in data and name not in required_vars and not np.issubdtype(data[name].dtype, dtype):
+                raise xv.SchemaError(
+                    f"Expected data type of variable {name} to be: {dtype}. Current {data[name].dtype}"
+                )
 
-        for edv in expected_dv:
-            if edv in data_vars:
-                dims = data[edv].dims
-                expected_dv_dims = expected_data_vars[edv]
-                for edim in expected_dv_dims:
-                    if edim not in dims:
-                        raise ValueError(
-                            f"Missing dimension for data variable: {edv}, {edim}. Current dims: {dims}"
-                        )
-            else:
-                raise ValidationError(f"Expected data variable: {edv} not present in standardised data")
-
-    def _check_dims(self, data: Dataset) -> None:
-        """
-        Check dimensions of data against the the schema.
-
-        Args:
-            data : xarray Dataset to be checked
-        Returns:
-            None
-
-            Raises a ValueError with details if expected dimensions
-            are not present in data based on the DataSchema object.
-        """
-        expected_dims = self.dims
-        if expected_dims is None:
-            logger.debug("No dims to check against schema")
-            return None
-
-        dims = data.dims
-
-        for edim in expected_dims:
-            if edim not in dims:
-                raise ValidationError(f"Expected dimension: {edim} not present in standardised data")
-
-    def _check_dtypes(self, data: Dataset) -> None:
-        """
-        Check dtypes of variables and coordinates of data against the schema.
-
-        Args:
-            data : xarray Dataset to be checked
-        Returns:
-            None
-
-            Raises a ValueError with details if data variables and coordinates
-            are not of expected data types based on the DataSchema object.
-        """
-        expected_data_types = self.dtypes
-        if expected_data_types is None:
-            logger.debug("No data types to check against schema")
-            return None
-
-        for variable, edata_type in expected_data_types.items():
-            if variable in data:
-                dtype = data[variable].dtype
-                if not np.issubdtype(dtype, edata_type):
-                    raise ValidationError(
-                        f"Expected data type of variable {variable} to be: {edata_type}. Current {dtype}"
-                    )
-
-    def validate_data(
-        self,
-        data: Dataset,
-    ) -> None:
-        """
-        Validate input data based on schema.
-
-        Currently check can include:
-         - data variables are present with expected dimensions.
-         - general dimensions are present
-         - data types of data variables and coordinates match to expected values
-
-        Args:
-            data : xarray Dataset to be validated
-        Returns:
-            None
-
-            Raises a ValidationError with details if the input data does not adhere
-            to the defined DataSchema.
-        """
-
-        if self.data_vars is not None:
-            self._check_data_vars(data)
-
-        if self.dims is not None:
-            self._check_dims(data)
-
-        if self.dtypes is not None:
-            self._check_dtypes(data)
-
-    # TODO: Add string method for pretty printing
+    def validate_data(self, data: Dataset) -> None:
+        """Validate an xarray Dataset, exposing OpenGHG's public error type."""
+        try:
+            self._schema.validate(data)
+        except xv.SchemaError as err:
+            raise ValidationError(str(err)) from err

--- a/openghg/store/_data_schema.py
+++ b/openghg/store/_data_schema.py
@@ -1,11 +1,15 @@
 from dataclasses import dataclass, field
 from functools import partial
+import logging
 
 import numpy as np
 from xarray import DataArray, Dataset
 import xarray_validate as xv  # type: ignore[import-untyped]
 
 from openghg.types import ValidationError
+
+logger = logging.getLogger("openghg.store")
+logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
 __all__ = ["DataSchema"]
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -291,6 +291,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/11/88c4bb44dff0e8003c4781190a8e598caf7fa95a27d1f1e0e2f16dcbb333/xarray_validate-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/5b/911af9f1f68f4e30474dc5923966656a57d6bc5b1f3b836362739a57d961/msgpack_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
@@ -507,6 +508,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/11/88c4bb44dff0e8003c4781190a8e598caf7fa95a27d1f1e0e2f16dcbb333/xarray_validate-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/35/819eeb4fa8ee676d38fdbb8213a76fd496f7dbbfdfafa89d34e02b22dfac/orjson-3.12.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/5b/911af9f1f68f4e30474dc5923966656a57d6bc5b1f3b836362739a57d961/msgpack_types-0.7.0-py3-none-any.whl
@@ -729,6 +731,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/11/88c4bb44dff0e8003c4781190a8e598caf7fa95a27d1f1e0e2f16dcbb333/xarray_validate-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/35/819eeb4fa8ee676d38fdbb8213a76fd496f7dbbfdfafa89d34e02b22dfac/orjson-3.12.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/5b/911af9f1f68f4e30474dc5923966656a57d6bc5b1f3b836362739a57d961/msgpack_types-0.7.0-py3-none-any.whl
@@ -1049,6 +1052,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/11/88c4bb44dff0e8003c4781190a8e598caf7fa95a27d1f1e0e2f16dcbb333/xarray_validate-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/5b/911af9f1f68f4e30474dc5923966656a57d6bc5b1f3b836362739a57d961/msgpack_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
@@ -1290,6 +1294,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/11/88c4bb44dff0e8003c4781190a8e598caf7fa95a27d1f1e0e2f16dcbb333/xarray_validate-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/35/819eeb4fa8ee676d38fdbb8213a76fd496f7dbbfdfafa89d34e02b22dfac/orjson-3.12.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/5b/911af9f1f68f4e30474dc5923966656a57d6bc5b1f3b836362739a57d961/msgpack_types-0.7.0-py3-none-any.whl
@@ -1537,6 +1542,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/11/88c4bb44dff0e8003c4781190a8e598caf7fa95a27d1f1e0e2f16dcbb333/xarray_validate-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/35/819eeb4fa8ee676d38fdbb8213a76fd496f7dbbfdfafa89d34e02b22dfac/orjson-3.12.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/5b/911af9f1f68f4e30474dc5923966656a57d6bc5b1f3b836362739a57d961/msgpack_types-0.7.0-py3-none-any.whl
@@ -7380,10 +7386,11 @@ packages:
   name: openghg
   requires_dist:
   - addict<=2.4.0
+  - attrs>=22
   - cdsapi>=0.7.7
   - cf-xarray<=0.10.6
-  - dask<2026.8
-  - filelock<=3.32.3
+  - dask<2026.9
+  - filelock<=3.32.5
   - flox<=0.10.4
   - h5netcdf>=1.0.0,<=1.8.1
   - h5py<3.17
@@ -7393,7 +7400,7 @@ packages:
   - kaleido>=1.3.0
   - matplotlib<=3.10.9
   - msgpack-types<=0.8.0
-  - msgpack<=1.2.1
+  - msgpack<=1.2.2
   - nbformat<=5.11.1
   - nc-time-axis<=1.4.1
   - netcdf4>=1.6.0,<=1.7.2
@@ -7407,7 +7414,7 @@ packages:
   - pandas>=2.0,<=2.3.3
   - pint-xarray<=0.5.1
   - pint<=0.24.4
-  - plotly<=6.9.0
+  - plotly<=7.0.0
   - pre-commit>=4.6.0
   - pytest-mock>=3.15.1
   - pytest>=7.0.0
@@ -7420,6 +7427,7 @@ packages:
   - tinydb<=4.9.0
   - toml<=0.10.2
   - urllib3>=1.26.3
+  - xarray-validate==0.0.5
   - xarray>=2025.4.0,<=2025.9.1
   - zarr==2.18.3
   - cfchecker @ git+https://github.com/openghg/cf-checker@master ; extra == 'dev'
@@ -7431,8 +7439,8 @@ packages:
   - pytest-tornasync<=0.6.0.post2 ; extra == 'dev'
   - pytest<=7.0.0 ; extra == 'dev'
   - requests-mock<=1.12.1 ; extra == 'dev'
-  - ruff==0.16.2 ; extra == 'dev'
-  - tox<=4.60.0 ; extra == 'dev'
+  - ruff==0.16.6 ; extra == 'dev'
+  - tox<=4.61.2 ; extra == 'dev'
   - types-paramiko<=5.0.0.20260724 ; extra == 'dev'
   - types-pyyaml<=6.0.12.20260815 ; extra == 'dev'
   - types-requests<=2.33.0.20260712 ; extra == 'dev'
@@ -7441,7 +7449,7 @@ packages:
   - docutils<=0.23 ; extra == 'doc'
   - ipython<=8.39.0 ; extra == 'doc'
   - jinja2 ; extra == 'doc'
-  - jupyter-client<=8.9.1 ; extra == 'doc'
+  - jupyter-client<=8.10.0 ; extra == 'doc'
   - jupyter-core<=5.9.1 ; extra == 'doc'
   - jupyter-sphinx ; extra == 'doc'
   - myst-parser<=4.0.1 ; extra == 'doc'
@@ -7457,7 +7465,7 @@ packages:
   - sphinx-rtd-theme<3.2.0 ; extra == 'doc'
   - sphinx-togglebutton ; extra == 'doc'
   - sphinxcontrib-bibtex<=2.7.0 ; extra == 'doc'
-  - sphinxcontrib-mermaid<=2.1.0 ; extra == 'doc'
+  - sphinxcontrib-mermaid<=2.1.1 ; extra == 'doc'
   - sphinxcontrib-programoutput ; extra == 'doc'
   - numba>=0.59 ; extra == 'fp-x-flux'
   requires_python: '>=3.10'
@@ -8479,6 +8487,18 @@ packages:
   - pytest-benchmark ; extra == 'devel'
   - pytest-cache ; extra == 'devel'
   - validictory ; extra == 'devel'
+- pypi: https://files.pythonhosted.org/packages/cc/11/88c4bb44dff0e8003c4781190a8e598caf7fa95a27d1f1e0e2f16dcbb333/xarray_validate-0.0.5-py3-none-any.whl
+  name: xarray-validate
+  version: 0.0.5
+  sha256: 4d472b40d1063c5b4f2f56097b57551380dc06393da4a480d9ca85fd3cf0f2a9
+  requires_dist:
+  - attrs
+  - numpy
+  - xarray
+  - dask ; extra == 'dask'
+  - pint ; extra == 'units'
+  - ruamel-yaml ; extra == 'yaml'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/cf/35/819eeb4fa8ee676d38fdbb8213a76fd496f7dbbfdfafa89d34e02b22dfac/orjson-3.12.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
   name: orjson
   version: 3.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ maintainers = [
 
 dependencies = [
     "addict<=2.4.0",
+    "attrs>=22",
     "cdsapi>=0.7.7",
     "cf-xarray<=0.10.6",
     "dask<2026.9",
@@ -64,6 +65,7 @@ dependencies = [
     "toml<=0.10.2",
     "urllib3>=1.26.3",
     "xarray>=2025.4.0, <=2025.9.1",
+    "xarray-validate==0.0.5",
     "zarr==2.18.3",
 ]
 classifiers = [

--- a/tests/store/test_data_schema.py
+++ b/tests/store/test_data_schema.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from openghg.store import DataSchema
+from openghg.types import ValidationError
 
 
 def test_data_schema():
@@ -64,3 +65,18 @@ def test_data_schema_empty(dummy_data_1):
     data_schema = DataSchema()
 
     data_schema.validate_data(dummy_data_1)
+
+
+def test_data_schema_missing_variable(data_schema_1, dummy_data_1):
+    with pytest.raises(ValidationError, match="fp"):
+        data_schema_1.validate_data(dummy_data_1.drop_vars("fp"))
+
+
+def test_data_schema_wrong_dtype(data_schema_1, dummy_data_1):
+    with pytest.raises(ValidationError, match="dtype mismatch"):
+        data_schema_1.validate_data(dummy_data_1.assign(fp=dummy_data_1.fp.astype(int)))
+
+
+def test_data_schema_missing_variable_dimension(data_schema_1, dummy_data_1):
+    with pytest.raises(ValueError, match="Missing dimension for data variable: fp, lon"):
+        data_schema_1.validate_data(dummy_data_1.rename(lon="height"))

--- a/tests/store/test_flux.py
+++ b/tests/store/test_flux.py
@@ -517,6 +517,14 @@ def test_flux_schema():
     # TODO: Could also add checks for dims and dtypes?
 
 
+def test_flux_schema_with_file_data():
+    """Validate an existing flux test file against the schema."""
+    test_datapath = get_flux_datapath("co2-gpp-cardamom_EUROPE_2012.nc")
+
+    with open_dataset(test_datapath) as data:
+        Flux.schema().validate_data(data)
+
+
 def test_info_metadata_raise_error(clear_stores):
     """
     Test to verify required keys present in optional metadata supplied as dictionary raise ValueError

--- a/uv.lock
+++ b/uv.lock
@@ -187,11 +187,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c0
 
 [[package]]
 name = "attrs"
-version = "20.3.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/cb/80a4a274df7da7b8baf083249b0890a0579374c3d74b5ac0ee9291f912dc/attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700", size = 164523, upload-time = "2020-11-05T10:04:49.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/aa/cb45262569fcc047bf070b5de61813724d6726db83259222cd7b4c79821a/attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6", size = 49337, upload-time = "2020-11-05T10:04:47.447Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -632,7 +632,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -705,7 +705,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1048,7 +1048,7 @@ name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
@@ -1102,7 +1102,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1460,7 +1460,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -2760,7 +2760,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/56/8895a76abe4ec94ebd01eeb6d74f587bc4cddd46569670e1402852a5da13/numcodecs-0.13.1.tar.gz", hash = "sha256:a3cf37881df0898f3a9c0d4477df88133fe85185bffe57ba31bcc2fa207709bc", size = 5955215, upload-time = "2024-10-09T16:28:00.188Z" }
 wheels = [
@@ -2793,8 +2793,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "deprecated" },
-    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "deprecated", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/fc/bb532969eb8236984ba65e4f0079a7da885b8ac0ce1f0835decbb3938a62/numcodecs-0.15.1.tar.gz", hash = "sha256:eeed77e4d6636641a2cc605fbc6078c7a8f2cc40f3dfa2b3f61e52e6091b04ff", size = 6267275, upload-time = "2025-02-10T10:23:33.254Z" }
 wheels = [
@@ -3050,6 +3050,7 @@ name = "openghg"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },
+    { name = "attrs" },
     { name = "cdsapi" },
     { name = "cf-xarray" },
     { name = "dask" },
@@ -3094,6 +3095,7 @@ dependencies = [
     { name = "urllib3" },
     { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "xarray", version = "2025.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "xarray-validate" },
     { name = "zarr" },
 ]
 
@@ -3147,6 +3149,7 @@ fp-x-flux = [
 [package.metadata]
 requires-dist = [
     { name = "addict", specifier = "<=2.4.0" },
+    { name = "attrs", specifier = ">=22" },
     { name = "cdsapi", specifier = ">=0.7.7" },
     { name = "cf-xarray", specifier = "<=0.10.6" },
     { name = "cfchecker", marker = "extra == 'dev'", git = "https://github.com/openghg/cf-checker?rev=master" },
@@ -3226,6 +3229,7 @@ requires-dist = [
     { name = "types-urllib3", marker = "extra == 'dev'" },
     { name = "urllib3", specifier = ">=1.26.3" },
     { name = "xarray", specifier = ">=2025.4.0,<=2025.9.1" },
+    { name = "xarray-validate", specifier = "==0.0.5" },
     { name = "zarr", specifier = "==2.18.3" },
 ]
 provides-extras = ["dev", "doc", "fp-x-flux"]
@@ -4297,7 +4301,7 @@ name = "roman-numerals-py"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "roman-numerals" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
 wheels = [
@@ -4514,23 +4518,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -4548,23 +4552,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals-py" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "imagesize", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
@@ -5437,9 +5441,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pandas" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pandas", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/ec/e50d833518f10b0c24feb184b209bb6856f25b919ba8c1f89678b930b1cd/xarray-2025.6.1.tar.gz", hash = "sha256:a84f3f07544634a130d7dc615ae44175419f4c77957a7255161ed99c69c7c8b0", size = 3003185, upload-time = "2025-06-12T03:04:09.099Z" }
 wheels = [
@@ -5457,13 +5461,29 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pandas" },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pandas", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/5d/e139112a463336c636d4455494f3227b7f47a2e06ca7571e6b88158ffc06/xarray-2025.9.1.tar.gz", hash = "sha256:f34a27a52c13d1f3cceb7b27276aeec47021558363617dd7ef4f4c8b379011c0", size = 3057322, upload-time = "2025-09-30T05:28:53.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/a7/6eeb32e705d510a672f74135f538ad27f87f3d600845bfd3834ea3a77c7e/xarray-2025.9.1-py3-none-any.whl", hash = "sha256:3e9708db0d7915c784ed6c227d81b398dca4957afe68d119481f8a448fc88c44", size = 1364411, upload-time = "2025-09-30T05:28:51.294Z" },
+]
+
+[[package]]
+name = "xarray-validate"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "xarray", version = "2025.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/93/fb3553bde135147e2ffbff76135663ab003deb23aed44a3a22ea38d15378/xarray_validate-0.0.5.tar.gz", hash = "sha256:b5dde34f5e8dbe7aa92d64d8c7c36c345848355b479be379224ac34d3e0c625a", size = 279495, upload-time = "2026-01-04T21:02:34.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/11/88c4bb44dff0e8003c4781190a8e598caf7fa95a27d1f1e0e2f16dcbb333/xarray_validate-0.0.5-py3-none-any.whl", hash = "sha256:4d472b40d1063c5b4f2f56097b57551380dc06393da4a480d9ca85fd3cf0f2a9", size = 19263, upload-time = "2026-01-04T21:02:33.409Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* **Summary of changes**

Refactors the existing `DataSchema` implementation to use `xarray-validate==0.0.5` behind the current OpenGHG API.

This PR deliberately adds no new validation features. It preserves the existing behavior:

- required named data variables;
- required dimensions as membership checks (order and additional dimensions remain allowed);
- dtype checks, including optional dtype-only coordinates;
- extra data variables remain allowed;
- xarray-validate schema errors are translated to OpenGHG `ValidationError`;
- the historical missing-variable-dimension `ValueError` remains unchanged.

Packaging updates include the runtime dependency, an explicit `attrs>=22` lower bound required by the validator API, refreshed uv/Pixi locks, and the legacy Conda environment pip entry. The developer data-specification docs now explain the compatibility API and behavior.

This is the base of a four-PR draft stack:

1. #1720 — this behavior-preserving refactor;
2. #1721 — explicit named-variable and coordinate unit requirements;
3. #1722 — stable non-unit attribute requirements;
4. #1723 — JSON-backed schema declarations.

Related to #549 and #1338; it does not close either issue.

* **Please check if the PR fulfills these requirements**

- [x] Tests added and passed: `tests/store/test_data_schema.py` and `tests/store/test_flux.py` (21 passed, 1 skipped; includes the checked-in CARDAMOM NetCDF)
- [x] Formatting/lint checks passed for changed Python files (Black and Flake8)
- [x] Documentation updated
- [x] New runtime requirements added to `pyproject.toml`, `uv.lock`, `pixi.lock`, and `environment.yaml`
- [x] Locked Pixi dev environment imports `attrs` and `xarray_validate`

*Not applicable / follow-up*

- No changelog entry: this is an internal behavior-preserving refactor.
- No tutorial or wiki update.
- The published Conda recipe cannot directly express the PyPI-only `xarray-validate` package; reproducible mixed Conda/PyPI installation is covered by Pixi and `environment.yaml`.
- The complete store suite currently reports one unrelated `SiteMet` object-store retrieval failure; all schema-focused tests pass.