### PR TITLE
Require stable schema attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added schema requirements for units on surface-observation signals, fluxes, footprints, boundary conditions, and their physical coordinates. Observation-count variables remain excluded from unit conversion. [Issue #1338](https://github.com/openghg/openghg/issues/1338)
+- Added schema requirements for stable non-unit attributes on named data variables, coordinates, and Datasets. [Issue #549](https://github.com/openghg/openghg/issues/549)
 - Added a lazy `fp_x_flux_time_resolved_numba` analysis operator that preserves source and spatial dimensions, supports single-source and regular coarse-frequency flux, and includes optional atomic ppm Zarr persistence and worker warm-up helpers.
 - Added support for passing in-memory `xarray.Dataset` objects to supported standardisation and transformation parsers, including object-store retrieval and forward `ModelScenario` coverage.
 - Added a tutorial for adding CO2 satellite data, including how integrated footprints differ from time-resolved footprints in OpenGHG. [PR #1698](https://github.com/openghg/openghg/pull/1698)

--- a/doc/source/development/specifications/data_spec.rst
+++ b/doc/source/development/specifications/data_spec.rst
@@ -83,6 +83,27 @@ such as ``ppm``, ``ppb``, and ``1e-9`` and CF spellings such as
 physical variables in a storage-class schema; do not use a wildcard merely to
 require units on every data variable.
 
+Other attribute requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``required_attrs`` to require non-empty string attributes on named data
+variables or coordinates, and ``dataset_attrs`` for Dataset-level attributes:
+
+.. code-block:: python
+
+    DataSchema(
+        data_vars={"example": ("time",)},
+        required_attrs={"example": {"long_name", "source"}},
+        dataset_attrs={"species"},
+    )
+
+Attribute requirements should describe stable parts of an internal data format,
+not metadata that is only available from some source formats. Surface signals
+require ``long_name``; fluxes require ``source`` and ``species``; footprint and
+boundary-condition signals require ``long_name``. Add or normalize these
+attributes in the standardizer before schema validation rather than silently
+adding them in the validator.
+
 ObsSurface
 ----------
 

--- a/openghg/standardise/boundary_conditions/_units.py
+++ b/openghg/standardise/boundary_conditions/_units.py
@@ -15,3 +15,5 @@ def normalise_boundary_condition_units(data: Dataset, vmr_units: str = "mol/mol"
     for name in ("vmr_n", "vmr_e", "vmr_s", "vmr_w"):
         if name in data and not data[name].attrs.get("units"):
             data[name].attrs["units"] = vmr_units
+        if name in data:
+            data[name].attrs.setdefault("long_name", f"volume_mixing_ratio_at_{name[-1]}_boundary")

--- a/openghg/standardise/footprints/_units.py
+++ b/openghg/standardise/footprints/_units.py
@@ -36,8 +36,14 @@ def normalise_footprint_units(data: Dataset) -> None:
             if name in data and not data[name].attrs.get("units"):
                 data[name].attrs["units"] = signal_unit
 
+    for name in _FOOTPRINT_SIGNALS:
+        if name in data:
+            data[name].attrs.setdefault("long_name", "source_receptor_relationship")
+
     for data_var in data.data_vars:
         if isinstance(data_var, str) and data_var.startswith("particle_locations_"):
             data[data_var].attrs["units"] = "1"
+            data[data_var].attrs.setdefault("long_name", "fraction_of_particles_leaving_domain")
         elif isinstance(data_var, str) and data_var.startswith("mean_age_particles_"):
             data[data_var].attrs["units"] = "hour"
+            data[data_var].attrs.setdefault("long_name", "mean_age_of_particles_leaving_domain")

--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -130,6 +130,7 @@ class BoundaryConditions(BaseStore):
             dtypes=dtypes,
             units={"lat": "degrees_north", "lon": "degrees_east", "height": "m"},
             units_compatible={name: "mol/mol" for name in data_vars},
+            required_attrs={name: {"long_name"} for name in data_vars},
         )
 
         return data_format

--- a/openghg/store/_data_schema.py
+++ b/openghg/store/_data_schema.py
@@ -19,15 +19,22 @@ __all__ = ["DataSchema"]
 xv_units.set_registry(cf_ureg)
 
 
-def _unit_attrs(unit: str | None = None, compatible: str | None = None) -> xv.AttrsSchema:
+def _attrs_schema(
+    required: set[str] | None = None,
+    unit: str | None = None,
+    compatible: str | None = None,
+    require_units: bool = False,
+) -> xv.AttrsSchema | None:
+    attrs = {name: xv.AttrSchema(type=str, value=r"{.*\S.*}") for name in required or set()}
     if unit is None and compatible is None:
-        requirement = xv.AttrSchema(type=str, value=r"{.*\S.*}")
+        if require_units:
+            attrs["units"] = xv.AttrSchema(type=str, value=r"{.*\S.*}")
     elif compatible is not None:
-        requirement = xv.AttrSchema(type=str, units_compatible=compatible)
+        attrs["units"] = xv.AttrSchema(type=str, units_compatible=compatible)
     else:
-        requirement = xv.AttrSchema(type=str, units=unit)
+        attrs["units"] = xv.AttrSchema(type=str, units=unit)
 
-    return xv.AttrsSchema({"units": requirement})
+    return xv.AttrsSchema(attrs) if attrs else None
 
 
 def _check_dims(expected: tuple[str, ...], data: DataArray) -> None:
@@ -47,6 +54,8 @@ class DataSchema:
     dims: list[str] | None = None
     units: dict[str, str | None] | None = None
     units_compatible: dict[str, str] | None = None
+    required_attrs: dict[str, set[str]] | None = None
+    dataset_attrs: set[str] | None = None
     _schema: xv.DatasetSchema = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -58,7 +67,9 @@ class DataSchema:
                 checks=[partial(_check_dims, dims)],
             )
 
-        coord_names = (set(self.units or {}) | set(self.units_compatible or {})) - set(variables)
+        coord_names = (
+            set(self.units or {}) | set(self.units_compatible or {}) | set(self.required_attrs or {})
+        ) - set(variables)
         coords = {
             name: xv.DataArraySchema(
                 attrs=self._attrs_for(name),
@@ -70,17 +81,19 @@ class DataSchema:
             data_vars=variables or None,
             allow_extra_keys=True,
             coords=xv.CoordsSchema(coords) if coords else None,
+            attrs=_attrs_schema(required=self.dataset_attrs),
             checks=[self._check_remaining_constraints],
         )
 
     def _attrs_for(self, name: str) -> xv.AttrsSchema | None:
         compatible_units = self.units_compatible or {}
         units = self.units or {}
+        required_attrs = (self.required_attrs or {}).get(name)
         if name in compatible_units:
-            return _unit_attrs(compatible=compatible_units[name])
+            return _attrs_schema(required=required_attrs, compatible=compatible_units[name])
         if name in units:
-            return _unit_attrs(unit=units[name])
-        return None
+            return _attrs_schema(required=required_attrs, unit=units[name], require_units=True)
+        return _attrs_schema(required=required_attrs)
 
     def _check_remaining_constraints(self, data: Dataset) -> None:
         """Retain the old optional-coordinate dtype and dataset-dimension checks."""

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -255,6 +255,7 @@ class Flux(BaseStore):
             dtypes=dtypes,
             units={"lat": "degrees_north", "lon": "degrees_east"},
             units_compatible={"flux": "mol m-2 s-1"},
+            required_attrs={"flux": {"source", "species"}},
         )
 
         return data_format

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -415,7 +415,12 @@ class Footprints(BaseStore):
             units["height"] = "m"
             units.update({name: "hour" for name in data_vars if name.startswith("mean_age_particles_")})
 
-        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes, units=units)
+        data_format = DataSchema(
+            data_vars=data_vars,
+            dtypes=dtypes,
+            units=units,
+            required_attrs={name: {"long_name"} for name in data_vars},
+        )
 
         return data_format
 

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -351,7 +351,12 @@ class ObsSurface(BaseStore):
         data_vars: dict[str, tuple[str, ...]] = {name: ("time",)}
         dtypes = {name: np.floating, "time": np.datetime64}
 
-        source_format = DataSchema(data_vars=data_vars, dtypes=dtypes, units={name: None})
+        source_format = DataSchema(
+            data_vars=data_vars,
+            dtypes=dtypes,
+            units={name: None},
+            required_attrs={name: {"long_name"}},
+        )
 
         return source_format
 

--- a/tests/store/test_boundary_conditions.py
+++ b/tests/store/test_boundary_conditions.py
@@ -115,6 +115,7 @@ def test_read_file_monthly():
     for dv in data_vars:
         assert orig_data[dv].equals(bc_data.data[dv])
         assert bc_data.data[dv].attrs["units"] == "mol/mol"
+        assert bc_data.data[dv].attrs["long_name"]
 
     assert bc_data.data.lat.attrs["units"] == "degrees_north"
     assert bc_data.data.lon.attrs["units"] == "degrees_east"
@@ -374,6 +375,7 @@ def test_bc_schema():
     assert "vmr_w" in data_vars
     assert set(data_schema.units_compatible) == {"vmr_n", "vmr_e", "vmr_s", "vmr_w"}
     assert data_schema.units == {"lat": "degrees_north", "lon": "degrees_east", "height": "m"}
+    assert data_schema.required_attrs == {name: {"long_name"} for name in data_vars}
 
     # TODO: Could also add checks for dims and dtypes?
 

--- a/tests/store/test_data_schema.py
+++ b/tests/store/test_data_schema.py
@@ -115,3 +115,28 @@ def test_data_schema_requires_units_on_named_variables_and_coordinates():
 
     with pytest.raises(ValidationError, match="not compatible"):
         schema.validate_data(data.assign(flux=data.flux.assign_attrs(units="ppm")))
+
+
+def test_data_schema_requires_named_variable_and_dataset_attributes():
+    data = xr.Dataset(
+        {"ch4": ("time", [1900.0], {"long_name": "methane_mole_fraction"})},
+        coords={"time": np.array(["2020-01-01"], dtype="datetime64[ns]")},
+        attrs={"species": "ch4"},
+    )
+    schema = DataSchema(
+        data_vars={"ch4": ("time",)},
+        required_attrs={"ch4": {"long_name"}},
+        dataset_attrs={"species"},
+    )
+
+    schema.validate_data(data)
+
+    missing_variable_attr = data.copy()
+    del missing_variable_attr.ch4.attrs["long_name"]
+    with pytest.raises(ValidationError, match="long_name"):
+        schema.validate_data(missing_variable_attr)
+
+    missing_dataset_attr = data.copy()
+    del missing_dataset_attr.attrs["species"]
+    with pytest.raises(ValidationError, match="species"):
+        schema.validate_data(missing_dataset_attr)

--- a/tests/store/test_flux.py
+++ b/tests/store/test_flux.py
@@ -515,6 +515,7 @@ def test_flux_schema():
     assert "lon" in data_vars["flux"]
     assert data_schema.units_compatible == {"flux": "mol m-2 s-1"}
     assert data_schema.units == {"lat": "degrees_north", "lon": "degrees_east"}
+    assert data_schema.required_attrs == {"flux": {"source", "species"}}
 
     # TODO: Could also add checks for dims and dtypes?
 

--- a/tests/store/test_footprints.py
+++ b/tests/store/test_footprints.py
@@ -103,6 +103,7 @@ def test_read_footprint_standard(keyword, value):
 
     assert "fp" in footprint_data.data_vars
     assert footprint_data.fp.attrs["units"] == "(mol/mol)/(mol/m2/s)"
+    assert footprint_data.fp.attrs["long_name"] == "source_receptor_relationship"
     assert footprint_data.particle_locations_n.attrs["units"] == "1"
     assert footprint_data.height.attrs["units"] == "m"
     assert footprint_data.lat.attrs["units"] == "degrees_north"
@@ -576,6 +577,7 @@ def test_footprint_schema():
     assert "particle_locations_w" in data_vars
     assert data_schema.units["fp"] == "m2 s mol-1"
     assert data_schema.units["particle_locations_n"] == "1"
+    assert data_schema.required_attrs == {name: {"long_name"} for name in data_vars}
 
     # TODO: Could also add checks for dims and dtypes?
 

--- a/tests/store/test_obssurface.py
+++ b/tests/store/test_obssurface.py
@@ -794,6 +794,7 @@ def test_obs_schema(species, obs_variable):
     data_vars = data_schema.data_vars
     assert obs_variable in data_vars
     assert data_schema.units == {obs_variable: None}
+    assert data_schema.required_attrs == {obs_variable: {"long_name"}}
 
     # TODO: Could also add checks for dims and dtypes?
 
@@ -801,7 +802,11 @@ def test_obs_schema(species, obs_variable):
 def test_obs_schema_requires_main_units_but_not_observation_count_units():
     data = xr.Dataset(
         {
-            "ch4": ("time", [1900.0], {"units": "ppb"}),
+            "ch4": (
+                "time",
+                [1900.0],
+                {"units": "ppb", "long_name": "mole_fraction_of_methane_in_air"},
+            ),
             "number_of_observations": ("time", [3]),
         },
         coords={"time": np.array(["2020-01-01"], dtype="datetime64[ns]")},


### PR DESCRIPTION
* **Summary of changes**

Adds non-unit attribute requirements to `DataSchema`, separately from the dimensional unit policy in #1721.

New schema inputs:

- `required_attrs`: maps a named data variable or coordinate to required, nonblank string attributes;
- `dataset_attrs`: requires nonblank string attributes on the Dataset itself.

The production schemas enforce only stable internal-format attributes:

- surface observation signal: `long_name`;
- flux: `source` and `species`;
- footprint signal, particle-location, and particle-age variables: `long_name`;
- boundary `vmr_n/e/s/w`: `long_name`.

Footprint and boundary standardizers normalize the newly required long names before validation. The validator remains non-mutating.

Stacked on #1721 and #1720. Followed by #1723 (JSON declarations). Related to #549.

* **Please check if the PR fulfills these requirements**

- [x] Tests added and passed
- [x] Full store suite: 161 passed, 7 skipped, 2 xfailed
- [x] Black passed on changed Python files
- [x] Flake8 passed on the schema/core changed files
- [x] Mypy passed on the schema and normalization helpers
- [x] Developer documentation updated
- [x] Changelog updated

*Not applicable / follow-up*

- No new dependencies.
- Source-specific metadata is deliberately not required; only attributes stable across the internal format are enforced.
- JSON-backed schema declarations are separated into #1723.