### PR TITLE
Move data schemas to JSON declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added schema requirements for units on surface-observation signals, fluxes, footprints, boundary conditions, and their physical coordinates. Observation-count variables remain excluded from unit conversion. [Issue #1338](https://github.com/openghg/openghg/issues/1338)
 - Added schema requirements for stable non-unit attributes on named data variables, coordinates, and Datasets. [Issue #549](https://github.com/openghg/openghg/issues/549)
+- Moved internal data-format schema declarations to a packaged JSON resource with dynamic observation substitutions and composable footprint fragments. [Issue #549](https://github.com/openghg/openghg/issues/549)
 - Added a lazy `fp_x_flux_time_resolved_numba` analysis operator that preserves source and spatial dimensions, supports single-source and regular coarse-frequency flux, and includes optional atomic ppm Zarr persistence and worker warm-up helpers.
 - Added support for passing in-memory `xarray.Dataset` objects to supported standardisation and transformation parsers, including object-store retrieval and forward `ModelScenario` coverage.
 - Added a tutorial for adding CO2 satellite data, including how integrated footprints differ from time-resolved footprints in OpenGHG. [PR #1698](https://github.com/openghg/openghg/pull/1698)

--- a/doc/source/development/specifications/data_spec.rst
+++ b/doc/source/development/specifications/data_spec.rst
@@ -31,19 +31,9 @@ Validation is implemented by ``xarray-validate`` behind the existing
 validation library directly. For compatibility, a missing dimension on a
 required variable continues to raise ``ValueError``.
 
-When adding or changing an internal format, define required variables and
-data types in the storage class's ``schema()`` method:
-
-.. code-block:: python
-
-    import numpy as np
-
-    from openghg.store import DataSchema
-
-    DataSchema(
-        data_vars={"example": ("time",)},
-        dtypes={"example": np.floating, "time": np.datetime64},
-    )
+Storage-class ``schema()`` methods select declarations from the packaged JSON
+schema resource described below. ``DataSchema`` can still be constructed
+directly for custom validation and tests.
 
 Extra variables remain allowed, and dimensions listed for a required variable
 must be present but may appear in a different order. Dtype constraints for
@@ -103,6 +93,47 @@ require ``long_name``; fluxes require ``source`` and ``species``; footprint and
 boundary-condition signals require ``long_name``. Add or normalize these
 attributes in the standardizer before schema validation rather than silently
 adding them in the validator.
+
+JSON schema declarations
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Internal format declarations live in
+``openghg/store/data_schemas.json``. Storage-class ``schema()`` methods select a
+named declaration with ``DataSchema.from_name()``; their public return type and
+validation API remain unchanged.
+
+Each declaration can contain ``data_vars``, ``dtypes``, ``dims``, ``units``,
+``units_compatible``, ``required_attrs``, and ``dataset_attrs``. Data-variable
+dimensions and attribute sets are JSON arrays. Supported dtype tokens are
+``floating``, ``integer``, ``number``, and ``datetime64``. For example:
+
+.. code-block:: json
+
+    {
+      "example": {
+        "data_vars": {"example": ["time"]},
+        "dtypes": {"example": "floating", "time": "datetime64"},
+        "units": {"example": null},
+        "required_attrs": {"example": ["long_name"]}
+      }
+    }
+
+``null`` in ``units`` means that a non-empty units string is required without
+constraining dimensionality. ``units_compatible`` accepts scaled units with the
+same dimensionality.
+
+Surface and column declarations use placeholders that their Python schema
+methods replace with canonical species and vertical names. Footprints compose
+the ``integrated``, ``high_spatial_resolution``, ``time_resolved_acrg``,
+``time_resolved_paris``, ``particle_locations``, and ``short_lifetime`` JSON
+fragments according to the existing schema flags.
+
+When changing an internal format, edit the JSON declaration and update the
+corresponding storage schema tests. Use Python only for dynamic selection and
+name substitution. The JSON is an OpenGHG declaration format rather than an
+``xarray-validate`` serialization: upstream serialization does not preserve the
+callable checks used for OpenGHG's compatibility semantics or its generic NumPy
+dtype classes.
 
 ObsSurface
 ----------

--- a/openghg/store/_boundary_conditions.py
+++ b/openghg/store/_boundary_conditions.py
@@ -6,7 +6,6 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any
 from openghg.types import pathType, TransformError
 from openghg.util import load_transform_parser, check_if_need_new_version, split_function_inputs
-import numpy as np
 
 if TYPE_CHECKING:
     from openghg.store import DataSchema
@@ -108,32 +107,7 @@ class BoundaryConditions(BaseStore):
         """
         from openghg.store import DataSchema
 
-        data_vars: dict[str, tuple[str, ...]] = {
-            "vmr_n": ("time", "height", "lon"),
-            "vmr_e": ("time", "height", "lat"),
-            "vmr_s": ("time", "height", "lon"),
-            "vmr_w": ("time", "height", "lat"),
-        }
-        dtypes = {
-            "lat": np.floating,
-            "lon": np.floating,
-            "height": np.floating,
-            "time": np.datetime64,
-            "vmr_n": np.floating,
-            "vmr_e": np.floating,
-            "vmr_s": np.floating,
-            "vmr_w": np.floating,
-        }
-
-        data_format = DataSchema(
-            data_vars=data_vars,
-            dtypes=dtypes,
-            units={"lat": "degrees_north", "lon": "degrees_east", "height": "m"},
-            units_compatible={name: "mol/mol" for name in data_vars},
-            required_attrs={name: {"long_name"} for name in data_vars},
-        )
-
-        return data_format
+        return DataSchema.from_name("boundary_conditions")
 
     def transform_data(
         self,

--- a/openghg/store/_data_schema.py
+++ b/openghg/store/_data_schema.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass, field
-from functools import partial
+from functools import lru_cache, partial
+from importlib import resources
+import json
 import logging
+from typing import Any, cast, Iterable, Mapping
 
 import numpy as np
 from xarray import DataArray, Dataset
@@ -17,6 +20,41 @@ __all__ = ["DataSchema"]
 
 
 xv_units.set_registry(cf_ureg)
+
+
+_DTYPES: dict[str, type] = {
+    "datetime64": np.datetime64,
+    "floating": np.floating,
+    "integer": np.integer,
+    "number": np.number,
+}
+
+
+@lru_cache(maxsize=1)
+def _schema_configs() -> dict[str, Any]:
+    schema_path = resources.files(__package__).joinpath("data_schemas.json")
+    with schema_path.open(encoding="utf-8") as file:
+        return cast(dict[str, Any], json.load(file))
+
+
+def _format(value: str, substitutions: Mapping[str, str]) -> str:
+    try:
+        return value.format_map(substitutions)
+    except KeyError as err:
+        raise ValueError(f"Missing schema substitution: {err.args[0]}") from err
+
+
+def _merge_configs(configs: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for config in configs:
+        for field_name, value in config.items():
+            if isinstance(value, dict):
+                merged.setdefault(field_name, {}).update(value)
+            elif isinstance(value, list):
+                merged.setdefault(field_name, []).extend(value)
+            else:
+                raise ValueError(f"Unsupported schema field: {field_name}")
+    return merged
 
 
 def _attrs_schema(
@@ -57,6 +95,69 @@ class DataSchema:
     required_attrs: dict[str, set[str]] | None = None
     dataset_attrs: set[str] | None = None
     _schema: xv.DatasetSchema = field(init=False, repr=False, compare=False)
+
+    @classmethod
+    def from_name(
+        cls,
+        name: str,
+        *,
+        fragments: Iterable[str] = (),
+        substitutions: Mapping[str, str] | None = None,
+    ) -> "DataSchema":
+        """Load an OpenGHG schema declaration from the packaged JSON resource."""
+        try:
+            config = _schema_configs()[name]
+        except KeyError as err:
+            raise ValueError(f"Unknown data schema: {name}") from err
+
+        if "base" in config:
+            selected = [config["base"]]
+            try:
+                selected.extend(config["fragments"][fragment] for fragment in fragments)
+            except KeyError as err:
+                raise ValueError(f"Unknown {name} schema fragment: {err.args[0]}") from err
+            config = _merge_configs(selected)
+        elif tuple(fragments):
+            raise ValueError(f"Schema {name} does not define fragments")
+
+        return cls.from_dict(config, substitutions=substitutions)
+
+    @classmethod
+    def from_dict(
+        cls, config: dict[str, Any], substitutions: Mapping[str, str] | None = None
+    ) -> "DataSchema":
+        """Create a schema from the JSON-compatible OpenGHG declaration format."""
+        substitutions = substitutions or {}
+
+        def name(value: str) -> str:
+            return _format(value, substitutions)
+
+        try:
+            dtypes = {name(variable): _DTYPES[dtype] for variable, dtype in config.get("dtypes", {}).items()}
+        except KeyError as err:
+            raise ValueError(f"Unknown schema dtype: {err.args[0]}") from err
+
+        data_vars = {
+            name(variable): tuple(name(dim) for dim in dims)
+            for variable, dims in config.get("data_vars", {}).items()
+        }
+
+        return cls(
+            data_vars=data_vars if "data_vars" in config else None,
+            dtypes=dtypes if "dtypes" in config else None,
+            dims=[name(dim) for dim in config.get("dims", [])] or None,
+            units={name(variable): unit for variable, unit in config.get("units", {}).items()} or None,
+            units_compatible={
+                name(variable): unit for variable, unit in config.get("units_compatible", {}).items()
+            }
+            or None,
+            required_attrs={
+                name(variable): set(attributes)
+                for variable, attributes in config.get("required_attrs", {}).items()
+            }
+            or None,
+            dataset_attrs=set(config.get("dataset_attrs", [])) or None,
+        )
 
     def __post_init__(self) -> None:
         variables: dict[str, xv.DataArraySchema] = {}

--- a/openghg/store/_eulerian_model.py
+++ b/openghg/store/_eulerian_model.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import numpy as np
 import logging
 from typing import Any
 
@@ -72,9 +71,4 @@ class EulerianModel(BaseStore):
 
         TODO: Decide on data_vars checks as we build up the use of this data_type
         """
-        data_vars: dict[str, tuple[str, ...]] = {}
-        dtypes = {"lat": np.floating, "lon": np.floating, "time": np.datetime64}
-
-        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
-
-        return data_format
+        return DataSchema.from_name("eulerian_model")

--- a/openghg/store/_flux.py
+++ b/openghg/store/_flux.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Optional
 import warnings
-import numpy as np
 from numpy import ndarray
 from xarray import DataArray
 
@@ -247,18 +246,7 @@ class Flux(BaseStore):
         Returns:
             DataSchema : Contains schema for Flux.
         """
-        data_vars: dict[str, tuple[str, ...]] = {"flux": ("time", "lat", "lon")}
-        dtypes = {"lat": np.floating, "lon": np.floating, "time": np.datetime64, "flux": np.floating}
-
-        data_format = DataSchema(
-            data_vars=data_vars,
-            dtypes=dtypes,
-            units={"lat": "degrees_north", "lon": "degrees_east"},
-            units_compatible={"flux": "mol m-2 s-1"},
-            required_attrs={"flux": {"source", "species"}},
-        )
-
-        return data_format
+        return DataSchema.from_name("flux")
 
     def chunking_schema(self) -> ChunkingSchema:
         """

--- a/openghg/store/_flux_timeseries.py
+++ b/openghg/store/_flux_timeseries.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import numpy as np
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -236,12 +235,4 @@ class FluxTimeseries(BaseStore):
         """
         from openghg.store import DataSchema
 
-        data_vars: dict[str, tuple[str, ...]] = {"flux_timeseries": ("time",)}
-        dtypes = {
-            "time": np.datetime64,
-            "flux_timeseries": np.floating,
-        }
-
-        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
-
-        return data_format
+        return DataSchema.from_name("flux_timeseries")

--- a/openghg/store/_footprints.py
+++ b/openghg/store/_footprints.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import logging
 from typing import cast, Any
 import warnings
-import numpy as np
 
 from openghg.store import DataSchema
 from openghg.store.base import BaseStore
@@ -319,19 +318,6 @@ class Footprints(BaseStore):
         # # but given that all other openghg internal formats are ("lat", "lon"), we are currently keeping the
         # # footprint internal format consistent with this.
 
-        # Names of data variables and associated dimensions (as a tuple)
-        data_vars: dict[str, tuple[str, ...]] = {}
-        units: dict[str, str | None] = {
-            "lat": "degrees_north",
-            "lon": "degrees_east",
-        }
-        # Internal data types of data variables and coordinates
-        dtypes = {
-            "lat": np.floating,  # Covers np.float16, np.float32, np.float64 types
-            "lon": np.floating,
-            "time": np.datetime64,
-        }
-
         # Disable particle_locations validation when inner_domain is present
         if inner_domain:
             particle_locations = False
@@ -343,86 +329,21 @@ class Footprints(BaseStore):
             )
             time_resolved = high_time_resolution
 
+        fragments = []
         if not time_resolved and not high_spatial_resolution:
-            # Includes standard footprint variable
-            data_vars["fp"] = ("time", "lat", "lon")
-            dtypes["fp"] = np.floating
-            units["fp"] = "m2 s mol-1"
-
+            fragments.append("integrated")
         if high_spatial_resolution:
-            # Include options for high spatial resolution footprint
-            # This includes footprint data on multiple resolutions
-
-            data_vars["fp_low"] = ("time", "lat", "lon")
-            data_vars["fp_high"] = ("time", "lat_high", "lon_high")
-
-            dtypes["fp_low"] = np.floating
-            dtypes["fp_high"] = np.floating
-            units["fp_low"] = "m2 s mol-1"
-            units["fp_high"] = "m2 s mol-1"
-            units["lat_high"] = "degrees_north"
-            units["lon_high"] = "degrees_east"
-
+            fragments.append("high_spatial_resolution")
         if time_resolved:
-            # Include options for high time resolution footprint (usually co2)
-            # This includes a footprint data with an additional hourly back dimension
-            if source_format in ("PARIS", "FLEXPART"):
-                data_vars["fp_time_resolved"] = ("time", "lat", "lon", "H_back")
-                data_vars["fp_residual"] = ("time", "lat", "lon")
-                dtypes["fp_time_resolved"] = np.floating
-                dtypes["fp_residual"] = np.floating
-                units["fp_time_resolved"] = "m2 s mol-1"
-                units["fp_residual"] = "m2 s mol-1"
-            else:
-                data_vars["fp_HiTRes"] = ("time", "lat", "lon", "H_back")
-                dtypes["fp_HiTRes"] = np.floating
-                units["fp_HiTRes"] = "m2 s mol-1"
-
-            dtypes["H_back"] = np.number  # float or integer
-            units["H_back"] = "hour"
-
-        # Includes particle location directions - one for each regional boundary
+            fragments.append(
+                "time_resolved_paris" if source_format in ("PARIS", "FLEXPART") else "time_resolved_acrg"
+            )
         if particle_locations:
-            data_vars["particle_locations_n"] = ("time", "lon", "height")
-            data_vars["particle_locations_e"] = ("time", "lat", "height")
-            data_vars["particle_locations_s"] = ("time", "lon", "height")
-            data_vars["particle_locations_w"] = ("time", "lat", "height")
-
-            dtypes["height"] = np.floating
-            dtypes["particle_locations_n"] = np.floating
-            dtypes["particle_locations_e"] = np.floating
-            dtypes["particle_locations_s"] = np.floating
-            dtypes["particle_locations_w"] = np.floating
-            units["height"] = "m"
-            units.update({name: "1" for name in data_vars if name.startswith("particle_locations_")})
-
-        # TODO: Could also add check for meteorological + other data
-        # "air_temperature", "air_pressure", "wind_speed", "wind_from_direction",
-        # "atmosphere_boundary_layer_thickness", "release_lon", "release_lat"
-
-        # Include options for short lifetime footprints (short-lived species)
-        # This includes additional particle ages (allow calculation of decay based on particle lifetimes)
+            fragments.append("particle_locations")
         if short_lifetime:
-            data_vars["mean_age_particles_n"] = ("time", "lon", "height")
-            data_vars["mean_age_particles_e"] = ("time", "lat", "height")
-            data_vars["mean_age_particles_s"] = ("time", "lon", "height")
-            data_vars["mean_age_particles_w"] = ("time", "lat", "height")
+            fragments.append("short_lifetime")
 
-            dtypes["mean_age_particles_n"] = np.floating
-            dtypes["mean_age_particles_e"] = np.floating
-            dtypes["mean_age_particles_s"] = np.floating
-            dtypes["mean_age_particles_w"] = np.floating
-            units["height"] = "m"
-            units.update({name: "hour" for name in data_vars if name.startswith("mean_age_particles_")})
-
-        data_format = DataSchema(
-            data_vars=data_vars,
-            dtypes=dtypes,
-            units=units,
-            required_attrs={name: {"long_name"} for name in data_vars},
-        )
-
-        return data_format
+        return DataSchema.from_name("footprints", fragments=fragments)
 
     def chunking_schema(
         self,

--- a/openghg/store/_met.py
+++ b/openghg/store/_met.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Any
-import numpy as np
 
 from openghg.store import DataSchema
 from openghg.store.base import BaseStore
@@ -59,15 +58,4 @@ class SiteMet(BaseStore):
 
         TODO: Expand to include data variables as well e.g. "pressure_level"
         """
-        # TODO: Add details of expected format for internal data
-        data_vars: dict = {}
-        dtypes = {
-            "lat": np.floating,  # Covers np.float16, np.float32, np.float64 types
-            "lon": np.floating,
-            "time": np.datetime64,
-            "pressure_level": np.floating,
-        }
-
-        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
-
-        return data_format
+        return DataSchema.from_name("site_met")

--- a/openghg/store/_obscolumn.py
+++ b/openghg/store/_obscolumn.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import logging
 from typing import Optional, Any
-import numpy as np
 from numpy import ndarray
 
 from openghg.store import DataSchema
@@ -206,25 +205,18 @@ class ObsColumn(BaseStore):
         """
         from openghg.standardise.meta import define_species_label
 
-        data_vars: dict[str, tuple[str, ...]] = {}
-        dtypes: dict[str, Any] = {"time": np.datetime64}
-
         species_name = define_species_label(species)[0]
 
         column_name = f"x{species_name}"
         averaging_kernal_name = f"x{species_name}_averaging_kernel"
         profile_apriori_name = f"{species_name}_profile_apriori"
 
-        data_vars[column_name] = ("time",)
-        data_vars[averaging_kernal_name] = ("time", vertical_name)
-        data_vars[profile_apriori_name] = ("time", vertical_name)
-
-        dtypes = {
-            column_name: np.floating,
-            averaging_kernal_name: np.floating,
-            profile_apriori_name: np.floating,
-        }
-
-        data_format = DataSchema(data_vars=data_vars, dtypes=dtypes)
-
-        return data_format
+        return DataSchema.from_name(
+            "obs_column",
+            substitutions={
+                "column": column_name,
+                "averaging_kernel": averaging_kernal_name,
+                "profile_apriori": profile_apriori_name,
+                "vertical": vertical_name,
+            },
+        )

--- a/openghg/store/_obssurface.py
+++ b/openghg/store/_obssurface.py
@@ -3,7 +3,6 @@ import logging
 from pathlib import Path
 from typing import Any, MutableSequence
 from collections.abc import Sequence
-import numpy as np
 
 from openghg.standardise.meta import align_metadata_attributes
 from openghg.store import DataSchema
@@ -348,17 +347,7 @@ class ObsSurface(BaseStore):
 
         name = define_species_label(species)[0]
 
-        data_vars: dict[str, tuple[str, ...]] = {name: ("time",)}
-        dtypes = {name: np.floating, "time": np.datetime64}
-
-        source_format = DataSchema(
-            data_vars=data_vars,
-            dtypes=dtypes,
-            units={name: None},
-            required_attrs={name: {"long_name"}},
-        )
-
-        return source_format
+        return DataSchema.from_name("obs_surface", substitutions={"species": name})
 
     def store_data(
         self,

--- a/openghg/store/data_schemas.json
+++ b/openghg/store/data_schemas.json
@@ -1,0 +1,189 @@
+{
+  "obs_surface": {
+    "data_vars": {"{species}": ["time"]},
+    "dtypes": {"{species}": "floating", "time": "datetime64"},
+    "units": {"{species}": null},
+    "required_attrs": {"{species}": ["long_name"]}
+  },
+  "flux": {
+    "data_vars": {"flux": ["time", "lat", "lon"]},
+    "dtypes": {
+      "lat": "floating",
+      "lon": "floating",
+      "time": "datetime64",
+      "flux": "floating"
+    },
+    "units": {"lat": "degrees_north", "lon": "degrees_east"},
+    "units_compatible": {"flux": "mol m-2 s-1"},
+    "required_attrs": {"flux": ["source", "species"]}
+  },
+  "boundary_conditions": {
+    "data_vars": {
+      "vmr_n": ["time", "height", "lon"],
+      "vmr_e": ["time", "height", "lat"],
+      "vmr_s": ["time", "height", "lon"],
+      "vmr_w": ["time", "height", "lat"]
+    },
+    "dtypes": {
+      "lat": "floating",
+      "lon": "floating",
+      "height": "floating",
+      "time": "datetime64",
+      "vmr_n": "floating",
+      "vmr_e": "floating",
+      "vmr_s": "floating",
+      "vmr_w": "floating"
+    },
+    "units": {"lat": "degrees_north", "lon": "degrees_east", "height": "m"},
+    "units_compatible": {
+      "vmr_n": "mol/mol",
+      "vmr_e": "mol/mol",
+      "vmr_s": "mol/mol",
+      "vmr_w": "mol/mol"
+    },
+    "required_attrs": {
+      "vmr_n": ["long_name"],
+      "vmr_e": ["long_name"],
+      "vmr_s": ["long_name"],
+      "vmr_w": ["long_name"]
+    }
+  },
+  "footprints": {
+    "base": {
+      "dtypes": {"lat": "floating", "lon": "floating", "time": "datetime64"},
+      "units": {"lat": "degrees_north", "lon": "degrees_east"}
+    },
+    "fragments": {
+      "integrated": {
+        "data_vars": {"fp": ["time", "lat", "lon"]},
+        "dtypes": {"fp": "floating"},
+        "units": {"fp": "m2 s mol-1"},
+        "required_attrs": {"fp": ["long_name"]}
+      },
+      "high_spatial_resolution": {
+        "data_vars": {
+          "fp_low": ["time", "lat", "lon"],
+          "fp_high": ["time", "lat_high", "lon_high"]
+        },
+        "dtypes": {"fp_low": "floating", "fp_high": "floating"},
+        "units": {
+          "fp_low": "m2 s mol-1",
+          "fp_high": "m2 s mol-1",
+          "lat_high": "degrees_north",
+          "lon_high": "degrees_east"
+        },
+        "required_attrs": {"fp_low": ["long_name"], "fp_high": ["long_name"]}
+      },
+      "time_resolved_acrg": {
+        "data_vars": {"fp_HiTRes": ["time", "lat", "lon", "H_back"]},
+        "dtypes": {"fp_HiTRes": "floating", "H_back": "number"},
+        "units": {"fp_HiTRes": "m2 s mol-1", "H_back": "hour"},
+        "required_attrs": {"fp_HiTRes": ["long_name"]}
+      },
+      "time_resolved_paris": {
+        "data_vars": {
+          "fp_time_resolved": ["time", "lat", "lon", "H_back"],
+          "fp_residual": ["time", "lat", "lon"]
+        },
+        "dtypes": {
+          "fp_time_resolved": "floating",
+          "fp_residual": "floating",
+          "H_back": "number"
+        },
+        "units": {
+          "fp_time_resolved": "m2 s mol-1",
+          "fp_residual": "m2 s mol-1",
+          "H_back": "hour"
+        },
+        "required_attrs": {
+          "fp_time_resolved": ["long_name"],
+          "fp_residual": ["long_name"]
+        }
+      },
+      "particle_locations": {
+        "data_vars": {
+          "particle_locations_n": ["time", "lon", "height"],
+          "particle_locations_e": ["time", "lat", "height"],
+          "particle_locations_s": ["time", "lon", "height"],
+          "particle_locations_w": ["time", "lat", "height"]
+        },
+        "dtypes": {
+          "height": "floating",
+          "particle_locations_n": "floating",
+          "particle_locations_e": "floating",
+          "particle_locations_s": "floating",
+          "particle_locations_w": "floating"
+        },
+        "units": {
+          "height": "m",
+          "particle_locations_n": "1",
+          "particle_locations_e": "1",
+          "particle_locations_s": "1",
+          "particle_locations_w": "1"
+        },
+        "required_attrs": {
+          "particle_locations_n": ["long_name"],
+          "particle_locations_e": ["long_name"],
+          "particle_locations_s": ["long_name"],
+          "particle_locations_w": ["long_name"]
+        }
+      },
+      "short_lifetime": {
+        "data_vars": {
+          "mean_age_particles_n": ["time", "lon", "height"],
+          "mean_age_particles_e": ["time", "lat", "height"],
+          "mean_age_particles_s": ["time", "lon", "height"],
+          "mean_age_particles_w": ["time", "lat", "height"]
+        },
+        "dtypes": {
+          "mean_age_particles_n": "floating",
+          "mean_age_particles_e": "floating",
+          "mean_age_particles_s": "floating",
+          "mean_age_particles_w": "floating"
+        },
+        "units": {
+          "height": "m",
+          "mean_age_particles_n": "hour",
+          "mean_age_particles_e": "hour",
+          "mean_age_particles_s": "hour",
+          "mean_age_particles_w": "hour"
+        },
+        "required_attrs": {
+          "mean_age_particles_n": ["long_name"],
+          "mean_age_particles_e": ["long_name"],
+          "mean_age_particles_s": ["long_name"],
+          "mean_age_particles_w": ["long_name"]
+        }
+      }
+    }
+  },
+  "obs_column": {
+    "data_vars": {
+      "{column}": ["time"],
+      "{averaging_kernel}": ["time", "{vertical}"],
+      "{profile_apriori}": ["time", "{vertical}"]
+    },
+    "dtypes": {
+      "{column}": "floating",
+      "{averaging_kernel}": "floating",
+      "{profile_apriori}": "floating"
+    }
+  },
+  "flux_timeseries": {
+    "data_vars": {"flux_timeseries": ["time"]},
+    "dtypes": {"time": "datetime64", "flux_timeseries": "floating"}
+  },
+  "eulerian_model": {
+    "data_vars": {},
+    "dtypes": {"lat": "floating", "lon": "floating", "time": "datetime64"}
+  },
+  "site_met": {
+    "data_vars": {},
+    "dtypes": {
+      "lat": "floating",
+      "lon": "floating",
+      "time": "datetime64",
+      "pressure_level": "floating"
+    }
+  }
+}

--- a/tests/store/test_serialized_schemas.py
+++ b/tests/store/test_serialized_schemas.py
@@ -1,0 +1,89 @@
+import pytest
+
+from openghg.store import (
+    BoundaryConditions,
+    DataSchema,
+    EulerianModel,
+    Flux,
+    FluxTimeseries,
+    Footprints,
+    ObsColumn,
+    ObsSurface,
+    SiteMet,
+)
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        Flux.schema(),
+        BoundaryConditions.schema(),
+        ObsSurface.schema("ch4"),
+        ObsColumn.schema("ch4"),
+        FluxTimeseries.schema(),
+        EulerianModel.schema(),
+        SiteMet.schema(),
+    ],
+)
+def test_packaged_json_schemas_load(schema):
+    assert isinstance(schema, DataSchema)
+
+
+def test_empty_data_variable_declarations_remain_empty_dicts():
+    assert EulerianModel.schema().data_vars == {}
+    assert SiteMet.schema().data_vars == {}
+
+
+def test_footprint_json_fragments_compose():
+    schema = Footprints.schema(
+        high_spatial_resolution=True,
+        time_resolved=True,
+        short_lifetime=True,
+        source_format="PARIS",
+    )
+
+    assert set(schema.data_vars) == {
+        "fp_low",
+        "fp_high",
+        "fp_time_resolved",
+        "fp_residual",
+        "particle_locations_n",
+        "particle_locations_e",
+        "particle_locations_s",
+        "particle_locations_w",
+        "mean_age_particles_n",
+        "mean_age_particles_e",
+        "mean_age_particles_s",
+        "mean_age_particles_w",
+    }
+
+
+def test_inner_domain_omits_particle_location_fragment():
+    schema = Footprints.schema(inner_domain="inner")
+
+    assert set(schema.data_vars) == {"fp"}
+
+
+def test_schema_substitutions_cover_names_and_dimensions():
+    schema = ObsColumn.schema("ch4", vertical_name="pressure")
+
+    assert schema.data_vars["xch4_averaging_kernel"] == ("time", "pressure")
+    assert schema.data_vars["ch4_profile_apriori"] == ("time", "pressure")
+
+
+def test_unknown_schema_dtype_has_actionable_error():
+    with pytest.raises(ValueError, match="Unknown schema dtype: unsupported"):
+        DataSchema.from_dict({"dtypes": {"example": "unsupported"}})
+
+
+def test_missing_schema_substitution_has_actionable_error():
+    with pytest.raises(ValueError, match="Missing schema substitution: species"):
+        DataSchema.from_dict({"data_vars": {"{species}": ["time"]}})
+
+
+def test_unknown_schema_and_fragment_have_actionable_errors():
+    with pytest.raises(ValueError, match="Unknown data schema: missing"):
+        DataSchema.from_name("missing")
+
+    with pytest.raises(ValueError, match="Unknown footprints schema fragment: missing"):
+        DataSchema.from_name("footprints", fragments=["missing"])


### PR DESCRIPTION
* **Summary of changes**

Moves the internal data-format declarations from Python dictionaries into the packaged `openghg/store/data_schemas.json` resource.

`DataSchema.from_name()` loads named declarations while `DataSchema.from_dict()` converts the small OpenGHG JSON format into the existing xarray-validate compatibility wrapper. Supported fields are:

- `data_vars`
- `dtypes`
- `dims`
- `units`
- `units_compatible`
- `required_attrs`
- `dataset_attrs`

Supported dtype tokens are `floating`, `integer`, `number`, and `datetime64`.

All current schema producers now load JSON declarations: surface, flux, footprints, boundary conditions, column observations, flux timeseries, Eulerian model, and site meteorology.

Dynamic behavior remains in small Python selectors:

- surface and column schemas substitute exact canonical variable and vertical names;
- footprints compose JSON fragments for integrated, high-spatial-resolution, ACRG/PARIS time-resolved, particle-location, and short-lifetime variants;
- exact variable requirements are preserved rather than replaced with optional wildcard patterns.

This is deliberately an OpenGHG JSON declaration format, not xarray-validate's serializer. xarray-validate 0.0.5 does not guarantee JSON round trips and drops the callable checks/generic NumPy dtype information needed to preserve current OpenGHG behavior.

Stacked on #1722, #1721, and #1720. Related to #549.

* **Please check if the PR fulfills these requirements**

- [x] Tests added and passed
- [x] Full store suite: 175 passed, 7 skipped, 2 xfailed
- [x] JSON loader tests cover every producer, substitutions, footprint composition, inner domains, and actionable invalid-token errors
- [x] Black and Flake8 passed on changed Python files
- [x] Mypy passed on the loader
- [x] Developer documentation updated
- [x] Changelog updated
- [x] Built wheel contains `openghg/store/data_schemas.json`
- [x] Schema loading smoke-tested directly from the built wheel

*Not applicable*

- No new dependency: the loader uses the standard library.
- YAML is not added because JSON is sufficient and avoids adding `ruamel-yaml`.