### PR TITLE
Add Gitleaks scanning to pre-commit and CI

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,23 @@
+name: Gitleaks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan the repository for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Run Gitleaks
+        # Keep this version aligned with .pre-commit-config.yaml.
+        uses: docker://ghcr.io/gitleaks/gitleaks:v8.18.4
+        with:
+          args: >-
+            detect --redact --verbose --source /github/workspace
+            --log-opts=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,8 @@ repos:
             types-requests,
             types-toml
           ]
+  - repo: https://github.com/gitleaks/gitleaks
+    # v8.30.x fails the upstream detection canary (gitleaks/gitleaks#2170).
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Gitleaks secret scanning to pre-commit and CI. [Issue
+  #1695](https://github.com/openghg/openghg/issues/1695)
 - Added reproducible Graphify regeneration, CI freshness checking, and a focused navigation
   skill for cross-module impact analysis. [Issue #1695](https://github.com/openghg/openghg/issues/1695)
 - Added a lazy `fp_x_flux_time_resolved_numba` analysis operator that preserves source and spatial dimensions, supports single-source and regular coarse-frequency flux, and includes optional atomic ppm Zarr persistence and worker warm-up helpers.


### PR DESCRIPTION
* **Summary of changes** (security tooling)

Part 2 of the split of #1730, stacked on #1731. Adds Gitleaks to pre-commit and a dedicated CI workflow that scans the commits introduced by each pull request. The tested v8.18.4 release is pinned because newer v8.30.x builds fail the upstream detection canary in gitleaks/gitleaks#2170.

* **Please check if the PR fulfills these requirements**

- [x] Related to #1695
- [x] Security checks added and passed
- [x] Added an entry in `CHANGELOG.md`

Validation:

- Full pre-commit run against the staged change
- Gitleaks scan of this commit range
- Published GitHub-token canary detected by the pinned binary

*Not needed: behavioural pytest cases, tutorials, wiki changes, or runtime package requirements.*