### PR TITLE
Require units for physical schema variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added schema requirements for units on surface-observation signals, fluxes, footprints, boundary conditions, and their physical coordinates. Observation-count variables remain excluded from unit conversion. [Issue #1338](https://github.com/openghg/openghg/issues/1338)
 - Added a lazy `fp_x_flux_time_resolved_numba` analysis operator that preserves source and spatial dimensions, supports single-source and regular coarse-frequency flux, and includes optional atomic ppm Zarr persistence and worker warm-up helpers.
 - Added support for passing in-memory `xarray.Dataset` objects to supported standardisation and transformation parsers, including object-store retrieval and forward `ModelScenario` coverage.
 - Added a tutorial for adding CO2 satellite data, including how integrated footprints differ from time-resolved footprints in OpenGHG. [PR #1698](https://github.com/openghg/openghg/pull/1698)

--- a/doc/source/development/specifications/data_spec.rst
+++ b/doc/source/development/specifications/data_spec.rst
@@ -50,6 +50,39 @@ must be present but may appear in a different order. Dtype constraints for
 coordinates remain optional when the coordinate is absent, matching the
 historical OpenGHG schema behaviour.
 
+Unit requirements
+~~~~~~~~~~~~~~~~~
+
+Schemas declare units only for variables whose physical meaning is known. The
+``units`` mapping requires a unit equivalent to the declared unit; a ``None``
+value requires a non-empty units string without constraining its dimension.
+``units_compatible`` accepts scaled units with the same dimensionality:
+
+.. code-block:: python
+
+    DataSchema(
+        data_vars={"flux": ("time", "lat", "lon")},
+        units={"lat": "degrees_north", "lon": "degrees_east"},
+        units_compatible={"flux": "mol m-2 s-1"},
+    )
+
+The main surface-observation variable uses the non-empty form because surface
+data includes mole fractions, isotopes, particulates, and other dimensions.
+Observation cardinalities such as ``number_of_observations`` are deliberately
+not assigned units and must not be converted with the observation signal.
+
+Flux, footprint, and boundary-condition schemas use dimensional constraints.
+Latitude, longitude, height, and numeric back-time coordinates are also
+validated where present in those formats. Datetime coordinates are excluded:
+xarray moves their CF units into the encoding when it decodes them, and Pint
+handles datetime coordinates without a units attribute.
+
+Unit parsing uses OpenGHG's CF-aware Pint registry, so scaled mole fractions
+such as ``ppm``, ``ppb``, and ``1e-9`` and CF spellings such as
+``degrees_north`` are handled consistently. Add requirements to the named
+physical variables in a storage-class schema; do not use a wildcard merely to
+require units on every data variable.
+
 ObsSurface
 ----------
 

--- a/openghg/analyse/_scenario.py
+++ b/openghg/analyse/_scenario.py
@@ -767,9 +767,10 @@ class ModelScenario:
         """Align units in dataset with obs units.
 
         Units will only be updated for data variables that: 1) have units and 2) have
-        a ``"time"`` dimension. Variables whose names end with
-        ``"_number_of_observations"`` are never converted, including when explicitly
-        listed in ``data_vars``. The input dataset is not modified.
+        a ``"time"`` dimension. Observation-count variables named
+        ``"number_of_observations"`` or ending in ``"_number_of_observations"`` are
+        never converted, including when explicitly listed in ``data_vars``. The input
+        dataset is not modified.
 
         Args:
             ds: dataset to align units on
@@ -791,7 +792,10 @@ class ModelScenario:
         data_vars = data_vars or ds.data_vars
         for dv in data_vars:
             unit = ds[dv].attrs.get("units")
-            is_observation_count = str(dv).endswith("_number_of_observations")
+            name = str(dv)
+            is_observation_count = name == "number_of_observations" or name.endswith(
+                "_number_of_observations"
+            )
             if unit is not None and "time" in ds[dv].dims and not is_observation_count:
                 to_convert.append(dv)
 

--- a/openghg/standardise/boundary_conditions/_openghg.py
+++ b/openghg/standardise/boundary_conditions/_openghg.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from openghg.util import clean_string, timestamp_now, synonyms, get_data
 from openghg.store import infer_date_range, update_zero_dim
+from openghg.standardise.boundary_conditions._units import normalise_boundary_condition_units
 
 logger = logging.getLogger("openghg.standardise.boundary_conditions")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -64,6 +65,7 @@ def parse_openghg(
 
         author_name = "OpenGHG Cloud"
         bc_data.attrs["author"] = author_name
+        normalise_boundary_condition_units(bc_data, vmr_units=bc_data.attrs.get("units", "mol/mol"))
 
         metadata = {}
         metadata.update(attrs)

--- a/openghg/standardise/boundary_conditions/_units.py
+++ b/openghg/standardise/boundary_conditions/_units.py
@@ -1,0 +1,17 @@
+from xarray import Dataset
+
+
+def normalise_boundary_condition_units(data: Dataset, vmr_units: str = "mol/mol") -> None:
+    """Fill the known units of the OpenGHG boundary-condition format."""
+    for name, unit in {
+        "lat": "degrees_north",
+        "lon": "degrees_east",
+        "level": "m",
+        "height": "m",
+    }.items():
+        if name in data.coords:
+            data[name].attrs["units"] = unit
+
+    for name in ("vmr_n", "vmr_e", "vmr_s", "vmr_w"):
+        if name in data and not data[name].attrs.get("units"):
+            data[name].attrs["units"] = vmr_units

--- a/openghg/standardise/footprints/_acrg_org.py
+++ b/openghg/standardise/footprints/_acrg_org.py
@@ -14,6 +14,7 @@ from openghg.util import (
 )
 from openghg.store import infer_date_range, update_zero_dim
 from openghg.types import ParseError
+from openghg.standardise.footprints._units import normalise_footprint_units
 
 logger = logging.getLogger("openghg.standardise.footprint")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -195,6 +196,8 @@ def parse_acrg_org(
     for dv, attr_details in dv_attribute_updates.items():
         for key, value in attr_details.items():
             fp_data[dv].attrs[key] = value
+
+    normalise_footprint_units(fp_data)
 
     # Need to read the metadata from the footprints and then store it
     # Do we need to chunk the footprints / will a Datasource store it correctly?

--- a/openghg/standardise/footprints/_paris.py
+++ b/openghg/standardise/footprints/_paris.py
@@ -14,6 +14,7 @@ from openghg.util import (
 )
 from openghg.store import infer_date_range, update_zero_dim
 from openghg.types import ParseError
+from openghg.standardise.footprints._units import normalise_footprint_units
 
 logger = logging.getLogger("openghg.standardise.footprint")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -151,6 +152,8 @@ def parse_paris(
         H_back = fp_data.H_back
         if H_back.dtype == "timedelta64[ns]":
             fp_data["H_back"] = H_back.dt.seconds / 3600.0
+
+    normalise_footprint_units(fp_data)
 
     for attr, new_attr in attribute_rename.items():
         if attr in fp_data:

--- a/openghg/standardise/footprints/_units.py
+++ b/openghg/standardise/footprints/_units.py
@@ -1,0 +1,43 @@
+from xarray import Dataset
+
+_FOOTPRINT_SIGNALS = (
+    "fp",
+    "fp_low",
+    "fp_high",
+    "fp_HiTRes",
+    "fp_time_resolved",
+    "fp_residual",
+)
+
+
+def normalise_footprint_units(data: Dataset) -> None:
+    """Apply known internal units without inventing a footprint signal unit."""
+    for name, unit in {
+        "lat": "degrees_north",
+        "lon": "degrees_east",
+        "lat_high": "degrees_north",
+        "lon_high": "degrees_east",
+        "height": "m",
+        "H_back": "hour",
+    }.items():
+        if name in data.coords:
+            data[name].attrs["units"] = unit
+
+    signal_unit = next(
+        (
+            str(data[name].attrs["units"])
+            for name in _FOOTPRINT_SIGNALS
+            if name in data and data[name].attrs.get("units")
+        ),
+        None,
+    )
+    if signal_unit is not None:
+        for name in _FOOTPRINT_SIGNALS:
+            if name in data and not data[name].attrs.get("units"):
+                data[name].attrs["units"] = signal_unit
+
+    for data_var in data.data_vars:
+        if isinstance(data_var, str) and data_var.startswith("particle_locations_"):
+            data[data_var].attrs["units"] = "1"
+        elif isinstance(data_var, str) and data_var.startswith("mean_age_particles_"):
+            data[data_var].attrs["units"] = "hour"

--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -125,7 +125,12 @@ class BoundaryConditions(BaseStore):
             "vmr_w": np.floating,
         }
 
-        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
+        data_format = DataSchema(
+            data_vars=data_vars,
+            dtypes=dtypes,
+            units={"lat": "degrees_north", "lon": "degrees_east", "height": "m"},
+            units_compatible={name: "mol/mol" for name in data_vars},
+        )
 
         return data_format
 

--- a/openghg/store/_data_schema.py
+++ b/openghg/store/_data_schema.py
@@ -5,13 +5,29 @@ import logging
 import numpy as np
 from xarray import DataArray, Dataset
 import xarray_validate as xv  # type: ignore[import-untyped]
+from xarray_validate import units as xv_units  # type: ignore[import-untyped]
 
 from openghg.types import ValidationError
+from openghg.util import cf_ureg
 
 logger = logging.getLogger("openghg.store")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
 
 __all__ = ["DataSchema"]
+
+
+xv_units.set_registry(cf_ureg)
+
+
+def _unit_attrs(unit: str | None = None, compatible: str | None = None) -> xv.AttrsSchema:
+    if unit is None and compatible is None:
+        requirement = xv.AttrSchema(type=str, value=r"{.*\S.*}")
+    elif compatible is not None:
+        requirement = xv.AttrSchema(type=str, units_compatible=compatible)
+    else:
+        requirement = xv.AttrSchema(type=str, units=unit)
+
+    return xv.AttrsSchema({"units": requirement})
 
 
 def _check_dims(expected: tuple[str, ...], data: DataArray) -> None:
@@ -29,6 +45,8 @@ class DataSchema:
     data_vars: dict[str, tuple[str, ...]] | None = None
     dtypes: dict[str, type] | None = None
     dims: list[str] | None = None
+    units: dict[str, str | None] | None = None
+    units_compatible: dict[str, str] | None = None
     _schema: xv.DatasetSchema = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -36,14 +54,33 @@ class DataSchema:
         for name, dims in (self.data_vars or {}).items():
             variables[name] = xv.DataArraySchema(
                 dtype=(self.dtypes or {}).get(name),
+                attrs=self._attrs_for(name),
                 checks=[partial(_check_dims, dims)],
             )
+
+        coord_names = (set(self.units or {}) | set(self.units_compatible or {})) - set(variables)
+        coords = {
+            name: xv.DataArraySchema(
+                attrs=self._attrs_for(name),
+            )
+            for name in coord_names
+        }
 
         self._schema = xv.DatasetSchema(
             data_vars=variables or None,
             allow_extra_keys=True,
+            coords=xv.CoordsSchema(coords) if coords else None,
             checks=[self._check_remaining_constraints],
         )
+
+    def _attrs_for(self, name: str) -> xv.AttrsSchema | None:
+        compatible_units = self.units_compatible or {}
+        units = self.units or {}
+        if name in compatible_units:
+            return _unit_attrs(compatible=compatible_units[name])
+        if name in units:
+            return _unit_attrs(unit=units[name])
+        return None
 
     def _check_remaining_constraints(self, data: Dataset) -> None:
         """Retain the old optional-coordinate dtype and dataset-dimension checks."""

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -250,7 +250,12 @@ class Flux(BaseStore):
         data_vars: dict[str, tuple[str, ...]] = {"flux": ("time", "lat", "lon")}
         dtypes = {"lat": np.floating, "lon": np.floating, "time": np.datetime64, "flux": np.floating}
 
-        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
+        data_format = DataSchema(
+            data_vars=data_vars,
+            dtypes=dtypes,
+            units={"lat": "degrees_north", "lon": "degrees_east"},
+            units_compatible={"flux": "mol m-2 s-1"},
+        )
 
         return data_format
 

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -321,6 +321,10 @@ class Footprints(BaseStore):
 
         # Names of data variables and associated dimensions (as a tuple)
         data_vars: dict[str, tuple[str, ...]] = {}
+        units: dict[str, str | None] = {
+            "lat": "degrees_north",
+            "lon": "degrees_east",
+        }
         # Internal data types of data variables and coordinates
         dtypes = {
             "lat": np.floating,  # Covers np.float16, np.float32, np.float64 types
@@ -343,6 +347,7 @@ class Footprints(BaseStore):
             # Includes standard footprint variable
             data_vars["fp"] = ("time", "lat", "lon")
             dtypes["fp"] = np.floating
+            units["fp"] = "m2 s mol-1"
 
         if high_spatial_resolution:
             # Include options for high spatial resolution footprint
@@ -353,6 +358,10 @@ class Footprints(BaseStore):
 
             dtypes["fp_low"] = np.floating
             dtypes["fp_high"] = np.floating
+            units["fp_low"] = "m2 s mol-1"
+            units["fp_high"] = "m2 s mol-1"
+            units["lat_high"] = "degrees_north"
+            units["lon_high"] = "degrees_east"
 
         if time_resolved:
             # Include options for high time resolution footprint (usually co2)
@@ -362,11 +371,15 @@ class Footprints(BaseStore):
                 data_vars["fp_residual"] = ("time", "lat", "lon")
                 dtypes["fp_time_resolved"] = np.floating
                 dtypes["fp_residual"] = np.floating
+                units["fp_time_resolved"] = "m2 s mol-1"
+                units["fp_residual"] = "m2 s mol-1"
             else:
                 data_vars["fp_HiTRes"] = ("time", "lat", "lon", "H_back")
                 dtypes["fp_HiTRes"] = np.floating
+                units["fp_HiTRes"] = "m2 s mol-1"
 
             dtypes["H_back"] = np.number  # float or integer
+            units["H_back"] = "hour"
 
         # Includes particle location directions - one for each regional boundary
         if particle_locations:
@@ -380,6 +393,8 @@ class Footprints(BaseStore):
             dtypes["particle_locations_e"] = np.floating
             dtypes["particle_locations_s"] = np.floating
             dtypes["particle_locations_w"] = np.floating
+            units["height"] = "m"
+            units.update({name: "1" for name in data_vars if name.startswith("particle_locations_")})
 
         # TODO: Could also add check for meteorological + other data
         # "air_temperature", "air_pressure", "wind_speed", "wind_from_direction",
@@ -397,8 +412,10 @@ class Footprints(BaseStore):
             dtypes["mean_age_particles_e"] = np.floating
             dtypes["mean_age_particles_s"] = np.floating
             dtypes["mean_age_particles_w"] = np.floating
+            units["height"] = "m"
+            units.update({name: "hour" for name in data_vars if name.startswith("mean_age_particles_")})
 
-        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
+        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes, units=units)
 
         return data_format
 

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -351,7 +351,7 @@ class ObsSurface(BaseStore):
         data_vars: dict[str, tuple[str, ...]] = {name: ("time",)}
         dtypes = {name: np.floating, "time": np.datetime64}
 
-        source_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
+        source_format = DataSchema(data_vars=data_vars, dtypes=dtypes, units={name: None})
 
         return source_format
 

--- a/openghg/transform/boundary_conditions/_cams.py
+++ b/openghg/transform/boundary_conditions/_cams.py
@@ -18,6 +18,7 @@ from openghg.util import (
 )
 from openghg.store import infer_date_range, update_zero_dim
 from openghg.retrieve import get_footprint
+from openghg.standardise.boundary_conditions._units import normalise_boundary_condition_units
 
 logger = logging.getLogger("openghg.transform.boundary_conditions")
 logger.setLevel(logging.DEBUG)  # Have to set level for logger as well as handler
@@ -333,8 +334,7 @@ def set_units(ds: xr.Dataset, units: str) -> None:
         ds: dataset with variable vmr_n/s/w/e
         units: units of the variables
     """
-    for c in ["n", "s", "e", "w"]:
-        ds[f"vmr_{c}"].attrs["units"] = units
+    normalise_boundary_condition_units(ds, vmr_units=units)
 
 
 def parse_cams(

--- a/tests/analyse/test_modelled_obs_integrated_co2.py
+++ b/tests/analyse/test_modelled_obs_integrated_co2.py
@@ -10,25 +10,24 @@ from openghg.analyse._modelled_obs import fp_x_flux_integrated
 from openghg.dataobjects import FluxData, FootprintData, ObsData
 
 
-def test_convert_units_preserves_unitless_observation_counts():
+@pytest.mark.parametrize("count_name", ["number_of_observations", "mf_number_of_observations"])
+def test_convert_units_preserves_unitless_observation_counts(count_name):
     """Converting mole fractions to ppm must not alter unitless observation counts."""
     dataset = xr.Dataset(
         {
             "mf": ("time", [1.0]),
-            "mf_number_of_observations": ("time", [2]),
+            count_name: ("time", [2]),
         },
         coords={"time": pd.to_datetime(["2012-01-01"])},
     )
     dataset.mf.attrs["units"] = "1"
-    dataset.mf_number_of_observations.attrs["units"] = "1"
+    dataset[count_name].attrs["units"] = "1"
     original = dataset.copy(deep=True)
 
     converted = ModelScenario().convert_units(dataset, output_units="ppm")
 
     xr.testing.assert_identical(dataset, original)
-    xr.testing.assert_identical(
-        converted.mf_number_of_observations, original.mf_number_of_observations
-    )
+    xr.testing.assert_identical(converted[count_name], original[count_name])
     assert converted.mf.item() == pytest.approx(1_000_000)
 
 
@@ -119,10 +118,7 @@ def test_modelled_obs_integrated_co2_uses_integrated_pipeline(integrated_co2_sce
     xr.testing.assert_allclose(flux_monthly, expected_flux)
 
     expected = (
-        fp_x_flux_integrated(combined, flux_monthly)
-        .pint.quantify()
-        .sum(["lat", "lon"])
-        .pint.dequantify()
+        fp_x_flux_integrated(combined, flux_monthly).pint.quantify().sum(["lat", "lon"]).pint.dequantify()
     )
     xr.testing.assert_allclose(combined.mf_mod, expected)
 

--- a/tests/store/test_boundary_conditions.py
+++ b/tests/store/test_boundary_conditions.py
@@ -114,6 +114,11 @@ def test_read_file_monthly():
     data_vars = ["vmr_n", "vmr_e", "vmr_s", "vmr_w"]
     for dv in data_vars:
         assert orig_data[dv].equals(bc_data.data[dv])
+        assert bc_data.data[dv].attrs["units"] == "mol/mol"
+
+    assert bc_data.data.lat.attrs["units"] == "degrees_north"
+    assert bc_data.data.lon.attrs["units"] == "degrees_east"
+    assert bc_data.data.height.attrs["units"] == "m"
 
     expected_metadata = {
         "title": "mozart volume mixing ratios at domain edges",
@@ -367,6 +372,8 @@ def test_bc_schema():
     assert "vmr_e" in data_vars
     assert "vmr_s" in data_vars
     assert "vmr_w" in data_vars
+    assert set(data_schema.units_compatible) == {"vmr_n", "vmr_e", "vmr_s", "vmr_w"}
+    assert data_schema.units == {"lat": "degrees_north", "lon": "degrees_east", "height": "m"}
 
     # TODO: Could also add checks for dims and dtypes?
 

--- a/tests/store/test_data_schema.py
+++ b/tests/store/test_data_schema.py
@@ -3,6 +3,7 @@ import pytest
 import xarray as xr
 from openghg.store import DataSchema
 from openghg.types import ValidationError
+from openghg.util import cf_ureg
 
 
 def test_data_schema():
@@ -80,3 +81,37 @@ def test_data_schema_wrong_dtype(data_schema_1, dummy_data_1):
 def test_data_schema_missing_variable_dimension(data_schema_1, dummy_data_1):
     with pytest.raises(ValueError, match="Missing dimension for data variable: fp, lon"):
         data_schema_1.validate_data(dummy_data_1.rename(lon="height"))
+
+
+def test_data_schema_requires_units_on_named_variables_and_coordinates():
+    data = xr.Dataset(
+        {
+            "flux": (
+                ("time", "lat", "lon"),
+                np.ones((1, 1, 1)),
+                {"units": "umol m-2 s-1"},
+            )
+        },
+        coords={
+            "time": np.array(["2020-01-01"], dtype="datetime64[ns]"),
+            "lat": ("lat", [51.0], {"units": "degrees_north"}),
+            "lon": ("lon", [-2.0], {"units": "degrees_east"}),
+        },
+    )
+    schema = DataSchema(
+        data_vars={"flux": ("time", "lat", "lon")},
+        units={"lat": "degrees_north", "lon": "degrees_east"},
+        units_compatible={"flux": "mol m-2 s-1"},
+    )
+
+    schema.validate_data(data)
+    quantified = data.pint.quantify(unit_registry=cf_ureg)
+    assert quantified.flux.pint.units == cf_ureg("umol m-2 s-1").units
+
+    missing_units = data.copy()
+    del missing_units["flux"].attrs["units"]
+    with pytest.raises(ValidationError, match="units"):
+        schema.validate_data(missing_units)
+
+    with pytest.raises(ValidationError, match="not compatible"):
+        schema.validate_data(data.assign(flux=data.flux.assign_attrs(units="ppm")))

--- a/tests/store/test_flux.py
+++ b/tests/store/test_flux.py
@@ -513,6 +513,8 @@ def test_flux_schema():
     assert "time" in data_vars["flux"]
     assert "lat" in data_vars["flux"]
     assert "lon" in data_vars["flux"]
+    assert data_schema.units_compatible == {"flux": "mol m-2 s-1"}
+    assert data_schema.units == {"lat": "degrees_north", "lon": "degrees_east"}
 
     # TODO: Could also add checks for dims and dtypes?
 

--- a/tests/store/test_footprints.py
+++ b/tests/store/test_footprints.py
@@ -102,6 +102,11 @@ def test_read_footprint_standard(keyword, value):
     assert footprint_coords == ["height", "lat", "lon", "time"]
 
     assert "fp" in footprint_data.data_vars
+    assert footprint_data.fp.attrs["units"] == "(mol/mol)/(mol/m2/s)"
+    assert footprint_data.particle_locations_n.attrs["units"] == "1"
+    assert footprint_data.height.attrs["units"] == "m"
+    assert footprint_data.lat.attrs["units"] == "degrees_north"
+    assert footprint_data.lon.attrs["units"] == "degrees_east"
 
     expected_attrs = {
         "author": "OpenGHG Cloud",
@@ -569,6 +574,8 @@ def test_footprint_schema():
     assert "particle_locations_e" in data_vars
     assert "particle_locations_s" in data_vars
     assert "particle_locations_w" in data_vars
+    assert data_schema.units["fp"] == "m2 s mol-1"
+    assert data_schema.units["particle_locations_n"] == "1"
 
     # TODO: Could also add checks for dims and dtypes?
 
@@ -618,6 +625,8 @@ def test_footprint_schema_temporal():
     assert "particle_locations_w" in data_vars
 
     assert "H_back" in data_vars["fp_HiTRes"]
+    assert data_schema.units["fp_HiTRes"] == "m2 s mol-1"
+    assert data_schema.units["H_back"] == "hour"
 
 
 def test_footprint_schema_lifetime():
@@ -652,6 +661,8 @@ def test_footprint_schema_paris(source_format):
     assert "fp_time_resolved" in data_vars
     assert "fp_residual" in data_vars
     assert "fp" not in data_vars
+    assert data_schema.units["fp_time_resolved"] == "m2 s mol-1"
+    assert data_schema.units["fp_residual"] == "m2 s mol-1"
 
 
 def test_process_footprints():

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -24,7 +24,7 @@ from openghg.objectstore import get_datasource, open_object_store
 from openghg.retrieve import get_obs_surface, search_surface
 from openghg.standardise import standardise_from_binary_data, standardise_surface
 from openghg.store import ObsSurface
-from openghg.types import DataOverlapError, MetadataAndData, StandardiseError
+from openghg.types import DataOverlapError, MetadataAndData, StandardiseError, ValidationError
 from openghg.util import create_daterange_str, clean_string
 from pandas import Timestamp
 
@@ -793,8 +793,27 @@ def test_obs_schema(species, obs_variable):
 
     data_vars = data_schema.data_vars
     assert obs_variable in data_vars
+    assert data_schema.units == {obs_variable: None}
 
     # TODO: Could also add checks for dims and dtypes?
+
+
+def test_obs_schema_requires_main_units_but_not_observation_count_units():
+    data = xr.Dataset(
+        {
+            "ch4": ("time", [1900.0], {"units": "ppb"}),
+            "number_of_observations": ("time", [3]),
+        },
+        coords={"time": np.array(["2020-01-01"], dtype="datetime64[ns]")},
+    )
+    schema = ObsSurface.schema(species="ch4")
+
+    schema.validate_data(data)
+
+    missing_units = data.copy()
+    del missing_units["ch4"].attrs["units"]
+    with pytest.raises(ValidationError, match="units"):
+        schema.validate_data(missing_units)
 
 
 def test_obssurface_same_data_raises_on_overlap():


### PR DESCRIPTION
* **Summary of changes**

Adds explicit, named unit requirements to the xarray-backed schemas introduced by #1720.

The policy is intentionally not “all data variables have units”:

- surface observations require a nonblank `units` attribute only on the canonical observation signal (for example `ch4`);
- `number_of_observations` and suffixed observation-count variables are not assigned or required to have units;
- flux requires a unit dimensionally compatible with `mol m-2 s-1`;
- footprint signal variants (`fp`, `fp_low`, `fp_high`, `fp_HiTRes`, `fp_time_resolved`, and `fp_residual`) require footprint units;
- boundary `vmr_n/e/s/w` variables require units compatible with `mol/mol`, allowing `1`, ppm, ppb, and scaled dimensionless spellings;
- physical coordinates require canonical/equivalent units for latitude, longitude, height, and numeric back time; decoded datetime coordinates are excluded.

Validation uses OpenGHG’s CF-aware Pint registry. Tests also quantify a validated dataset with `pint-xarray`.

The footprint and boundary standardizers now normalize known internal units before validation. Missing related footprint-signal units are copied from the available footprint signal; particle fractions are `1`; particle ages/back time are hours; spatial-coordinate assumptions are explicit. Legacy OpenGHG boundary VMR data defaults to the internal `mol/mol` convention.

This also fixes `ModelScenario.convert_units()` so the exact variable name `number_of_observations` is protected from ppm/ppb conversion, not only suffixed names.

Stacked on #1720. Followed by #1722 (non-unit attributes) and #1723 (JSON declarations). Related to #1338 and #1337.

* **Please check if the PR fulfills these requirements**

- [x] Tests added and passed
- [x] Full store suite: 160 passed, 7 skipped, 2 xfailed
- [x] Exact and suffixed observation-count conversion regression tests passed
- [x] Black passed on changed Python files
- [x] Flake8 passed on the new/core changed files
- [x] Mypy passed on the schema and normalization helpers
- [x] Developer documentation updated
- [x] Changelog updated

*Not applicable / follow-up*

- No new dependency: Pint and pint-xarray are already runtime dependencies.
- General non-unit attribute requirements are separated into #1722 because long-name/standard-name policies need their own producer normalization and review.
- JSON-backed schema declarations are separated into #1723.