### PR TITLE
safeguard against release tags

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -12,11 +12,17 @@ on:
     paths-ignore:
       - 'CHANGELOG.md'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag value to validate without releasing"
+        required: true
+        default: "1.2.3"
+        type: string
 
 jobs:
   release_tag:
     name: Check for a release tag
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.check.outputs.is_release }}
@@ -24,13 +30,15 @@ jobs:
       - name: Validate release tag
         id: check
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            is_release=true
           else
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            is_release=false
           fi
+          echo "Tag '$TAG': is_release=$is_release"
+          echo "is_release=$is_release" >> "$GITHUB_OUTPUT"
 
   test:
     name: Run the tests
@@ -81,7 +89,7 @@ jobs:
           uv run pytest --run-cfchecks
   docs:
     name: Build and deploy the documentation
-    if: needs.release_tag.outputs.is_release == 'true'
+    if: github.event_name == 'push' && needs.release_tag.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     needs: ["test", "release_tag"]
     steps:
@@ -118,7 +126,7 @@ jobs:
     name: TestPyPI Build and publish Python distributions (PEP 621, Trusted Publishing)
     needs: ["test", "docs", "release_tag"]
     runs-on: ubuntu-latest
-    if: needs.release_tag.outputs.is_release == 'true'
+    if: github.event_name == 'push' && needs.release_tag.outputs.is_release == 'true'
     environment:
       name: testpypi
       url: https://test.pypi.org/p/openghg
@@ -148,7 +156,7 @@ jobs:
     name: PyPI Build and publish Python distributions (PEP 621, Trusted Publishing)
     runs-on: ubuntu-latest
     needs: ["test", "docs", "release_testpypi", "release_tag"]
-    if: needs.release_tag.outputs.is_release == 'true'
+    if: github.event_name == 'push' && needs.release_tag.outputs.is_release == 'true'
     environment:
       name: pypi
       url: https://pypi.org/p/openghg
@@ -178,7 +186,7 @@ jobs:
     name: Build and publish conda package
     runs-on: ubuntu-latest
     needs: ["test", "docs", "release_tag"]
-    if: needs.release_tag.outputs.is_release == 'true'
+    if: github.event_name == 'push' && needs.release_tag.outputs.is_release == 'true'
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,6 +14,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  release_tag:
+    name: Check for a release tag
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+    steps:
+      - name: Validate release tag
+        id: check
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Run the tests
     runs-on: ${{ matrix.operating-system }}
@@ -63,9 +81,9 @@ jobs:
           uv run pytest --run-cfchecks
   docs:
     name: Build and deploy the documentation
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !contains(github.ref_name, '-') && contains(github.ref_name, '.')
+    if: needs.release_tag.outputs.is_release == 'true'
     runs-on: ubuntu-latest
-    needs: ["test"]
+    needs: ["test", "release_tag"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
@@ -98,9 +116,9 @@ jobs:
 
   release_testpypi:
     name: TestPyPI Build and publish Python distributions (PEP 621, Trusted Publishing)
-    needs: ["test", "docs"]
+    needs: ["test", "docs", "release_tag"]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') && contains(github.ref_name, '.')
+    if: needs.release_tag.outputs.is_release == 'true'
     environment:
       name: testpypi
       url: https://test.pypi.org/p/openghg
@@ -129,8 +147,8 @@ jobs:
   release_pypi:
     name: PyPI Build and publish Python distributions (PEP 621, Trusted Publishing)
     runs-on: ubuntu-latest
-    needs: ["test", "docs", "release_testpypi"]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') && contains(github.ref_name, '.')
+    needs: ["test", "docs", "release_testpypi", "release_tag"]
+    if: needs.release_tag.outputs.is_release == 'true'
     environment:
       name: pypi
       url: https://pypi.org/p/openghg
@@ -159,8 +177,8 @@ jobs:
   release_conda:
     name: Build and publish conda package
     runs-on: ubuntu-latest
-    needs: ["test", "docs"]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !contains(github.ref_name, '-') && contains(github.ref_name, '.')
+    needs: ["test", "docs", "release_tag"]
+    if: needs.release_tag.outputs.is_release == 'true'
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

The issue suggested requiring release tags to use a v prefix. However, OpenGHG has a long history of using unprefixed version tags such as 0.19.0. I have therefore kept the existing convention and added a safeguard so that release jobs run only for tags matching the exact X.Y.Z format. Other tags can still be pushed for reference or to preserve checkpoints—for example, "deprecated-parsers" without publishing a new version to PyPI or conda. Normal CI tests will still run for those tags. This means the recent discussion we had for the work on Brendans CI can have a tag even after merging into devel.

* **Please check if the PR fulfills these requirements**

- [x] Closes #1123 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing) if fixing a bug or adding a new feature
- [x] All code checks passing - `ruff format --check`, `ruff check`, and `mypy` not showing any errors
- [x] Documentation updated/added
- [x] Added any new package requirements to `pyproject.toml` [dependencies section] and `recipes/meta.yaml`

*Note: if any of the above are not needed for a PR please separate to below and remove the checkbox.*
